### PR TITLE
Azure fixes for Windows

### DIFF
--- a/azure-pipelines-windows-template.yml
+++ b/azure-pipelines-windows-template.yml
@@ -33,7 +33,7 @@ jobs:
       nmake
     displayName: 'Build'
   - script: |
-      set PATH=C:\Qt\${{ parameters.qt_version }}\${{ parameters.qt_spec }}\bin
+      set PATH=C:\Qt\${{ parameters.qt_version }}\${{ parameters.qt_spec }}\bin;%PATH%
       cd $(Build.SourcesDirectory)\ci\win
       .\create_installer.cmd ${{ parameters.architecture }} 7z $(Build.BuildNumber)
     displayName: 'Create installer'

--- a/azure-pipelines-windows-template.yml
+++ b/azure-pipelines-windows-template.yml
@@ -18,22 +18,22 @@ jobs:
       pip install aqtinstall
       mkdir C:\Qt
       python -m aqt install -O c:\Qt ${{ parameters.qt_version }} windows desktop ${{ parameters.qt_aqt_spec }}
-      dir C:\Qt\Qt${{ parameters.qt_version }}\${{ parameters.qt_version }}\${{ parameters.qt_spec }}\bin
+      dir C:\Qt\${{ parameters.qt_version }}\${{ parameters.qt_spec }}\bin
       choco install -y wget
-      choco install innosetup 
+      choco install innosetup
       wget "https://sourceforge.net/projects/sevenzip/files/7-Zip/18.05/7z1805-src.7z" -P $(Build.SourcesDirectory)\compressed_archive
       7z x $(Build.SourcesDirectory)\compressed_archive\7z1805-src.7z -o$(Build.SourcesDirectory)\compressed_archive\lib7zip
       wget "${{ parameters.vc_redist_url }}" -O $(Build.SourcesDirectory)\${{ parameters.vc_redist_file_name }}
     displayName: 'Install dependencies'
   - script: |
       call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\${{ parameters.vc_vars }}"
-      set PATH=C:\Qt\Qt${{ parameters.qt_version }}\${{ parameters.qt_version }}\${{ parameters.qt_spec }}\bin;%PATH%
+      set PATH=C:\Qt\${{ parameters.qt_version }}\${{ parameters.qt_spec }}\bin;%PATH%
       set DEFINES_VAR=DEFINES+="BUILD_NUMBER=\\\\\\\"$(Build.BuildNumber)\\\\\\\""
       qmake CONFIG+="7zip" %DEFINES_VAR%
       nmake
     displayName: 'Build'
   - script: |
-      set PATH=%PATH%;C:\Qt\Qt${{ parameters.qt_version }}\${{ parameters.qt_version }}\${{ parameters.qt_spec }}\bin;%PATH%
+      set PATH=C:\Qt\${{ parameters.qt_version }}\${{ parameters.qt_spec }}\bin
       cd $(Build.SourcesDirectory)\ci\win
       .\create_installer.cmd ${{ parameters.architecture }} 7z $(Build.BuildNumber)
     displayName: 'Create installer'
@@ -48,4 +48,4 @@ jobs:
       artifactName: Windows ${{ parameters.architecture }} $(Build.BuildNumber) 7z Installer
 
 
-    
+

--- a/azure-pipelines-windows-template.yml
+++ b/azure-pipelines-windows-template.yml
@@ -1,6 +1,6 @@
 parameters:
   name: Windows_x64
-  arquitecture: 'x64'
+  architecture: 'x64'
   qt_version: '5.12.4'
   qt_spec: 'msvc2017_64'
   qt_aqt_spec: 'win64_msvc2017_64'
@@ -35,7 +35,7 @@ jobs:
   - script: |
       set PATH=%PATH%;C:\Qt\Qt${{ parameters.qt_version }}\${{ parameters.qt_version }}\${{ parameters.qt_spec }}\bin;%PATH%
       cd $(Build.SourcesDirectory)\ci\win
