### PR TITLE
Fix object leaks in database code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Version counting is based on semantic versioning (Major.Feature.Patch)
 
 ### YACReaderLibrary
 * update QsLog logger to version 2.1, snapshot 46b643d5bcbc
+* fix object leaks in database code
 
 ## 9.6.0
 ### Reader and Library

--- a/YACReaderLibrary/comic_vine/comic_vine_dialog.cpp
+++ b/YACReaderLibrary/comic_vine/comic_vine_dialog.cpp
@@ -431,16 +431,18 @@ void ComicVineDialog::getComicsInfo(QList<QPair<ComicDB, QString>> &matchingInfo
 
         setLoadingMessage(tr("Retrieving tags for : %1").arg(p.first.getFileName()));
     }
-
-    QSqlDatabase db = DataBaseManagement::loadDatabase(databasePath);
-    db.open();
-    db.transaction();
-    foreach (ComicDB comic, comics) {
-        DBHelper::update(&(comic.info), db);
+    QString connectionName = "";
+    {
+        QSqlDatabase db = DataBaseManagement::loadDatabase(databasePath);
+        db.open();
+        db.transaction();
+        foreach (ComicDB comic, comics) {
+            DBHelper::update(&(comic.info), db);
+        }
+        db.commit();
+        connectionName = db.connectionName();
     }
-    db.commit();
-    db.close();
-    QSqlDatabase::removeDatabase(db.connectionName());
+    QSqlDatabase::removeDatabase(connectionName);
 
     emit accepted();
 }
