### PR TITLE
Fix a data race in PictureFlow::triggerRender()

### DIFF
--- a/common/pictureflow.cpp
+++ b/common/pictureflow.cpp
@@ -999,7 +999,6 @@ public:
   PictureFlowState* state;
   PictureFlowAnimator* animator;
   PictureFlowAbstractRenderer* renderer;
-  QTimer triggerTimer;
 };
 
 
@@ -1034,8 +1033,6 @@ PictureFlow::PictureFlow(QWidget* parent,FlowType flowType): QWidget(parent)
   d->animator = new PictureFlowAnimator;
   d->animator->state = d->state;
   QObject::connect(&d->animator->animateTimer, SIGNAL(timeout()), this, SLOT(updateAnimation()));
-
-  QObject::connect(&d->triggerTimer, SIGNAL(timeout()), this, SLOT(render()));
 
 #ifdef PICTUREFLOW_QT4
   setAttribute(Qt::WA_StaticContents, true);
@@ -1194,13 +1191,7 @@ void PictureFlow::render()
 
 void PictureFlow::triggerRender()
 {
-#ifdef PICTUREFLOW_QT4
-  d->triggerTimer.setSingleShot(true);
-  d->triggerTimer.start(0);
-#endif
-#if defined(PICTUREFLOW_QT3) || defined(PICTUREFLOW_QT2)
-  d->triggerTimer.start(0, true);
-#endif
+  QTimer::singleShot(0, this, &PictureFlow::render);
 }
 
 void PictureFlow::showPrevious()


### PR DESCRIPTION
`PictureFlow::triggerRender()` is called from at least two different threads. Thus modifying `triggerTimer` in this function was a data race.

Not sharing the timer object should not degrade performance because the documentation for `QWidget::update()` [states](https://doc.qt.io/qt-5/qwidget.html#update):

> Calling `update()` several times normally results in just one `paintEvent()` call.

Without this fix YACReader on GNU/Linux often uses an entire CPU core from launch till exit if hardware acceleration is disabled (#56).

This commit also eliminates the following errors from YACReader's standard output:

>     QObject::killTimer: Timers cannot be stopped from another thread
>     QObject::startTimer: Timers cannot be started from another thread

The code requires Qt 5.4 or later, which should be OK as INSTALL.md [lists](https://github.com/YACReader/yacreader/blob/master/INSTALL.md#build-dependencies) "Qt >= 5.6" as a build dependency.