### PR TITLE
Server logging 2.0

### DIFF
--- a/YACReaderLibrary/main.cpp
+++ b/YACReaderLibrary/main.cpp
@@ -80,8 +80,47 @@ void logSystemAndConfig()
     QLOG_INFO() << "--------------------------------------------";
 }
 
+void messageHandler(QtMsgType type, const QMessageLogContext& context, const QString& msg)
+{
+	Q_UNUSED(context);
+
+	QByteArray localMsg = msg.toLocal8Bit();
+    switch (type)
+	{
+    case QtInfoMsg:
+    {
+      QLOG_INFO() << localMsg.constData();
+      break;
+    }
+		case QtDebugMsg:
+		{
+			QLOG_DEBUG() << localMsg.constData();
+			break;
+		}
+
+		case QtWarningMsg:
+		{
+			QLOG_WARN() << localMsg.constData();
+			break;
+		}
+
+		case QtCriticalMsg:
+		{
+			QLOG_ERROR() << localMsg.constData();
+			break;
+		}
+
+		case QtFatalMsg:
+		{
+			QLOG_FATAL() << localMsg.constData();
+			break;
+		}
+  }
+}
+
 int main( int argc, char ** argv )
 {
+  qInstallMessageHandler(messageHandler);
   QApplication app( argc, argv );
 
 #ifdef FORCE_ANGLE

--- a/YACReaderLibrary/main.cpp
+++ b/YACReaderLibrary/main.cpp
@@ -135,7 +135,29 @@ int main( int argc, char ** argv )
 QCommandLineParser parser;
 parser.addHelpOption();
 parser.addVersionOption();
+parser.addOption({"loglevel", "Set log level. Valid values: trace, info, debug, warn, error.", "loglevel", "warning"});
 parser.process(app);
+
+if (parser.isSet("loglevel")) {
+    if (parser.value("loglevel") == "trace") {
+        logger.setLoggingLevel(QsLogging::TraceLevel);
+    }
+    else if (parser.value("loglevel") == "info") {
+        logger.setLoggingLevel(QsLogging::InfoLevel);
+    }
+    else if (parser.value("loglevel") == "debug") {
+        logger.setLoggingLevel(QsLogging::DebugLevel);
+    }
+    else if (parser.value("loglevel") == "warn") {
+      logger.setLoggingLevel(QsLogging::WarnLevel);
+    }
+    else if (parser.value("loglevel") == "error") {
+        logger.setLoggingLevel(QsLogging::ErrorLevel);
+    }
+    else {
+        parser.showHelp();
+    }
+}
 
 #ifdef SERVER_RELEASE
   QSettings * settings = new QSettings(YACReader::getSettingsPath()+"/YACReaderLibrary.ini",QSettings::IniFormat); //TODO unificar la creaci�n del fichero de config con el servidor

--- a/YACReaderLibrary/main.cpp
+++ b/YACReaderLibrary/main.cpp
@@ -136,7 +136,31 @@ QCommandLineParser parser;
 parser.addHelpOption();
 parser.addVersionOption();
 parser.addOption({"loglevel", "Set log level. Valid values: trace, info, debug, warn, error.", "loglevel", "warning"});
+#ifdef Q_OS_WIN
+parser.addOption({"opengl", "Set opengl renderer. Valid values: desktop, es, software.", "gl_renderer"});
+#endif
 parser.process(app);
+
+#ifdef Q_OS_WIN
+if (parser.isSet("opengl")) {
+    QTextStream qout(stdout);
+    if (parser.value("opengl") == "desktop") {
+        app.setAttribute(Qt::AA_UseDesktopOpenGL);
+    }
+    else if (parser.value("opengl") == "es") {
+        app.setAttribute(Qt::AA_UseOpenGLES);
+    }
+    else if (parser.value("opengl") == "software") {
+        qout << "Warning! This will be slow as hell. Only use this setting for"
+            "testing or as a last resort.";
+        app.setAttribute(Qt::AA_UseSoftwareOpenGL);
+    }
+    else {
+        qout << "Invalid value:" << parser.value("gl_renderer");
+        parser.showHelp();
+    }
+}
+#endif
 
 if (parser.isSet("loglevel")) {
     if (parser.value("loglevel") == "trace") {

--- a/YACReaderLibrary/server/server.pri
+++ b/YACReaderLibrary/server/server.pri
@@ -90,7 +90,7 @@ SOURCES += \
     $$PWD/controllers/v2/taginfocontroller_v2.cpp
 	
 
-include(lib/logging/logging.pri)
+#include(lib/logging/logging.pri)
 include(lib/httpserver/httpserver.pri)
 include(lib/templateengine/templateengine.pri)
 

--- a/YACReaderLibrary/server/startup.cpp
+++ b/YACReaderLibrary/server/startup.cpp
@@ -5,7 +5,7 @@
 
 #include "static.h"
 #include "startup.h"
-#include "dualfilelogger.h"
+//#include "dualfilelogger.h"
 #include "httplistener.h"
 #include "requestmapper.h"
 #include "staticfilecontroller.h"
@@ -27,9 +27,9 @@
 void Startup::start() {
 	// Initialize the core application
     QCoreApplication* app = QCoreApplication::instance();
-
 	QString configFileName=YACReader::getSettingsPath()+"/"+QCoreApplication::applicationName()+".ini";
 
+/*
 	// Configure logging into files
 	QSettings* mainLogSettings=new QSettings(configFileName,QSettings::IniFormat,app);
 	mainLogSettings->beginGroup("mainLogFile");
@@ -49,7 +49,7 @@ void Startup::start() {
         mainLogSettings->setValue("minLevel",QtCriticalMsg);
 
     Logger* logger=new FileLogger(mainLogSettings,10000,app);
-    logger->installMsgHandler();
+    logger->installMsgHandler();*/
 
 	// Configure template loader and cache
 	QSettings* templateSettings=new QSettings(configFileName,QSettings::IniFormat,app);
@@ -150,5 +150,3 @@ QString Startup::getPort()
 {
 	return QString("%1").arg(listener->serverPort());
 }
-
-

--- a/YACReaderLibraryServer/main.cpp
+++ b/YACReaderLibraryServer/main.cpp
@@ -44,8 +44,48 @@ void logSystemAndConfig()
     QLOG_INFO() << "--------------------------------------------";
 }
 
+void messageHandler(QtMsgType type, const QMessageLogContext& context, const QString& msg)
+{
+	Q_UNUSED(context);
+
+	QByteArray localMsg = msg.toLocal8Bit();
+    switch (type)
+	{
+    case QtInfoMsg:
+    {
+      QLOG_INFO() << localMsg.constData();
+      break;
+    }
+		case QtDebugMsg:
+		{
+			QLOG_DEBUG() << localMsg.constData();
+			break;
+		}
+
+		case QtWarningMsg:
+		{
+			QLOG_WARN() << localMsg.constData();
+			break;
+		}
+
+		case QtCriticalMsg:
+		{
+			QLOG_ERROR() << localMsg.constData();
+			break;
+		}
+
+		case QtFatalMsg:
+		{
+			QLOG_FATAL() << localMsg.constData();
+			break;
+		}
+  }
+}
+
 int main( int argc, char ** argv )
 {
+    qInstallMessageHandler(messageHandler);
+
     QCoreApplication app(argc, argv);
 
     app.setApplicationName("YACReaderLibrary");

--- a/YACReaderLibraryServer/main.cpp
+++ b/YACReaderLibraryServer/main.cpp
@@ -70,6 +70,7 @@ int main( int argc, char ** argv )
     parser.addHelpOption();
     const QCommandLineOption versionOption = parser.addVersionOption();
     parser.addPositionalArgument("command", "The command to execute. [start, create-library, update-library, add-library, remove-library, list-libraries]");
+    parser.addOption({"loglevel", "Set log level. Valid values: trace, info, debug, warn, error.", "loglevel", "info"});
     parser.parse(app.arguments());
 
     const QStringList args = parser.positionalArguments();
@@ -92,7 +93,27 @@ int main( int argc, char ** argv )
         QDir().mkpath(YACReader::getSettingsPath());
 
         Logger& logger = Logger::instance();
-        logger.setLoggingLevel(QsLogging::InfoLevel);
+
+        if (parser.isSet("loglevel")) {
+            if (parser.value("loglevel") == "trace") {
+                logger.setLoggingLevel(QsLogging::TraceLevel);
+            }
+            else if (parser.value("loglevel") == "info") {
+                logger.setLoggingLevel(QsLogging::InfoLevel);
+            }
+            else if (parser.value("loglevel") == "debug") {
+                logger.setLoggingLevel(QsLogging::DebugLevel);
+            }
+            else if (parser.value("loglevel") == "warn") {
+              logger.setLoggingLevel(QsLogging::WarnLevel);
+            }
+            else if (parser.value("loglevel") == "error") {
+                logger.setLoggingLevel(QsLogging::ErrorLevel);
+            }
+            else {
+                parser.showHelp();
+            }
+        }
 
         DestinationPtr fileDestination(DestinationFactory::MakeFileDestination(
                                            destLog, EnableLogRotation, MaxSizeBytes(1048576), MaxOldLogCount(2)));


### PR DESCRIPTION
This pr improves the ability to debug YACReaderLibrary and Server. It adds the following features:

- loglevel commandline option to set the desired log level
- replace QtWebApp's logger with a QsLog based message handler. This prevents QtWebApp from eating our debug messages and allows control over the server log level
- add opengl renderer selection on Windows to the commandline (this one isn't really tested yet)

Stuff still missing:

- silent commandline option to prevent Library/Server from spamming the commandline