### PR TITLE
Unbreak build on FreeBSD

### DIFF
--- a/YACReaderLibrary/server_config_dialog.cpp
+++ b/YACReaderLibrary/server_config_dialog.cpp
@@ -38,6 +38,7 @@ bool ipComparator(const QString &ip1, const QString &ip2)
 
 #include <sys/types.h>
 #include <ifaddrs.h>
+#include <sys/socket.h>
 #include <netinet/in.h>
 #include <string.h>
 #include <arpa/inet.h>


### PR DESCRIPTION
`AF_INET` is in `<sys/socket.h>` [according to](https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_socket.h.html) POSIX.