### PR TITLE
Fix headless server build defaults

### DIFF
--- a/YACReaderLibraryServer/YACReaderLibraryServer.pro
+++ b/YACReaderLibraryServer/YACReaderLibraryServer.pro
@@ -129,17 +129,19 @@ DATADIR = $$PREFIX/share
 DEFINES += "LIBDIR=\\\"$$LIBDIR\\\""  "DATADIR=\\\"$$DATADIR\\\"" "BINDIR=\\\"$$BINDIR\\\""
 
 #make install
+
+!CONFIG(server_bundled):!CONFIG(server_standalone): {
+    CONFIG+=server_bundled
+    message("No build type specified. Defaulting to bundled server build (CONFIG+=server_bundled).")
+    message("If you wish to run YACReaderLibraryServer on a system without an existing install of YACReaderLibrary,\
+            please specify CONFIG+=server_standalone as an option when running qmake to avoid missing dependencies.")
+}
+
 CONFIG(server_standalone) {
   INSTALLS += bin server translation systemd
 }
 else:CONFIG(server_bundled) {
   INSTALLS += bin systemd
-}
-else {
-  INSTALLS += bin server translation systemd
-  message("No build type specified. Defaulting to standalone server build (CONFIG+=server_standalone).")
-  message("If you wish to run YACReaderLibraryServer on a system with an existing install of YACReaderLibrary,\
-            please specify CONFIG+=server_bundled as an option when running qmake.")
 }
 
 bin.path = $$BINDIR

--- a/YACReaderLibraryServer/YACReaderLibraryServer.pro
+++ b/YACReaderLibraryServer/YACReaderLibraryServer.pro
@@ -10,7 +10,7 @@ INCLUDEPATH += ../YACReaderLibrary \
                 ../YACReaderLibrary/server \
                 ../YACReaderLibrary/db
 
-DEFINES += SERVER_RELEASE NOMINMAX YACREADER_LIBRARY QT_NO_DEBUG_OUTPUT
+DEFINES += SERVER_RELEASE NOMINMAX YACREADER_LIBRARY
 # load default build flags
 # do a basic dependency check
 include(headless_config.pri)


### PR DESCRIPTION
This PR fixes the problem that our headless server used to default to a standalone build, which gives conflicts when installing both the headless server and YACReaderLibrary.
It also removes the directive removing all debug output (QT_NO_DEBUG_OUTPUT) as we no longer can remember why we added it in the first place and our new loglevel commandline option supercedes it anyway.