@@ -464,16 +466,18 @@ void ComicVineDialog::getComicInfo(const QString &comicId, int count, const QStr
     ComicDB comic = parseComicInfo(comics[currentIndex], result, count, publisher); //TODO check result error
     comic.info.comicVineID = comicId;
     setLoadingMessage(tr("Retrieving tags for : %1").arg(comics[currentIndex].getFileName()));
+    QString connectionName = "";
+    {
+        QSqlDatabase db = DataBaseManagement::loadDatabase(databasePath);
+        db.open();
+        db.transaction();
 
-    QSqlDatabase db = DataBaseManagement::loadDatabase(databasePath);
-    db.open();
-    db.transaction();
+        DBHelper::update(&(comic.info), db);
 
-    DBHelper::update(&(comic.info), db);
-
-    db.commit();
-    db.close();
-    QSqlDatabase::removeDatabase(db.connectionName());
+        db.commit();
+        connectionName = db.connectionName();
+    }
+    QSqlDatabase::removeDatabase(connectionName);
 
     if (mode == SingleComic || currentIndex == (comics.count() - 1)) {
         emit accepted();

--- a/YACReaderLibrary/db/comic_model.cpp
+++ b/YACReaderLibrary/db/comic_model.cpp
@@ -152,23 +152,25 @@ bool ComicModel::dropMimeData(const QMimeData *data, Qt::DropAction action, int 
     foreach (ComicItem *item, _data) {
         allComicIds << item->data(Id).toULongLong();
     }
-
-    QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
-    switch (mode) {
-    case Favorites:
-        DBHelper::reasignOrderToComicsInFavorites(allComicIds, db);
-        break;
-    case Label:
-        DBHelper::reasignOrderToComicsInLabel(sourceId, allComicIds, db);
-        break;
-    case ReadingList:
-        DBHelper::reasignOrderToComicsInReadingList(sourceId, allComicIds, db);
-        break;
-    default:
-        break;
+    QString connectionName = "";
+    {
+        QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
+        switch (mode) {
+        case Favorites:
+            DBHelper::reasignOrderToComicsInFavorites(allComicIds, db);
+            break;
+        case Label:
+            DBHelper::reasignOrderToComicsInLabel(sourceId, allComicIds, db);
+            break;
+        case ReadingList:
+            DBHelper::reasignOrderToComicsInReadingList(sourceId, allComicIds, db);
+            break;
+        default:
+            break;
+        }
+        connectionName = db.connectionName();
     }
-
-    QSqlDatabase::removeDatabase(db.connectionName());
+    QSqlDatabase::removeDatabase(connectionName);
 
     //endMoveRows();
 
@@ -441,8 +443,9 @@ void ComicModel::setupFolderModelData(unsigned long long int folderId, const QSt
     _data.clear();
 
     _databasePath = databasePath;
-    QSqlDatabase db = DataBaseManagement::loadDatabase(databasePath);
+    QString connectionName = "";
     {
+        QSqlDatabase db = DataBaseManagement::loadDatabase(databasePath);
         QSqlQuery selectQuery(db);
         selectQuery.prepare("SELECT ci.number,ci.title,c.fileName,ci.numPages,c.id,c.parentId,c.path,ci.hash,ci.read,ci.isBis,ci.currentPage,ci.rating,ci.hasBeenOpened "
                             "FROM comic c INNER JOIN comic_info ci ON (c.comicInfoId = ci.id) "
@@ -450,13 +453,10 @@ void ComicModel::setupFolderModelData(unsigned long long int folderId, const QSt
         selectQuery.bindValue(":parentId", folderId);
         selectQuery.exec();
         setupModelData(selectQuery);
+        connectionName = db.connectionName();
     }
-    db.close();
-    QSqlDatabase::removeDatabase(db.connectionName());
+    QSqlDatabase::removeDatabase(connectionName);
     endResetModel();
-
-    /*if(_data.length()==0)
-        emit isEmpty();*/
 }
 
 void ComicModel::setupLabelModelData(unsigned long long parentLabel, const QString &databasePath)
@@ -470,8 +470,9 @@ void ComicModel::setupLabelModelData(unsigned long long parentLabel, const QStri
     _data.clear();
 
     _databasePath = databasePath;
-    QSqlDatabase db = DataBaseManagement::loadDatabase(databasePath);
+    QString connectionName = "";
     {
+        QSqlDatabase db = DataBaseManagement::loadDatabase(databasePath);
         QSqlQuery selectQuery(db);
         selectQuery.prepare("SELECT ci.number,ci.title,c.fileName,ci.numPages,c.id,c.parentId,c.path,ci.hash,ci.read,ci.isBis,ci.currentPage,ci.rating,ci.hasBeenOpened "
                             "FROM comic c INNER JOIN comic_info ci ON (c.comicInfoId = ci.id) "
@@ -481,13 +482,10 @@ void ComicModel::setupLabelModelData(unsigned long long parentLabel, const QStri
         selectQuery.bindValue(":parentLabelId", parentLabel);
         selectQuery.exec();
         setupModelDataForList(selectQuery);
+        connectionName = db.connectionName();
     }
-    db.close();
-    QSqlDatabase::removeDatabase(db.connectionName());
+    QSqlDatabase::removeDatabase(connectionName);
     endResetModel();
-
-    /*if(_data.length()==0)
-        emit isEmpty();*/
 }
 
 void ComicModel::setupReadingListModelData(unsigned long long parentReadingList, const QString &databasePath)
@@ -500,8 +498,9 @@ void ComicModel::setupReadingListModelData(unsigned long long parentReadingList,
     _data.clear();
 
     _databasePath = databasePath;
-    QSqlDatabase db = DataBaseManagement::loadDatabase(databasePath);
+    QString connectionName = "";
     {
+        QSqlDatabase db = DataBaseManagement::loadDatabase(databasePath);
         QList<qulonglong> ids;
         ids << parentReadingList;
 
@@ -535,9 +534,9 @@ void ComicModel::setupReadingListModelData(unsigned long long parentReadingList,
 
             _data = tempData << _data;
         }
+        connectionName = db.connectionName();
     }
-    db.close();
-    QSqlDatabase::removeDatabase(db.connectionName());
+    QSqlDatabase::removeDatabase(connectionName);
     endResetModel();
 }
 
@@ -551,8 +550,9 @@ void ComicModel::setupFavoritesModelData(const QString &databasePath)
     _data.clear();
 
     _databasePath = databasePath;
-    QSqlDatabase db = DataBaseManagement::loadDatabase(databasePath);
+    QString connectionName = "";
     {
+        QSqlDatabase db = DataBaseManagement::loadDatabase(databasePath);
         QSqlQuery selectQuery(db);
         selectQuery.prepare("SELECT ci.number,ci.title,c.fileName,ci.numPages,c.id,c.parentId,c.path,ci.hash,ci.read,ci.isBis,ci.currentPage,ci.rating,ci.hasBeenOpened "
                             "FROM comic c INNER JOIN comic_info ci ON (c.comicInfoId = ci.id) "
@@ -562,13 +562,10 @@ void ComicModel::setupFavoritesModelData(const QString &databasePath)
         selectQuery.bindValue(":parentDefaultListId", 1);
         selectQuery.exec();
         setupModelDataForList(selectQuery);
+        connectionName = db.connectionName();
     }
-    db.close();
-    QSqlDatabase::removeDatabase(db.connectionName());
+    QSqlDatabase::removeDatabase(connectionName);
     endResetModel();
-
-    /*if(_data.length()==0)
-        emit isEmpty();*/
 }
 
 void ComicModel::setupReadingModelData(const QString &databasePath)
@@ -581,8 +578,9 @@ void ComicModel::setupReadingModelData(const QString &databasePath)
     _data.clear();
 
     _databasePath = databasePath;
-    QSqlDatabase db = DataBaseManagement::loadDatabase(databasePath);
+    QString connectionName = "";
     {
+        QSqlDatabase db = DataBaseManagement::loadDatabase(databasePath);
         QSqlQuery selectQuery(db);
         selectQuery.prepare("SELECT ci.number,ci.title,c.fileName,ci.numPages,c.id,c.parentId,c.path,ci.hash,ci.read,ci.isBis,ci.currentPage,ci.rating,ci.hasBeenOpened "
                             "FROM comic c INNER JOIN comic_info ci ON (c.comicInfoId = ci.id) "
@@ -591,32 +589,22 @@ void ComicModel::setupReadingModelData(const QString &databasePath)
         selectQuery.exec();
 
         setupModelDataForList(selectQuery);
+        connectionName = db.connectionName();
     }
-    db.close();
-    QSqlDatabase::removeDatabase(db.connectionName());
+    QSqlDatabase::removeDatabase(connectionName);
     endResetModel();
-
-    /*if(_data.length()==0)
-        emit isEmpty();*/
 }
 
 void ComicModel::setupModelData(const SearchModifiers modifier, const QString &filter, const QString &databasePath)
 {
-    //QFile f(QCoreApplication::applicationDirPath()+"/performance.txt");
-    //f.open(QIODevice::Append);
     beginResetModel();
-    //QElapsedTimer timer;
-    //timer.start();
     qDeleteAll(_data);
     _data.clear();
-
-    //QTextStream txtS(&f);
-    //txtS << "TABLEMODEL: Tiempo de borrado: " << timer.elapsed() << "ms\r\n";
     _databasePath = databasePath;
-    QSqlDatabase db = DataBaseManagement::loadDatabase(databasePath);
+    QString connectionName = "";
+
     {
-        //crear la consulta
-        //timer.restart();
+        QSqlDatabase db = DataBaseManagement::loadDatabase(databasePath);
         QSqlQuery selectQuery(db);
 
         switch (modifier) {
@@ -653,14 +641,10 @@ void ComicModel::setupModelData(const SearchModifiers modifier, const QString &f
 
         QLOG_DEBUG() << selectQuery.lastError() << "--";
 
-        //txtS << "TABLEMODEL: Tiempo de consulta: " << timer.elapsed() << "ms\r\n";
-        //timer.restart();
         setupModelData(selectQuery);
-        //txtS << "TABLEMODEL: Tiempo de creaciï¿½n del modelo: " << timer.elapsed() << "ms\r\n";
-        //selectQuery.finish();
+        connectionName = db.connectionName();
     }
-    db.close();
-    QSqlDatabase::removeDatabase(db.connectionName());
+    QSqlDatabase::removeDatabase(connectionName);
     endResetModel();
 
     emit searchNumResults(_data.length());
@@ -715,20 +699,28 @@ void ComicModel::setupModelDataForList(QSqlQuery &sqlquery)
 
 ComicDB ComicModel::getComic(const QModelIndex &mi)
 {
-    QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
-    ComicDB c = DBHelper::loadComic(_data.at(mi.row())->data(ComicModel::Id).toULongLong(), db);
-    db.close();
-    QSqlDatabase::removeDatabase(db.connectionName());
+    ComicDB c;
+    QString connectionName = "";
+    {
+        QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
+        c = DBHelper::loadComic(_data.at(mi.row())->data(ComicModel::Id).toULongLong(), db);
+        connectionName = db.connectionName();
+    }
+    QSqlDatabase::removeDatabase(connectionName);
 
     return c;
 }
 
 ComicDB ComicModel::_getComic(const QModelIndex &mi)
 {
-    QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
-    ComicDB c = DBHelper::loadComic(_data.at(mi.row())->data(ComicModel::Id).toULongLong(), db);
-    db.close();
-    QSqlDatabase::removeDatabase(db.connectionName());
+    ComicDB c;
+    QString connectionName = "";
+    {
+        QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
+        c = DBHelper::loadComic(_data.at(mi.row())->data(ComicModel::Id).toULongLong(), db);
+        connectionName = db.connectionName();
+    }
+    QSqlDatabase::removeDatabase(connectionName);
 
     return c;
 }
@@ -757,18 +749,21 @@ QVector<YACReaderComicReadStatus> ComicModel::setAllComicsRead(YACReaderComicRea
 
 QList<ComicDB> ComicModel::getAllComics()
 {
-    QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
-    db.transaction();
-
     QList<ComicDB> comics;
-    int numComics = _data.count();
-    for (int i = 0; i < numComics; i++) {
-        comics.append(DBHelper::loadComic(_data.value(i)->data(ComicModel::Id).toULongLong(), db));
-    }
+    QString connectionName = "";
+    {
+        QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
+        db.transaction();
 
-    db.commit();
-    db.close();
-    QSqlDatabase::removeDatabase(db.connectionName());
+        int numComics = _data.count();
+        for (int i = 0; i < numComics; i++) {
+            comics.append(DBHelper::loadComic(_data.value(i)->data(ComicModel::Id).toULongLong(), db));
+        }
+
+        db.commit();
+        connectionName = db.connectionName();
+    }
+    QSqlDatabase::removeDatabase(connectionName);
 
     return comics;
 }
@@ -776,44 +771,40 @@ QList<ComicDB> ComicModel::getAllComics()
 QList<ComicDB> ComicModel::getComics(QList<QModelIndex> list)
 {
     QList<ComicDB> comics;
-
-    QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
-    db.transaction();
-    QList<QModelIndex>::const_iterator itr;
-    for (itr = list.constBegin(); itr != list.constEnd(); itr++) {
+    for (auto itr = list.constBegin(); itr != list.constEnd(); itr++) {
         comics.append(_getComic(*itr));
     }
-    db.commit();
-    db.close();
-    QSqlDatabase::removeDatabase(db.connectionName());
     return comics;
 }
 //TODO
 QVector<YACReaderComicReadStatus> ComicModel::setComicsRead(QList<QModelIndex> list, YACReaderComicReadStatus read)
 {
-    QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
-    db.transaction();
-    foreach (QModelIndex mi, list) {
-        if (read == YACReader::Read) {
-            _data.value(mi.row())->setData(ComicModel::ReadColumn, QVariant(true));
-            ComicDB c = DBHelper::loadComic(_data.value(mi.row())->data(ComicModel::Id).toULongLong(), db);
-            c.info.read = true;
-            DBHelper::update(&(c.info), db);
+    QString connectionName = "";
+    {
+        QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
+        db.transaction();
+        foreach (QModelIndex mi, list) {
+            if (read == YACReader::Read) {
+                _data.value(mi.row())->setData(ComicModel::ReadColumn, QVariant(true));
+                ComicDB c = DBHelper::loadComic(_data.value(mi.row())->data(ComicModel::Id).toULongLong(), db);
+                c.info.read = true;
+                DBHelper::update(&(c.info), db);
+            }
+            if (read == YACReader::Unread) {
+                _data.value(mi.row())->setData(ComicModel::ReadColumn, QVariant(false));
+                _data.value(mi.row())->setData(ComicModel::CurrentPage, QVariant(1));
+                _data.value(mi.row())->setData(ComicModel::HasBeenOpened, QVariant(false));
+                ComicDB c = DBHelper::loadComic(_data.value(mi.row())->data(ComicModel::Id).toULongLong(), db);
+                c.info.read = false;
+                c.info.currentPage = 1;
+                c.info.hasBeenOpened = false;
+                DBHelper::update(&(c.info), db);
+            }
         }
-        if (read == YACReader::Unread) {
-            _data.value(mi.row())->setData(ComicModel::ReadColumn, QVariant(false));
-            _data.value(mi.row())->setData(ComicModel::CurrentPage, QVariant(1));
-            _data.value(mi.row())->setData(ComicModel::HasBeenOpened, QVariant(false));
-            ComicDB c = DBHelper::loadComic(_data.value(mi.row())->data(ComicModel::Id).toULongLong(), db);
-            c.info.read = false;
-            c.info.currentPage = 1;
-            c.info.hasBeenOpened = false;
-            DBHelper::update(&(c.info), db);
-        }
+        db.commit();
+        connectionName = db.connectionName();
     }
-    db.commit();
-    db.close();
-    QSqlDatabase::removeDatabase(db.connectionName());
+    QSqlDatabase::removeDatabase(connectionName);
 
     emit dataChanged(index(list.first().row(), ComicModel::ReadColumn), index(list.last().row(), ComicModel::HasBeenOpened), QVector<int>() << ReadColumnRole << CurrentPageRole << HasBeenOpenedRole);
 
@@ -821,23 +812,25 @@ QVector<YACReaderComicReadStatus> ComicModel::setComicsRead(QList<QModelIndex> l
 }
 qint64 ComicModel::asignNumbers(QList<QModelIndex> list, int startingNumber)
 {
-    QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
-    db.transaction();
-    qint64 idFirst = _data.value(list[0].row())->data(ComicModel::Id).toULongLong();
-    int i = 0;
-    foreach (QModelIndex mi, list) {
-        ComicDB c = DBHelper::loadComic(_data.value(mi.row())->data(ComicModel::Id).toULongLong(), db);
-        c.info.number = startingNumber + i;
-        c.info.edited = true;
-        DBHelper::update(&(c.info), db);
-        i++;
+    qint64 idFirst;
+    QString connectionName = "";
+    {
+        QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
+        db.transaction();
+        idFirst = _data.value(list[0].row())->data(ComicModel::Id).toULongLong();
+        int i = 0;
+        foreach (QModelIndex mi, list) {
+            ComicDB c = DBHelper::loadComic(_data.value(mi.row())->data(ComicModel::Id).toULongLong(), db);
+            c.info.number = startingNumber + i;
+            c.info.edited = true;
+            DBHelper::update(&(c.info), db);
+            i++;
+        }
+        db.commit();
+        connectionName = db.connectionName();
     }
 
-    db.commit();
-    db.close();
-    QSqlDatabase::removeDatabase(db.connectionName());
-
-    //emit dataChanged(index(0,ComicModel::Number),index(_data.count()-1,ComicModel::HasBeenOpened));
+    QSqlDatabase::removeDatabase(connectionName);
 
     return idFirst;
 }
@@ -867,19 +860,22 @@ QList<QModelIndex> ComicModel::getIndexesFromIds(const QList<qulonglong> &comicI
 
 void ComicModel::startTransaction()
 {
-    dbTransaction = DataBaseManagement::loadDatabase(_databasePath);
+    auto dbTransaction = DataBaseManagement::loadDatabase(_databasePath);
+    _databaseConnection = dbTransaction.connectionName();
     dbTransaction.transaction();
 }
 
 void ComicModel::finishTransaction()
 {
-    dbTransaction.commit();
-    dbTransaction.close();
-    QSqlDatabase::removeDatabase(dbTransaction.connectionName());
+    {
+        QSqlDatabase::database(_databaseConnection).commit();
+    }
+    QSqlDatabase::removeDatabase(_databaseConnection);
 }
 
 void ComicModel::removeInTransaction(int row)
 {
+    auto dbTransaction = QSqlDatabase::database(_databaseConnection);
     ComicDB c = DBHelper::loadComic(_data.at(row)->data(ComicModel::Id).toULongLong(), dbTransaction);
 
     DBHelper::removeFromDB(&c, dbTransaction);
@@ -890,27 +886,6 @@ void ComicModel::removeInTransaction(int row)
 
     endRemoveRows();
 }
-/*
-void ComicModel::remove(ComicDB * comic, int row)
-{
-	beginRemoveRows(QModelIndex(),row,row);
-	QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
-
-	DBHelper::removeFromDB(comic,db);
-	
-	removeRow(row);
-	delete _data.at(row);
-	_data.removeAt(row);
-
-	db.close();
-	QSqlDatabase::removeDatabase(db.connectionName());
-	endRemoveRows();
-}
-*/
-/*ComicDB TableModel::getComic(int row)
-{
-	return getComic(index(row,0));
-}*/
 
 void ComicModel::remove(int row)
 {
@@ -938,17 +913,18 @@ void ComicModel::reload(const ComicDB &comic)
 void ComicModel::resetComicRating(const QModelIndex &mi)
 {
     ComicDB comic = getComic(mi);
+    QString connectionName = "";
+    {
+        QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
 
-    QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
+        comic.info.rating = 0;
+        _data[mi.row()]->setData(ComicModel::Rating, 0);
+        DBHelper::update(&(comic.info), db);
 
-    comic.info.rating = 0;
-    _data[mi.row()]->setData(ComicModel::Rating, 0);
-    DBHelper::update(&(comic.info), db);
-
-    emit dataChanged(mi, mi);
-
-    db.close();
-    QSqlDatabase::removeDatabase(db.connectionName());
+        emit dataChanged(mi, mi);
+        connectionName = db.connectionName();
+    }
+    QSqlDatabase::removeDatabase(connectionName);
 }
 
 QUrl ComicModel::getCoverUrlPathForComicHash(const QString &hash) const
@@ -964,13 +940,14 @@ void ComicModel::addComicsToFavorites(const QList<qulonglong> &comicIds)
 void ComicModel::addComicsToFavorites(const QList<QModelIndex> &comicsList)
 {
     QList<ComicDB> comics = getComics(comicsList);
+    QString connectionName = "";
+    {
+        QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
 
-    QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
-
-    DBHelper::insertComicsInFavorites(comics, db);
-
-    db.close();
-    QSqlDatabase::removeDatabase(db.connectionName());
+        DBHelper::insertComicsInFavorites(comics, db);
+        connectionName = db.connectionName();
+    }
+    QSqlDatabase::removeDatabase(connectionName);
 }
 
 void ComicModel::addComicsToLabel(const QList<qulonglong> &comicIds, qulonglong labelId)
@@ -981,13 +958,14 @@ void ComicModel::addComicsToLabel(const QList<qulonglong> &comicIds, qulonglong 
 void ComicModel::addComicsToLabel(const QList<QModelIndex> &comicsList, qulonglong labelId)
 {
     QList<ComicDB> comics = getComics(comicsList);
+    QString connectionName = "";
+    {
+        QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
 
-    QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
-
-    DBHelper::insertComicsInLabel(comics, labelId, db);
-
-    db.close();
-    QSqlDatabase::removeDatabase(db.connectionName());
+        DBHelper::insertComicsInLabel(comics, labelId, db);
+        connectionName = db.connectionName();
+    }
+    QSqlDatabase::removeDatabase(connectionName);
 }
 
 void ComicModel::addComicsToReadingList(const QList<qulonglong> &comicIds, qulonglong readingListId)
@@ -998,25 +976,27 @@ void ComicModel::addComicsToReadingList(const QList<qulonglong> &comicIds, qulon
 void ComicModel::addComicsToReadingList(const QList<QModelIndex> &comicsList, qulonglong readingListId)
 {
     QList<ComicDB> comics = getComics(comicsList);
+    QString connectionName = "";
+    {
+        QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
 
-    QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
-
-    DBHelper::insertComicsInReadingList(comics, readingListId, db);
-
-    db.close();
-    QSqlDatabase::removeDatabase(db.connectionName());
+        DBHelper::insertComicsInReadingList(comics, readingListId, db);
+        connectionName = db.connectionName();
+    }
+    QSqlDatabase::removeDatabase(connectionName);
 }
 
 void ComicModel::deleteComicsFromFavorites(const QList<QModelIndex> &comicsList)
 {
     QList<ComicDB> comics = getComics(comicsList);
+    QString connectionName = "";
+    {
+        QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
 
-    QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
-
-    DBHelper::deleteComicsFromFavorites(comics, db);
-
-    db.close();
-    QSqlDatabase::removeDatabase(db.connectionName());
+        DBHelper::deleteComicsFromFavorites(comics, db);
+        connectionName = db.connectionName();
+    }
+    QSqlDatabase::removeDatabase(connectionName);
 
     if (mode == Favorites)
         deleteComicsFromModel(comicsList);
@@ -1025,13 +1005,14 @@ void ComicModel::deleteComicsFromFavorites(const QList<QModelIndex> &comicsList)
 void ComicModel::deleteComicsFromLabel(const QList<QModelIndex> &comicsList, qulonglong labelId)
 {
     QList<ComicDB> comics = getComics(comicsList);
+    QString connectionName = "";
+    {
+        QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
 
-    QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
-
-    DBHelper::deleteComicsFromLabel(comics, labelId, db);
-
-    db.close();
-    QSqlDatabase::removeDatabase(db.connectionName());
+        DBHelper::deleteComicsFromLabel(comics, labelId, db);
+        connectionName = db.connectionName();
+    }
+    QSqlDatabase::removeDatabase(connectionName);
 
     deleteComicsFromModel(comicsList);
 }
@@ -1039,13 +1020,14 @@ void ComicModel::deleteComicsFromLabel(const QList<QModelIndex> &comicsList, qul
 void ComicModel::deleteComicsFromReadingList(const QList<QModelIndex> &comicsList, qulonglong readingListId)
 {
     QList<ComicDB> comics = getComics(comicsList);
+    QString connectionName = "";
+    {
+        QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
 
-    QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
-
-    DBHelper::deleteComicsFromReadingList(comics, readingListId, db);
-
-    db.close();
-    QSqlDatabase::removeDatabase(db.connectionName());
+        DBHelper::deleteComicsFromReadingList(comics, readingListId, db);
+        connectionName = db.connectionName();
+    }
+    QSqlDatabase::removeDatabase(connectionName);
 
     deleteComicsFromModel(comicsList);
 }
@@ -1068,13 +1050,14 @@ void ComicModel::deleteComicsFromModel(const QList<QModelIndex> &comicsList)
 bool ComicModel::isFavorite(const QModelIndex &index)
 {
     bool isFavorite;
+    QString connectionName = "";
+    {
+        QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
 
-    QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
-
-    isFavorite = DBHelper::isFavoriteComic(_data[index.row()]->data(Id).toLongLong(), db);
-
-    db.close();
-    QSqlDatabase::removeDatabase(db.connectionName());
+        isFavorite = DBHelper::isFavoriteComic(_data[index.row()]->data(Id).toLongLong(), db);
+        connectionName = db.connectionName();
+    }
+    QSqlDatabase::removeDatabase(connectionName);
 
     return isFavorite;
 }
@@ -1082,16 +1065,17 @@ bool ComicModel::isFavorite(const QModelIndex &index)
 void ComicModel::updateRating(int rating, QModelIndex mi)
 {
     ComicDB comic = getComic(mi);
+    QString connectionName = "";
+    {
+        QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
+        //TODO optimize update
 
-    QSqlDatabase db = DataBaseManagement::loadDatabase(_databasePath);
-    //TODO optimize update
+        comic.info.rating = rating;
+        _data[mi.row()]->setData(ComicModel::Rating, rating);
+        DBHelper::update(&(comic.info), db);
 
-    comic.info.rating = rating;
-    _data[mi.row()]->setData(ComicModel::Rating, rating);
-    DBHelper::update(&(comic.info), db);
-
-    emit dataChanged(mi, mi);
-
-    db.close();
-    QSqlDatabase::removeDatabase(db.connectionName());
+        emit dataChanged(mi, mi);
+        connectionName = db.connectionName();
+    }
+    QSqlDatabase::removeDatabase(connectionName);
 }

--- a/YACReaderLibrary/db/comic_model.h
+++ b/YACReaderLibrary/db/comic_model.h
@@ -150,8 +150,7 @@ private:
     QList<ComicItem *> _data;
 
     QString _databasePath;
-
-    QSqlDatabase dbTransaction;
+    QString _databaseConnection;
 
     bool enableResorting;
     Mode mode;

--- a/YACReaderLibrary/library_creator.h
+++ b/YACReaderLibrary/library_creator.h
@@ -38,7 +38,7 @@ private:
     QString _target;
     QString _sourceFolder; //used for partial updates
     QStringList _nameFilter;
-    QSqlDatabase _database;
+    QString _databaseConnection;
     QList<Folder> _currentPathFolders; //lista de folders en el orden en el que están siendo explorados, el último es el folder actual
     //recursive method
     void create(QDir currentDirectory);

--- a/YACReaderLibrary/properties_dialog.cpp
+++ b/YACReaderLibrary/properties_dialog.cpp
@@ -552,17 +552,20 @@ void PropertiesDialog::setComics(QList<ComicDB> comics)
 
 void PropertiesDialog::updateComics()
 {
-    QSqlDatabase db = DataBaseManagement::loadDatabase(databasePath);
-    db.open();
-    db.transaction();
-    QList<ComicDB>::iterator itr;
-    for (itr = comics.begin(); itr != comics.end(); itr++) {
-        if (itr->info.edited)
-            DBHelper::update(&(itr->info), db);
+    QString connectionName = "";
+    {
+        QSqlDatabase db = DataBaseManagement::loadDatabase(databasePath);
+        db.open();
+        db.transaction();
+        QList<ComicDB>::iterator itr;
+        for (itr = comics.begin(); itr != comics.end(); itr++) {
+            if (itr->info.edited)
+                DBHelper::update(&(itr->info), db);
+        }
+        db.commit();
+        connectionName = db.connectionName();
     }
-    db.commit();
-    db.close();
-    QSqlDatabase::removeDatabase(databasePath);
+    QSqlDatabase::removeDatabase(connectionName);
 }
 
 void PropertiesDialog::setMultipleCover()


### PR DESCRIPTION
Qt's database and query model requires that both the queries and the database
objects are out of scope before a database connection can safely be removed.

Solution: Properly encapsulate databases and queries in "{ }" and use a string
to cache the connection name for out-of-scope removal.