### PR TITLE
Unify image loader classes

### DIFF
--- a/YACReaderLibrary/YACReaderLibrary.pro
+++ b/YACReaderLibrary/YACReaderLibrary.pro
@@ -107,6 +107,8 @@ HEADERS += comic_flow.h \
   ../common/comic.h \
   ../common/bookmarks.h \
   ../common/pictureflow.h \
+  ../common/release_acquire_atomic.h \
+  ../common/worker_thread.h \
   ../common/custom_widgets.h \
   ../common/qnaturalsorting.h \
   ../common/yacreader_global.h \

--- a/YACReaderLibrary/comic_flow.cpp
+++ b/YACReaderLibrary/comic_flow.cpp
@@ -3,14 +3,11 @@
 
 #include "yacreader_global.h"
 
-#include <QTimer>
-
 ComicFlow::ComicFlow(QWidget *parent, FlowType flowType)
     : YACReaderFlow(parent, flowType), worker(new WorkerThread<QImage>)
 {
     resetWorkerIndex();
-    updateTimer = new QTimer;
-    connect(updateTimer, SIGNAL(timeout()), this, SLOT(updateImageData()));
+    connect(&updateTimer, SIGNAL(timeout()), this, SLOT(updateImageData()));
 
     connect(this, SIGNAL(centerIndexChanged(int)), this, SLOT(preload()));
     connect(this, SIGNAL(centerIndexChangedSilent(int)), this, SLOT(preload()));
@@ -18,10 +15,7 @@ ComicFlow::ComicFlow(QWidget *parent, FlowType flowType)
     setReflectionEffect(PlainReflection);
 }
 
-ComicFlow::~ComicFlow()
-{
-    delete updateTimer;
-}
+ComicFlow::~ComicFlow() = default;
 
 void ComicFlow::setImagePaths(const QStringList &paths)
 {
@@ -55,7 +49,7 @@ void ComicFlow::setImagePaths(const QStringList &paths)
 void ComicFlow::preload()
 {
     if (numImagesLoaded < imagesLoaded.size())
-        updateTimer->start(30); //TODO comprobar rendimiento, originalmente era 70
+        updateTimer.start(30); //TODO comprobar rendimiento, originalmente era 70
 }
 
 void ComicFlow::updateImageData()
@@ -101,7 +95,7 @@ void ComicFlow::updateImageData()
     }
 
     // no need to generate anything? stop polling...
-    updateTimer->stop();
+    updateTimer.stop();
 }
 
 void ComicFlow::keyPressEvent(QKeyEvent *event)

--- a/YACReaderLibrary/comic_flow.h
+++ b/YACReaderLibrary/comic_flow.h
@@ -4,21 +4,21 @@
 #include "yacreader_flow.h"
 
 #include <QtCore>
-#include <QObject>
-#include <QThread>
 #include <QImage>
-#include <QMutex>
-#include <QWaitCondition>
 #include <QString>
 #include <QWheelEvent>
 
-class ImageLoader;
+#include <memory>
+
+template<typename Result>
+class WorkerThread;
+
 class ComicFlow : public YACReaderFlow
 {
     Q_OBJECT
 public:
     ComicFlow(QWidget *parent = nullptr, FlowType flowType = CoverFlowLike);
-    virtual ~ComicFlow();
+    ~ComicFlow() override;
 
     void setImagePaths(const QStringList &paths);
     //bool eventFilter(QObject *target, QEvent *event);
@@ -31,46 +31,16 @@ private slots:
     void updateImageData();
 
 private:
-    //QString imagePath;
+    void resetWorkerIndex() { workerIndex = -1; }
+
     QStringList imageFiles;
     QVector<bool> imagesLoaded;
     QVector<bool> imagesSetted;
     int numImagesLoaded;
+    int workerIndex;
     QTimer *updateTimer;
-    ImageLoader *worker;
+    std::unique_ptr<WorkerThread<QImage>> worker;
     virtual void wheelEvent(QWheelEvent *event);
-};
-
-//-----------------------------------------------------------------------------
-// Source code of ImageLoader class was modified from http://code.google.com/p/photoflow/
-//------------------------------------------------------------------------------
-class ImageLoader : public QThread
-{
-public:
-    ImageLoader();
-    ~ImageLoader() override;
-    // returns FALSE if worker is still busy and can't take the task
-    bool busy() const;
-    void generate(int index, const QString &fileName, QSize size);
-    void reset() { idx = -1; };
-    int index() const { return idx; };
-    void lock();
-    void unlock();
-    QImage result();
-
-protected:
-    void run() override;
-
-private:
-    QMutex mutex;
-    QWaitCondition condition;
-
-    bool restart;
-    bool working;
-    int idx;
-    QString fileName;
-    QSize size;
-    QImage img;
 };
 
 #endif

