### PR TITLE
Library: fix a crash at exit when server is disabled

### DIFF
--- a/YACReaderLibrary/server/startup.cpp
+++ b/YACReaderLibrary/server/startup.cpp
@@ -142,6 +142,7 @@ void Startup::stop() {
 
 
 Startup::Startup()
+    : listener(nullptr)
 {
 
 }


### PR DESCRIPTION
[`Startup::stop()`](https://github.com/YACReader/yacreader/blob/87a66458751b5486eb40b7a54ab3214704a3666a/YACReaderLibrary/server/startup.cpp#L132) called from [`LibraryWindow::closeEvent()`](https://github.com/YACReader/yacreader/blob/87a66458751b5486eb40b7a54ab3214704a3666a/YACReaderLibrary/library_window.cpp#L2415) crashes if `listener` is not initialized.