### PR TITLE
bug: 'else' without braces but several lines indented

### DIFF
--- a/YACReader/render.cpp
+++ b/YACReader/render.cpp
@@ -1035,6 +1035,7 @@ void Render::updateBuffer()
 		}
 	}
 	else //add pages to left pages and remove on the right
+	{
 		if(windowSize<0)
 		{
 			windowSize = -windowSize;
@@ -1060,6 +1061,7 @@ void Render::updateBuffer()
 			}
 		}
 		previousIndex = currentIndex;
+	}
 }
 
 void Render::fillBuffer()

--- a/YACReader/render.cpp
+++ b/YACReader/render.cpp
@@ -1060,8 +1060,8 @@ void Render::updateBuffer()
 				buffer.pop_back();
 			}
 		}
-		previousIndex = currentIndex;
 	}
+	previousIndex = currentIndex;
 }
 
 void Render::fillBuffer()


### PR DESCRIPTION
The indentation suggests that the line that update `previousIndex` was meant to be inside the `if`, but the lack of braces means it isn't. I don't think it was an indentation error.

This bug was discovered while fixing the warnings of gcc compilation. See #40.