### PR TITLE
Fix gcc8 warnings

### DIFF
--- a/YACReader/render.cpp
+++ b/YACReader/render.cpp
@@ -361,12 +361,12 @@ PageRender::PageRender()
 }
 PageRender::PageRender(Render * r,int np, const QByteArray & rd, QImage * p,unsigned int d, QVector<ImageFilter *> f)
 :QThread(),
-render(r),
 numPage(np),
 data(rd),
 page(p),
 degrees(d),
-filters(f)
+filters(f),
+render(r)
 {
 }
 

--- a/YACReader/render.cpp
+++ b/YACReader/render.cpp
@@ -734,20 +734,26 @@ void Render::load(const QString & path, const ComicDB & comicDB)
    for(int i = 0; i < filters.count(); i++)
    {
 	   if(typeid(*filters[i]) == typeid(BrightnessFilter))
+	   {
 		   if(comicDB.info.brightness == -1)
 			   filters[i]->setLevel(0);
 		   else
 			filters[i]->setLevel(comicDB.info.brightness);
+	   }
 	   if(typeid(*filters[i]) == typeid(ContrastFilter))
+	   {
 		   if(comicDB.info.contrast == -1)
 			   filters[i]->setLevel(100);
 		   else
 			   filters[i]->setLevel(comicDB.info.contrast);
+	   }
 	   if(typeid(*filters[i]) == typeid(GammaFilter))
+	   {
 		   if(comicDB.info.gamma == -1)
 			   filters[i]->setLevel(100);
 		   else
 			   filters[i]->setLevel(comicDB.info.gamma);
+	   }
    }
    createComic(path);
    if (comic!=0)

--- a/YACReader/render.cpp
+++ b/YACReader/render.cpp
@@ -398,7 +398,7 @@ void PageRender::run()
 //-----------------------------------------------------------------------------
 
 Render::Render()
-:currentIndex(0),doublePage(false),doubleMangaPage(false),comic(0),loadedComic(false),imageRotation(0),numLeftPages(4),numRightPages(4)
+:comic(0),doublePage(false),doubleMangaPage(false),currentIndex(0),numLeftPages(4),numRightPages(4),loadedComic(false),imageRotation(0)
 {
 	int size = numLeftPages+numRightPages+1;
 	currentPageBufferedIndex = numLeftPages;

--- a/YACReader/render.cpp
+++ b/YACReader/render.cpp
@@ -863,7 +863,7 @@ void Render::nextPage()
 		update();
 		emit pageChanged(currentIndex);
 	}
-	else if (hasLoadedComic() && (currentIndex == numPages()-1))
+	else if (hasLoadedComic() && ((unsigned int)currentIndex == numPages()-1))
 	{
 		emit isLast();
 	}

--- a/YACReader/viewer.cpp
+++ b/YACReader/viewer.cpp
@@ -24,20 +24,20 @@
 
 Viewer::Viewer(QWidget * parent)
 	:QScrollArea(parent),
-	  currentPage(0),
-	  magnifyingGlassShowed(false),
 	  fullscreen(false),
 	  information(false),
 	  doublePage(false),
 	  doubleMangaPage(false),
+	  zoom(100),
+	  currentPage(0),
 	  wheelStop(false),
 	  direction(1),
-	  restoreMagnifyingGlass(false),
 	  drag(false),
 	  numScrollSteps(22),
 	  shouldOpenNext(false),
 	  shouldOpenPrevious(false),
