### PR TITLE
bugfix: 'switch case' for OpenVG had no 'break'

### DIFF
--- a/common/opengl_checker.cpp
+++ b/common/opengl_checker.cpp
@@ -31,6 +31,7 @@ OpenGLChecker::OpenGLChecker()
 
     case QSurfaceFormat::OpenVG:
         type = "OpenVG";
+        break;
 
     default: case QSurfaceFormat::DefaultRenderableType:
         type = "unknown";


### PR DESCRIPTION
OpenVG can't be detected because of an obvious bug.

This bug was encountered while fixing the compilation warnings of gcc. See #40.