### PR TITLE
Fix possible memleaks in console library creator

### DIFF
--- a/YACReaderLibraryServer/console_ui_library_creator.cpp
+++ b/YACReaderLibraryServer/console_ui_library_creator.cpp
@@ -12,21 +12,21 @@ ConsoleUILibraryCreator::ConsoleUILibraryCreator(QObject *parent)
 
 void ConsoleUILibraryCreator::createLibrary(const QString &name, const QString &path)
 {
-    QEventLoop eventLoop;
-    LibraryCreator *libraryCreator = new LibraryCreator();
-
     QDir pathDir(path);
     if (!pathDir.exists()) {
         std::cout << "Directory not found." << std::endl;
         return;
     }
 
+    QEventLoop eventLoop;
+    LibraryCreator *libraryCreator = new LibraryCreator();
     QString cleanPath = QDir::cleanPath(pathDir.absolutePath());
 
     YACReaderLibraries yacreaderLibraries;
     yacreaderLibraries.load();
     if (yacreaderLibraries.contains(name)) {
         std::cout << "A Library named \"" << name.toUtf8().constData() << "\" already exists in database." << std::endl;
+        delete libraryCreator;
         return;
     }
 
@@ -49,14 +49,14 @@ void ConsoleUILibraryCreator::createLibrary(const QString &name, const QString &
 
 void ConsoleUILibraryCreator::updateLibrary(const QString &path)
 {
-    QEventLoop eventLoop;
-    LibraryCreator *libraryCreator = new LibraryCreator();
-
     QDir pathDir(path);
     if (!pathDir.exists()) {
         std::cout << "Directory not found." << std::endl;
         return;
     }
+
+    QEventLoop eventLoop;
+    LibraryCreator *libraryCreator = new LibraryCreator();
     QString cleanPath = QDir::cleanPath(pathDir.absolutePath());
 
     libraryCreator->updateLibrary(cleanPath, QDir::cleanPath(pathDir.absolutePath() + "/.yacreaderlibrary"));


### PR DESCRIPTION
When passing a nonexistent path to the console library creator or updator, the create and update functions exit without cleaning up all ressources. This patch fixes that behavior.