-      .\create_installer.cmd ${{ parameters.arquitecture }} 7z $(Build.BuildNumber)
+      .\create_installer.cmd ${{ parameters.architecture }} 7z $(Build.BuildNumber)
     displayName: 'Create installer'
   - task: CopyFiles@2
     inputs:
@@ -45,7 +45,7 @@ jobs:
   - task: PublishPipelineArtifact@1
     inputs:
       path: $(Build.ArtifactStagingDirectory)
-      artifactName: Windows ${{ parameters.arquitecture }} $(Build.BuildNumber) 7z Installer
-  
+      artifactName: Windows ${{ parameters.architecture }} $(Build.BuildNumber) 7z Installer
+
 
     

--- a/azure-pipelines-windows-template.yml
+++ b/azure-pipelines-windows-template.yml
@@ -1,7 +1,7 @@
 parameters:
   name: Windows_x64
   architecture: 'x64'
-  qt_version: '5.12.4'
+  qt_version: '5.12.6'
   qt_spec: 'msvc2017_64'
   qt_aqt_spec: 'win64_msvc2017_64'
   vc_redist_url: 'https://go.microsoft.com/fwlink/?LinkId=746572'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -96,7 +96,7 @@ jobs:
   parameters:
     name: Windows_x64
     architecture: 'x64'
-    qt_version: '5.12.4'
+    qt_version: '5.12.6'
     qt_spec: 'msvc2017_64'
     qt_aqt_spec: 'win64_msvc2017_64'
     vc_redist_url: 'https://go.microsoft.com/fwlink/?LinkId=746572'
@@ -106,7 +106,7 @@ jobs:
   parameters:
     name: Windows_x86
     architecture: 'x86'
-    qt_version: '5.12.4'
+    qt_version: '5.12.6'
     qt_spec: 'msvc2017'
     qt_aqt_spec: 'win32_msvc2017'
     vc_redist_url: 'https://go.microsoft.com/fwlink/?LinkId=746571'
@@ -169,4 +169,3 @@ jobs:
       tagSource: 'manual'
       tag: $(VERSION)
       addChangeLog: false
-

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -95,7 +95,7 @@ jobs:
 - template: azure-pipelines-windows-template.yml
   parameters:
     name: Windows_x64
-    arquitecture: 'x64'
+    architecture: 'x64'
     qt_version: '5.12.4'
     qt_spec: 'msvc2017_64'
     qt_aqt_spec: 'win64_msvc2017_64'
@@ -103,9 +103,9 @@ jobs:
     vc_redist_file_name: 'vc_redist.x64.exe'
     vc_vars: 'vcvars64.bat'
 - template: azure-pipelines-windows-template.yml
-  parameters: 
+  parameters:
     name: Windows_x86
-    arquitecture: 'x86'
+    architecture: 'x86'
     qt_version: '5.12.4'
     qt_spec: 'msvc2017'
     qt_aqt_spec: 'win32_msvc2017'
@@ -113,7 +113,7 @@ jobs:
     vc_redist_file_name: 'vc_redist.x86.exe'
     vc_vars: 'vcvars32.bat'
 - job: PublishDevBuilds
-  dependsOn: 
+  dependsOn:
   - Linux
   - MacOS
   - Windows_x86
@@ -140,7 +140,7 @@ jobs:
         remotePath: ''
         url: https://api.bintray.com/content/luisangelsm/YACReader/DevBuilds/$(Build.BuildNumber)/
 - job: Release
-  dependsOn: 
+  dependsOn:
   - Linux
   - MacOS
   - Windows_x86
@@ -170,5 +170,3 @@ jobs:
       tag: $(VERSION)
       addChangeLog: false
 
-      
-      


### PR DESCRIPTION
This PR fixes a few minor issues with our CI system:

- translate stray spanish parameter name "arquitecture" to english "architecture"
- increase Qt version for Windows builds to 5.12.6 (latest LTS version)
- fix Qt install paths for Windows builds - aqtinstall changed its defaults