--- a/YACReaderLibrary/comic_flow.h
+++ b/YACReaderLibrary/comic_flow.h
@@ -6,6 +6,7 @@
 #include <QtCore>
 #include <QImage>
 #include <QString>
+#include <QTimer>
 #include <QWheelEvent>
 
 #include <memory>
@@ -38,7 +39,7 @@ private:
     QVector<bool> imagesSetted;
     int numImagesLoaded;
     int workerIndex;
-    QTimer *updateTimer;
+    QTimer updateTimer;
     std::unique_ptr<WorkerThread<QImage>> worker;
     virtual void wheelEvent(QWheelEvent *event);
 };

--- a/common/release_acquire_atomic.h
+++ b/common/release_acquire_atomic.h
@@ -1,0 +1,28 @@
+#ifndef RELEASE_ACQUIRE_ATOMIC_H
+#define RELEASE_ACQUIRE_ATOMIC_H
+
+#include <atomic>
+
+template<typename T>
+class ReleaseAcquireAtomic
+{
+public:
+    constexpr ReleaseAcquireAtomic(T desired) noexcept
+        : value(desired) {}
+
+    T operator=(T desired) noexcept
+    {
+        value.store(desired, std::memory_order_release);
+        return desired;
+    }
+
+    operator T() const noexcept
+    {
+        return value.load(std::memory_order_acquire);
+    }
+
+private:
+    std::atomic<T> value;
+};
+
+#endif // RELEASE_ACQUIRE_ATOMIC_H

--- a/common/worker_thread.h
+++ b/common/worker_thread.h
@@ -1,0 +1,91 @@
+#ifndef WORKER_THREAD_H
+#define WORKER_THREAD_H
+
+#include "release_acquire_atomic.h"
+
+#include <cassert>
+#include <utility>
+#include <functional>
+#include <mutex>
+#include <condition_variable>
+#include <thread>
+
+//! Usage:
+//!  1. call performTask();
+//!  2. wait until busy() returns false;
+//!  3. (optionally) call extractResult();
+//!  4. return to step 1 (assign another task).
+//!  You may invoke busy() and the destructor at any moment.
+template<typename Result>
+class WorkerThread
+{
+public:
+    WorkerThread() = default;
+    ~WorkerThread();
+
+    using Task = std::function<Result()>;
+    void performTask(Task newTask);
+
+    //! @return true if the last assigned task is not done yet.
+    bool busy() const { return working; }
+    Result extractResult() { return std::move(result); }
+
+private:
+    void run();
+
+    Task task;
+    Result result;
+
+    ReleaseAcquireAtomic<bool> working { false };
+    bool abort { false };
+    std::mutex mutex;
+    std::condition_variable condition;
+    std::thread thread;
+};
+
+template<typename Result>
+WorkerThread<Result>::~WorkerThread()
+{
+    {
+        std::lock_guard<std::mutex> lock(mutex);
+        abort = true;
+    }
+    condition.notify_one();
+    if (thread.joinable())
+        thread.join();
+}
+
+template<typename Result>
+void WorkerThread<Result>::performTask(Task newTask)
+{
+    assert(!working && "Don't interrupt my work!");
+    assert(newTask && "The task may not be empty.");
+    task = std::move(newTask);
+
+    if (thread.joinable()) {
+        {
+            std::lock_guard<std::mutex> lock(mutex);
+            working = true;
+        }
+        condition.notify_one();
+    } else {
+        working = true;
+        thread = std::thread(&WorkerThread::run, this);
+    }
+}
+
+template<typename Result>
+void WorkerThread<Result>::run()
+{
+    while (true) {
+        result = task();
+        working = false;
+
+        std::unique_lock<std::mutex> lock(mutex);
+        condition.wait(lock, [this] { return working || abort; });
+        if (abort)
+            break;
+    }
+}
+
+#endif // WORKER_THREAD_H


### PR DESCRIPTION
This is the first pull request in a series of two. It introduces the common worker class and uses it instead of one of the 4 image loader classes. See commit messages for details.

Note: I don't like some of the formatting changes clang-format does. There aren't many templates, lambdas or default member initializers in YACReader code yet. Consider the results and see if you like them. If not, you could change some of the formatting rules. I'd be happy to reformat changes in this pull request afterwards :). These are clang-format changes to the initial version of this pull request: [clang-format-changes.patch.zip](https://github.com/YACReader/yacreader/files/3855411/clang-format-changes.patch.zip).

