### PR TITLE
Reader: fix restoring Info visibility

### DIFF
--- a/YACReader/main_window_viewer.cpp
+++ b/YACReader/main_window_viewer.cpp
@@ -1217,11 +1217,7 @@ void MainWindowViewer::checkNewVersion()
         connect(versionChecker, SIGNAL(newVersionDetected()),
                 this, SLOT(newVersion()));
 
-        auto tT = new QTimer;
-        tT->setSingleShot(true);
-        connect(tT, SIGNAL(timeout()), versionChecker, SLOT(get()));
-        //versionChecker->get(); //TOD�
-        tT->start(100);
+        QTimer::singleShot(100, versionChecker, &HttpVersionChecker::get);
 
         conf.setLastVersionCheck(current);
     }

--- a/YACReader/viewer.cpp
+++ b/YACReader/viewer.cpp
@@ -161,7 +161,7 @@ void Viewer::createConnections()
     connect(goToFlow, SIGNAL(goToPage(unsigned int)), this, SLOT(goTo(unsigned int)));
 
     //current time
-    auto t = new QTimer();
+    auto t = new QTimer(this);
     connect(t, SIGNAL(timeout()), this, SLOT(updateInformation()));
     t->start(1000);
 

--- a/YACReader/viewer.cpp
+++ b/YACReader/viewer.cpp
@@ -205,12 +205,8 @@ void Viewer::prepareForOpening()
 
     verticalScrollBar()->setSliderPosition(verticalScrollBar()->minimum());
 
-    if (Configuration::getConfiguration().getShowInformation() && !information) {
-        auto timer = new QTimer();
-        connect(timer, SIGNAL(timeout()), this, SLOT(informationSwitch()));
-        connect(timer, SIGNAL(timeout()), timer, SLOT(deleteLater()));
-        timer->start();
-    }
+    if (Configuration::getConfiguration().getShowInformation() && !information)
+        QTimer::singleShot(0, this, &Viewer::informationSwitch);
 
     informationLabel->setText("...");
 }


### PR DESCRIPTION
See commit messages for details.

There is one more place where a temporary `QTimer` can be refactored into `QTimer::singleShot`: [`LibraryWindow::toNormal()`](https://github.com/YACReader/yacreader/blob/36c1cdd2dac57225aa4b9743120c2c71f7f6fab5/YACReaderLibrary/library_window.cpp#L2057). I am not touching that code for two reasons:
1. I can not test it because I don't have access to Mac.
2. I doubt that it currently works as intended because [`YACReaderMacOSXToolbar::show()`](https://github.com/YACReader/yacreader/blob/36c1cdd2dac57225aa4b9743120c2c71f7f6fab5/custom_widgets/yacreader_macosx_toolbar.h#L59) is a simple function. As far as I know, only slots can be connected to with the old signal and slot syntax.