### PR TITLE
9.5.0 fixes

### DIFF
--- a/YACReader/main.cpp
+++ b/YACReader/main.cpp
@@ -83,8 +83,14 @@ int main(int argc, char * argv[])
   QCommandLineOption comicId("comicId", "", "comicId");
   QCommandLineOption libraryId("libraryId", "", "libraryId");
   // hide comicId and libraryId from help
+  #if QT_VERSION >= 0x050800
   comicId.setFlags(QCommandLineOption::HiddenFromHelp);
   libraryId.setFlags(QCommandLineOption::HiddenFromHelp);
+  #else
+  comicId.setHidden(true);
+  libraryId.setHidden(true);
+  #endif
+
   // process
   parser.addOption(comicId);
   parser.addOption(libraryId);

--- a/config.pri
+++ b/config.pri
@@ -11,11 +11,8 @@ QT_VER_MIN = $$member(QT_VERSION, 1)
 lessThan(QT_VER_MAJ, 5) {
 error(YACReader requires Qt 5 or newer but Qt $$[QT_VERSION] was detected.)
   }
-lessThan(QT_VER_MIN, 6) {
-  warning ("Qt < 5.6 detected. Compilation will probably work, but some qml based components in YACReaderLibrary (GridView, InfoView) will fail at runtime.")
-  }
-lessThan(QT_VER_MIN, 4):!CONFIG(no_opengl) {
-  error ("You need at least Qt 5.4 to compile YACReader or YACReaderLibrary.")
+lessThan(QT_VER_MIN, 6):!CONFIG(no_opengl) {
+  error ("You need at least Qt 5.6 to compile YACReader or YACReaderLibrary.")
   }
 
 # Disable coverflow for arm targets


### PR DESCRIPTION
This PR fixes YACReader build using Qt 5.6 and 5.7.

Impact on other versions is minimal, so it is a low-risk merge. Fast review would be appreciated as I'd like to use this for a 9.5.1 bugfix release (Linux, source code release only).