### PR TITLE
Fixed potential stack overflow.

### DIFF
--- a/YACReaderLibrary/server/controllers/v2/pagecontroller_v2.cpp
+++ b/YACReaderLibrary/server/controllers/v2/pagecontroller_v2.cpp
@@ -75,10 +75,10 @@ void PageControllerV2::service(HttpRequest& request, HttpResponse& response)
                     response.setHeader("Transfer-Encoding","chunked");
                     QByteArray pageData = comicFile->getRawPage(page);
                     QDataStream data(pageData);
-                    char buffer[100000];
+                    std::vector<char> buffer(100000);
                     while (!data.atEnd()) {
-                        int len = data.readRawData(buffer,100000);
-                        response.write(QByteArray(buffer,len));
+                        int len = data.readRawData(&buffer[0],buffer.size());
+                        response.write(QByteArray(&buffer[0],len));
                     }
                     response.write(QByteArray(),true);
                 }


### PR DESCRIPTION
In my case, I am compiling YACReader against `musl` libc, under Alpine Linux.

`musl` is known to have a stack size much smaller than `glibc`, thus explaining why the issue is not seen on most platforms.
