### PR TITLE
Editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,15 @@
+# EditorConfig for YACReader
+# see https://EditorConfig.org
+
+root = true
+
+[*]
+charset = utf-8
+trim_trailing_whitespace = true
+end_of_line = lf
+insert_final_newline = true
+indent_style = space
+indent_size = 4
+
+[*.yml]
+indent_size = 2


### PR DESCRIPTION
This PR adds an .editorconfig file which is a great way to configure whitespace and encoding defaults in an environment where contributors may use all kinds of editors and IDEs. Some apps support this out of the box, others will need to install a plugin to make this work.

For QtCreator an inofficial plugin is available here:
https://github.com/editorconfig/editorconfig-qtcreator/releases

Note that using EditorConfig is not intended to solve any of our current whitespace and indentation issues but as a sane default and measure to prevent further errors from slipping in. 