-	  zoom(100)
+	  magnifyingGlassShowed(false),
+	  restoreMagnifyingGlass(false)
 {
 	translator = new YACReaderTranslator(this);
 	translator->hide();

--- a/YACReader/yacreader_local_client.cpp
+++ b/YACReader/yacreader_local_client.cpp
@@ -69,7 +69,7 @@ bool YACReaderLocalClient::requestComicInfo(quint64 libraryId, ComicDB & comic, 
 		int dataAvailable = 0;
 		QByteArray packageSize;
         localSocket->waitForReadyRead(1000);
-		while(packageSize.size() < sizeof(quint32) && tries < 20)
+		while(packageSize.size() < (int)sizeof(quint32) && tries < 20)
 		{
 			packageSize.append(localSocket->read(sizeof(quint32) - packageSize.size()));
 			localSocket->waitForReadyRead(100);

--- a/YACReaderLibrary/comic_vine/comic_vine_dialog.cpp
+++ b/YACReaderLibrary/comic_vine/comic_vine_dialog.cpp
@@ -189,6 +189,7 @@ void ComicVineDialog::goBack()
 			showSearchVolume();
 		else
 			showSearchSingleComic();
+		break;
 	default:
 		if(mode == Volume)
 			showSearchVolume();

--- a/YACReaderLibrary/comic_vine/comic_vine_dialog.cpp
+++ b/YACReaderLibrary/comic_vine/comic_vine_dialog.cpp
@@ -702,7 +702,7 @@ void ComicVineDialog::searchVolume(const QString &v, int page)
 	status = SearchingVolume;
 }
 
-void ComicVineDialog::getVolumeComicsInfo(const QString &vID, int page)
+void ComicVineDialog::getVolumeComicsInfo(const QString &vID, int /* page */)
 {
 	showLoading(tr("Retrieving volume info..."));
 

--- a/YACReaderLibrary/comic_vine/model/response_parser.cpp
+++ b/YACReaderLibrary/comic_vine/model/response_parser.cpp
@@ -4,7 +4,7 @@
 #include <QDebug>
 
 ResponseParser::ResponseParser(QObject *parent) :
-    QObject(parent),error(false),numResults(-1),currentPage(-1),totalPages(-1),errorTxt("None")
+    QObject(parent),error(false),errorTxt("None"),numResults(-1),currentPage(-1),totalPages(-1)
 {
 }
 

--- a/YACReaderLibrary/db/comic_model.cpp
+++ b/YACReaderLibrary/db/comic_model.cpp
@@ -174,6 +174,8 @@ bool ComicModel::dropMimeData(const QMimeData *data, Qt::DropAction action, int 
     case ReadingList:
         DBHelper::reasignOrderToComicsInReadingList(sourceId,allComicIds,db);
         break;
+    default:
+        break;
     }
 
     QSqlDatabase::removeDatabase(db.connectionName());

--- a/YACReaderLibrary/db/data_base_management.cpp
+++ b/YACReaderLibrary/db/data_base_management.cpp
@@ -753,8 +753,8 @@ bool DataBaseManagement::updateToCurrentVersion(const QString & path)
     if(compareVersions(DataBaseManagement::checkValidDB(fullPath),"9.5.0")<0)
         pre9_5 = true;
 
-	QSqlDatabase db = loadDatabaseFromFile(fullPath);
-	bool returnValue = false;
+    QSqlDatabase db = loadDatabaseFromFile(fullPath);
+    bool returnValue = false;
     if(db.isValid() && db.isOpen())
 	{
 		QSqlQuery updateVersion(db);

--- a/YACReaderLibrary/db/folder_model.cpp
+++ b/YACReaderLibrary/db/folder_model.cpp
@@ -188,10 +188,10 @@ QVariant FolderModel::data(const QModelIndex &index, int role) const
     if(role == FolderModel::IdRole)
         return item->id;
 
-	if (role != Qt::DisplayRole)
-		return QVariant();
+    if (role != Qt::DisplayRole)
+        return QVariant();
 
-	return item->data(index.column());
+    return item->data(index.column());
 }
 //! [3]
 

--- a/YACReaderLibrary/db/folder_model.cpp
+++ b/YACReaderLibrary/db/folder_model.cpp
@@ -159,7 +159,7 @@ QVariant FolderModel::data(const QModelIndex &index, int role) const
     }
 
 	if (role == Qt::DecorationRole)
-
+	{
 #ifdef Q_OS_MAC
         if(item->data(FolderModel::Finished).toBool()){
             if(finishedFolderIcon.isNull()){
@@ -177,6 +177,7 @@ QVariant FolderModel::data(const QModelIndex &index, int role) const
         else
             return QVariant(YACReader::noHighlightedIcon(":/images/sidebar/folder.png"));
 #endif
+	}
 
     if(role == FolderModel::CompletedRole)
         return item->data(FolderModel::Completed);

--- a/YACReaderLibrary/db/folder_model.cpp
+++ b/YACReaderLibrary/db/folder_model.cpp
@@ -621,7 +621,7 @@ void FolderModel::updateFolderChildrenInfo(qulonglong folderId)
 //PROXY
 
 FolderModelProxy::FolderModelProxy(QObject *parent)
-    :QSortFilterProxyModel(parent),rootItem(0),filterEnabled(false),filter(""),includeComics(true)
+    :QSortFilterProxyModel(parent),rootItem(0),includeComics(true),filter(""),filterEnabled(false)
 {
 
 }

--- a/YACReaderLibrary/db/reading_list_model.cpp
+++ b/YACReaderLibrary/db/reading_list_model.cpp
@@ -219,6 +219,7 @@ bool ReadingListModel::canDropMimeData(const QMimeData *data, Qt::DropAction act
         return true;
 
     if(rowIsReadingList(row,parent))// TODO avoid droping in a different parent
+    {
         if(!parent.isValid())
             return false;
         else
@@ -232,6 +233,7 @@ bool ReadingListModel::canDropMimeData(const QMimeData *data, Qt::DropAction act
             return data->formats().contains(YACReader::YACReaderLibrarSubReadingListMimeDataFormat);
 
         }
+    }
 
     return false;
 }

--- a/YACReaderLibrary/db/reading_list_model.cpp
+++ b/YACReaderLibrary/db/reading_list_model.cpp
@@ -344,7 +344,9 @@ QMimeData *ReadingListModel::mimeData(const QModelIndexList &indexes) const
     }
 
     if(indexes.length() > 1)
+    {
         QLOG_DEBUG() << "mimeData requested for more than one index, this shouldn't be possible";
+    }
 
     QModelIndex modelIndex = indexes.at(0);
 

--- a/YACReaderLibrary/db_helper.cpp
+++ b/YACReaderLibrary/db_helper.cpp
@@ -499,8 +499,8 @@ void DBHelper::update(qulonglong libraryId, ComicInfo & comicInfo)
 
 void DBHelper::update(ComicInfo * comicInfo, QSqlDatabase & db)
 {
-    if(comicInfo == nullptr)
-        return;
+	if(comicInfo == nullptr)
+		return;
 
 	QSqlQuery updateComicInfo(db);
 	updateComicInfo.prepare("UPDATE comic_info SET "

--- a/YACReaderLibrary/db_helper.cpp
+++ b/YACReaderLibrary/db_helper.cpp
@@ -1335,7 +1335,6 @@ QList<Label> DBHelper::getLabels(qulonglong libraryId)
     QSqlRecord record = selectQuery.record();
 
     int name =  record.indexOf("name");
-    int color = record.indexOf("color");
     int id = record.indexOf("id");
     int ordering = record.indexOf("ordering");
 

--- a/YACReaderLibrary/import_widget.cpp
+++ b/YACReaderLibrary/import_widget.cpp
@@ -267,8 +267,6 @@ void ImportWidget::newCover(const QPixmap & image)
 {
 	Q_UNUSED(image)
 }
-static int i = 1;
-static int previousWidth = 10;
 static int j = 0;
 void ImportWidget::addCoverTest()
 {

--- a/YACReaderLibrary/library_window.cpp
+++ b/YACReaderLibrary/library_window.cpp
@@ -2629,7 +2629,7 @@ void LibraryWindow::importLibraryPackage()
 
 void LibraryWindow::updateComicsView(quint64 libraryId, const ComicDB & comic)
 {
-    if(libraryId == libraries.getId(selectedLibrary->currentText())) {
+    if(libraryId == (quint64)libraries.getId(selectedLibrary->currentText())) {
         comicsModel->reload(comic);
         comicsViewsManager->updateCurrentComicView();
     }

--- a/YACReaderLibrary/library_window.cpp
+++ b/YACReaderLibrary/library_window.cpp
@@ -88,7 +88,7 @@
 #endif
 
 LibraryWindow::LibraryWindow()
-    :QMainWindow(),fullscreen(false),fetching(false),previousFilter(""),removeError(false),status(LibraryWindow::Normal)
+    :QMainWindow(),fullscreen(false),previousFilter(""),fetching(false),status(LibraryWindow::Normal),removeError(false)
 {
     setupUI();
 

--- a/YACReaderLibrary/library_window.cpp
+++ b/YACReaderLibrary/library_window.cpp
@@ -2571,6 +2571,8 @@ void LibraryWindow::deleteComicsFromList()
         case ReadingListModel::ReadingList:
             comicsModel->deleteComicsFromReadingList(indexList,id);
             break;
+        case ReadingListModel::Separator:
+            break;
         }
     }
 

--- a/YACReaderLibrary/properties_dialog.cpp
+++ b/YACReaderLibrary/properties_dialog.cpp
@@ -422,37 +422,37 @@ void PropertiesDialog::setComics(QList<ComicDB> comics)
 	numPagesEdit->setText(QString::number(*comic.info.numPages));*/
 
 
-    if(!comic.info.number.isNull())
-        numberEdit->setText(comic.info.number.toString());
-    if(!comic.info.isBis.isNull())
-        isBisCheck->setChecked(comic.info.isBis.toBool());
-    if(!comic.info.count.isNull())
-        countEdit->setText(comic.info.count.toString());
+	if(!comic.info.number.isNull())
+		numberEdit->setText(comic.info.number.toString());
+	if(!comic.info.isBis.isNull())
+		isBisCheck->setChecked(comic.info.isBis.toBool());
+	if(!comic.info.count.isNull())
+		countEdit->setText(comic.info.count.toString());
 
-    if(!comic.info.volume.isNull())
-        volumeEdit->setText(comic.info.volume.toString());
-    if(!comic.info.storyArc.isNull())
-        storyArcEdit->setText(comic.info.storyArc.toString());
-    if(!comic.info.arcNumber.isNull())
-        arcNumberEdit->setText(comic.info.arcNumber.toString());
+	if(!comic.info.volume.isNull())
+		volumeEdit->setText(comic.info.volume.toString());
+	if(!comic.info.storyArc.isNull())
+		storyArcEdit->setText(comic.info.storyArc.toString());
+	if(!comic.info.arcNumber.isNull())
+		arcNumberEdit->setText(comic.info.arcNumber.toString());
 	if(!comic.info.arcCount.isNull())
-        arcCountEdit->setText(comic.info.arcCount.toString());
+		arcCountEdit->setText(comic.info.arcCount.toString());
 
 	if(!comic.info.genere.isNull())
-        genereEdit->setText(comic.info.genere.toString());
+		genereEdit->setText(comic.info.genere.toString());
 
 	if(!comic.info.writer.isNull())
-        writer->setPlainText(comic.info.writer.toString());
+		writer->setPlainText(comic.info.writer.toString());
 	if(!comic.info.penciller.isNull())
-        penciller->setPlainText(comic.info.penciller.toString());
+		penciller->setPlainText(comic.info.penciller.toString());
 	if(!comic.info.inker.isNull())
-        inker->setPlainText(comic.info.inker.toString());
+		inker->setPlainText(comic.info.inker.toString());
 	if(!comic.info.colorist.isNull())
-        colorist->setPlainText(comic.info.colorist.toString());
+		colorist->setPlainText(comic.info.colorist.toString());
 	if(!comic.info.letterer.isNull())
-        letterer->setPlainText(comic.info.letterer.toString());
+		letterer->setPlainText(comic.info.letterer.toString());
 	if(!comic.info.coverArtist.isNull())
-        coverArtist->setPlainText(comic.info.coverArtist.toString());
+		coverArtist->setPlainText(comic.info.coverArtist.toString());
 
 	size->setText(QString::number(comic.info.hash.right(comic.info.hash.length()-40).toInt()/1024.0/1024.0,'f',2)+"Mb");
 

--- a/YACReaderLibrary/server/controllers/v2/librariescontroller_v2.cpp
+++ b/YACReaderLibrary/server/controllers/v2/librariescontroller_v2.cpp
@@ -9,7 +9,7 @@
 
 LibrariesControllerV2::LibrariesControllerV2() {}
 
-void LibrariesControllerV2::service(HttpRequest& request, HttpResponse& response)
+void LibrariesControllerV2::service(HttpRequest& /* request */, HttpResponse& response)
 {
     response.setHeader("Content-Type", "application/json");
 

--- a/YACReaderLibrary/server/lib/httpserver/staticfilecontroller.cpp
+++ b/YACReaderLibrary/server/lib/httpserver/staticfilecontroller.cpp
@@ -273,7 +273,7 @@ QString StaticFileController::getDeviceAwareFileName(QString fileName, QString d
         return getLocalizedFileName(fileName,locales,path); //no hay archivo específico para el dispositivo, pero puede haberlo para estas locales
 }
 
-QString StaticFileController::getDeviceAwareFileName(QString fileName, QString device, QString display, QString locales, QString path) const
+QString StaticFileController::getDeviceAwareFileName(QString fileName, QString device, QString display, QString /* locales */, QString path) const
 {
     QFileInfo fi(fileName);
     QString baseName = fi.baseName();

--- a/YACReaderLibrary/server/requestmapper.cpp
+++ b/YACReaderLibrary/server/requestmapper.cpp
@@ -121,7 +121,7 @@ void RequestMapper::loadSessionV1(HttpRequest & request, HttpResponse& response)
     }
 }
 
-void RequestMapper::loadSessionV2(HttpRequest & request, HttpResponse& response)
+void RequestMapper::loadSessionV2(HttpRequest & request, HttpResponse& /* response */)
 {
     QMutexLocker locker(&mutex);
     

--- a/YACReaderLibrary/server/startup.cpp
+++ b/YACReaderLibrary/server/startup.cpp
@@ -70,16 +70,16 @@ void Startup::start() {
     if(templateSettings->value("path").isNull())
         templateSettings->setValue("path",templatePath);
 
-	Static::templateLoader=new TemplateCache(templateSettings,app);
+    Static::templateLoader=new TemplateCache(templateSettings,app);
 
-	// Configure session store
-	QSettings* sessionSettings=new QSettings(configFileName,QSettings::IniFormat,app);
-	sessionSettings->beginGroup("sessions");
+    // Configure session store
+    QSettings* sessionSettings=new QSettings(configFileName,QSettings::IniFormat,app);
+    sessionSettings->beginGroup("sessions");
 
     if(sessionSettings->value("expirationTime").isNull())
         sessionSettings->setValue("expirationTime",864000000);
 
-	Static::sessionStore=new HttpSessionStore(sessionSettings,app);
+    Static::sessionStore=new HttpSessionStore(sessionSettings,app);
 
     Static::yacreaderSessionStore = new YACReaderHttpSessionStore(Static::sessionStore, app);
 
@@ -101,12 +101,12 @@ void Startup::start() {
     if(fileSettings->value("path").isNull())
         fileSettings->setValue("path",docroot);
 
-	Static::staticFileController=new StaticFileController(fileSettings,app);
+    Static::staticFileController=new StaticFileController(fileSettings,app);
 
-	// Configure and start the TCP listener
-	qDebug("ServiceHelper: Starting service");
-	QSettings* listenerSettings=new QSettings(configFileName,QSettings::IniFormat,app);
-	listenerSettings->beginGroup("listener");
+    // Configure and start the TCP listener
+    qDebug("ServiceHelper: Starting service");
+    QSettings* listenerSettings=new QSettings(configFileName,QSettings::IniFormat,app);
+    listenerSettings->beginGroup("listener");
 
     if(listenerSettings->value("maxRequestSize").isNull())
         listenerSettings->setValue("maxRequestSize","32000000");
@@ -123,9 +123,9 @@ void Startup::start() {
     if(listenerSettings->value("minThreads").isNull())
         listenerSettings->setValue("minThreads",50);
 
-	listener = new HttpListener(listenerSettings,new RequestMapper(app),app);
+    listener = new HttpListener(listenerSettings,new RequestMapper(app),app);
 
-	qDebug("ServiceHelper: Service has started");
+    qDebug("ServiceHelper: Service has started");
 }
 
 

--- a/YACReaderLibrary/server/yacreader_http_session.cpp
+++ b/YACReaderLibrary/server/yacreader_http_session.cpp
@@ -1,7 +1,7 @@
 #include "yacreader_http_session.h"
 
 YACReaderHttpSession::YACReaderHttpSession(QObject *parent)
-    : QObject(parent), comic(nullptr), remoteComic(nullptr), comicId(0), remoteComicId(0)
+    : QObject(parent), comicId(0), remoteComicId(0), comic(nullptr), remoteComic(nullptr)
 {
 
 }

--- a/YACReaderLibrary/yacreader_local_server.cpp
+++ b/YACReaderLibrary/yacreader_local_server.cpp
@@ -188,7 +188,9 @@ void YACReaderClientConnectionWorker::run()
 					tries++;
 			}
 			if(tries == 200 && written != block.size())
+			{
 				QLOG_ERROR() << QString("Local connection (comic info requested): unable to send response (%1,%2)").arg(written).arg(block.size());
+			}
 			break;
 		}
 	case YACReader::SendComicInfo:

--- a/YACReaderLibrary/yacreader_local_server.cpp
+++ b/YACReaderLibrary/yacreader_local_server.cpp
@@ -104,7 +104,7 @@ void YACReaderClientConnectionWorker::run()
 	int dataAvailable = 0;
 	QByteArray packageSize;
     clientConnection->waitForReadyRead(1000);
-	while(packageSize.size() < sizeof(quint32) && tries < 20)
+	while(((long unsigned int)packageSize.size() < sizeof(quint32)) && (tries < 20))
 	{
 		packageSize.append(clientConnection->read(sizeof(quint32) - packageSize.size()));
 		clientConnection->waitForReadyRead(100);

--- a/YACReaderLibrary/yacreader_navigation_controller.cpp
+++ b/YACReaderLibrary/yacreader_navigation_controller.cpp
@@ -259,6 +259,8 @@ void YACReaderNavigationController::loadIndexFromHistory(const YACReaderLibraryS
         loadListInfo(sourceMI);
         break;
     }
+    case YACReaderLibrarySourceContainer::None:
+        break;
     }
 }
 

--- a/common/comic.cpp
+++ b/common/comic.cpp
@@ -44,13 +44,13 @@ const QStringList Comic::literalComicExtensions = LiteralComicArchiveExtensions;
 
 //-----------------------------------------------------------------------------
 Comic::Comic()
-:_pages(),_index(0),_path(),_loaded(false),bm(new Bookmarks()),_loadedPages(),_isPDF(false),_invalidated(false),_errorOpening(false)
+:_pages(),_loadedPages(),_index(0),_path(),_loaded(false),_isPDF(false),_invalidated(false),_errorOpening(false),bm(new Bookmarks())
 {
 	setup();
 }
 //-----------------------------------------------------------------------------
 Comic::Comic(const QString & pathFile, int atPage )
-:_pages(),_index(0),_path(pathFile),_loaded(false),bm(new Bookmarks()),_loadedPages(),_isPDF(false),_firstPage(atPage),_errorOpening(false)
+:_pages(),_loadedPages(),_index(0),_path(pathFile),_loaded(false),_firstPage(atPage),_isPDF(false),_errorOpening(false),bm(new Bookmarks())
 {
 	setup();
 }

--- a/common/comic_db.cpp
+++ b/common/comic_db.cpp
@@ -29,7 +29,7 @@ QString ComicDB::toTXT()
 	txt.append(QString("comicid:%1\r\n").arg(id));
 	txt.append(QString("hash:%1\r\n").arg(info.hash));
 	txt.append(QString("path:%1\r\n").arg(path));
-    txt.append(QString("numpages:%1\r\n").arg(info.numPages.toString()));
+	txt.append(QString("numpages:%1\r\n").arg(info.numPages.toString()));
 
 	//new 7.0
 	txt.append(QString("rating:%1\r\n").arg(info.rating));
@@ -37,23 +37,23 @@ QString ComicDB::toTXT()
 	txt.append(QString("contrast:%1\r\n").arg(info.contrast));
 
 	//Informaci�n general
-    if(!info.coverPage.isNull())
-        txt.append(QString("coverPage:%1\r\n").arg(info.coverPage.toString()));
+	if(!info.coverPage.isNull())
+		txt.append(QString("coverPage:%1\r\n").arg(info.coverPage.toString()));
 
-    if(!info.title.isNull())
-        txt.append(QString("title:%1\r\n").arg(info.title.toString()));
+	if(!info.title.isNull())
+		txt.append(QString("title:%1\r\n").arg(info.title.toString()));
 
 	if(!info.number.isNull())
-        txt.append(QString("number:%1\r\n").arg(info.number.toString()));
+		txt.append(QString("number:%1\r\n").arg(info.number.toString()));
 
 	if(!info.isBis.isNull())
-        txt.append(QString("isBis:%1\r\n").arg(info.isBis.toBool()?"1":"0"));
+		txt.append(QString("isBis:%1\r\n").arg(info.isBis.toBool()?"1":"0"));
 
 	if(!info.count.isNull())
-        txt.append(QString("count:%1\r\n").arg(info.count.toString()));
+		txt.append(QString("count:%1\r\n").arg(info.count.toString()));
 
 	if(!info.volume.isNull())
-        txt.append(QString("volume:%1\r\n").arg(info.volume.toString()));
+		txt.append(QString("volume:%1\r\n").arg(info.volume.toString()));
 
 	if(!info.storyArc.isNull())
 		txt.append(QString("storyArc:%1\r\n").arg(info.storyArc.toString()));
@@ -88,7 +88,7 @@ QString ComicDB::toTXT()
 	//Publicaci�n
 	if(!info.date.isNull())
 		txt.append(QString("date:%1\r\n").arg(info.date.toString()));
-	
+
 	if(!info.publisher.isNull())
 		txt.append(QString("publisher:%1\r\n").arg(info.publisher.toString()));
 
@@ -110,7 +110,7 @@ QString ComicDB::toTXT()
 	if(!info.notes.isNull())
 		txt.append(QString("notes:%1\r\n").arg(info.notes.toString()));
 
-    return txt;
+	return txt;
 }
 
 ComicDB &ComicDB::operator=(const ComicDB &other)

--- a/common/comic_db.cpp
+++ b/common/comic_db.cpp
@@ -181,6 +181,7 @@ ComicInfo::ComicInfo()
 }
 
 ComicInfo::ComicInfo(const ComicInfo & comicInfo)
+	:QObject()
 {
 	operator=(comicInfo);
 }

--- a/common/gl/yacreader_flow_gl.cpp
+++ b/common/gl/yacreader_flow_gl.cpp
@@ -650,22 +650,21 @@ void YACReaderFlowGL::setCurrentIndex(int pos)
     if(pos >= images.length() && images.length() > 0)
         pos = images.length()-1;
 
-        startAnimationTimer();
+    startAnimationTimer();
 
-        currentSelected = pos;
+    currentSelected = pos;
 
-        config.animationStep *= config.animationSpeedUp;
+    config.animationStep *= config.animationSpeedUp;
 
-        if(config.animationStep > config.animationStepMax){
-            config.animationStep = config.animationStepMax;
-        }
+    if(config.animationStep > config.animationStepMax){
+        config.animationStep = config.animationStepMax;
+    }
 
-        if(viewRotateActive && viewRotate < 1){
-            viewRotate += config.viewRotateAdd;
-        }
+    if(viewRotateActive && viewRotate < 1){
+        viewRotate += config.viewRotateAdd;
+    }
 
-        viewRotateActive = 1;
-
+    viewRotateActive = 1;
 }
 
 void YACReaderFlowGL::updatePositions()

--- a/common/gl/yacreader_flow_gl.cpp
+++ b/common/gl/yacreader_flow_gl.cpp
@@ -200,7 +200,7 @@ struct Preset pressetYACReaderFlowDownConfig = {
 };
 /*Constructor*/
 YACReaderFlowGL::YACReaderFlowGL(QWidget *parent,struct Preset p)
-    :QOpenGLWidget(/*QOpenGLWidget migration QGLFormat(QGL::SampleBuffers),*/ parent),numObjects(0),lazyPopulateObjects(-1),bUseVSync(false),hasBeenInitialized(false),flowRightToLeft(false)
+    :QOpenGLWidget(/*QOpenGLWidget migration QGLFormat(QGL::SampleBuffers),*/ parent),numObjects(0),lazyPopulateObjects(-1),hasBeenInitialized(false),bUseVSync(false),flowRightToLeft(false)
 {
 	updateCount = 0;
 	config = p;

--- a/common/gl/yacreader_flow_gl.cpp
+++ b/common/gl/yacreader_flow_gl.cpp
@@ -755,7 +755,7 @@ void YACReaderFlowGL::remove(int item)
     if(texture != defaultTexture)
         delete(texture);
 
-	numObjects--;
+    numObjects--;
 }
 
 /*Info*/

--- a/common/pictureflow.cpp
+++ b/common/pictureflow.cpp
@@ -1399,6 +1399,8 @@ void PictureFlow::setFlowType(FlowType flowType)
 		  d->state->spacingRatio = 0;
 		  d->state->reposition();
 	  break;
+	default:
+	  break;
   }
   d->state->reset();
   d->renderer->init();

--- a/common/pictureflow.cpp
+++ b/common/pictureflow.cpp
@@ -1261,18 +1261,19 @@ void PictureFlow::showSlide(unsigned int index)
 {
   index = qMax<unsigned int>(index, 0);
   index = qMin<unsigned int>(slideCount()-1, index);
-  if((int)index == d->state->centerSlide.slideIndex)
+  if((int)index == d->state->centerSlide.slideIndex) {
     return;
+  }
 
-    int distance = centerIndex()-index;
+  int distance = centerIndex()-index;
 
-    if(abs(distance)>10)
-    {
-        if(distance<0)
-            setCenterIndex(centerIndex()+(-distance)-10);
-        else
-            setCenterIndex(centerIndex()-distance+10);
-    }
+  if(abs(distance)>10)
+  {
+    if(distance<0)
+      setCenterIndex(centerIndex()+(-distance)-10);
+    else
+      setCenterIndex(centerIndex()-distance+10);
+  }
 
   d->state->centerIndex = index;
   d->animator->start(index);

--- a/common/pictureflow.cpp
+++ b/common/pictureflow.cpp
@@ -1261,7 +1261,7 @@ void PictureFlow::showSlide(unsigned int index)
 {
   index = qMax<unsigned int>(index, 0);
   index = qMin<unsigned int>(slideCount()-1, index);
-  if(index == d->state->centerSlide.slideIndex)
+  if((int)index == d->state->centerSlide.slideIndex)
     return;
 
     int distance = centerIndex()-index;

--- a/common/pictureflow.cpp
+++ b/common/pictureflow.cpp
@@ -283,7 +283,7 @@ private:
 
 PictureFlowState::PictureFlowState(int a, float sr):
 backgroundColor(0), slideWidth(150), slideHeight(200),
-reflectionEffect(PictureFlow::BlurredReflection), centerIndex(0) , rawAngle(a), spacingRatio(sr), flowRightToLeft(false)
+reflectionEffect(PictureFlow::BlurredReflection), rawAngle(a), spacingRatio(sr), centerIndex(0), flowRightToLeft(false)
 {
 }
 

--- a/common/pictureflow.cpp
+++ b/common/pictureflow.cpp
@@ -1017,6 +1017,8 @@ PictureFlow::PictureFlow(QWidget* parent,FlowType flowType): QWidget(parent)
 	case StripOverlapped:
 	  d->state = new PictureFlowState(0,0);
 	  break;
+	default:
+	  break;
   }
 
   framesSkip = 0;

--- a/common/scroll_management.cpp
+++ b/common/scroll_management.cpp
@@ -23,7 +23,7 @@ ScrollManagement::Movement ScrollManagement::getMovement(QWheelEvent *event)
     }
 
     // Accumulate the delta
-    if(event->delta()<0 != wheelAccumulator<0 ) //different sign means change in direction
+    if((event->delta()<0) != (wheelAccumulator<0) ) //different sign means change in direction
         wheelAccumulator = 0;
 
     wheelAccumulator += event->delta();

--- a/custom_widgets/yacreader_busy_widget.cpp
+++ b/custom_widgets/yacreader_busy_widget.cpp
@@ -57,7 +57,7 @@ void BusyIndicator::setColor(QColor color)
 	fillColor = color;
 }
 
-const BusyIndicator::IndicatorStyle BusyIndicator::indicatorStyle() const
+BusyIndicator::IndicatorStyle BusyIndicator::indicatorStyle() const
 {
 	return m_style;
 }

--- a/custom_widgets/yacreader_busy_widget.h
+++ b/custom_widgets/yacreader_busy_widget.h
@@ -26,7 +26,7 @@ public:
 
 	void setIndicatorStyle(IndicatorStyle);
 	void setColor(QColor color);
-	const IndicatorStyle indicatorStyle() const;
+	IndicatorStyle indicatorStyle() const;
 
 signals:
 


### PR DESCRIPTION
This branch fixes the compilation warnings of gcc. This replaces #40 (the context is described there).

As requested, I've moved some bugs discovered here into separated branches : #41 and #42.
I've also changed my commit policy to make micro-commits that should be easier to rebase.