### PR TITLE
Headless server: Add support for setting a port from commandline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ Version counting is based on semantic versioning (Major.Feature.Patch)
 * fix object leaks in database code
 * add bidirectional sync support
 
+### YACReaderLibraryServer
+* add support for port setting from the commandline
+
 ## 9.6.0
 ### Reader and Library
 * RAR5 support.

--- a/YACReaderLibrary/server/startup.cpp
+++ b/YACReaderLibrary/server/startup.cpp
@@ -32,33 +32,11 @@ using stefanfrings::HttpSessionStore;
 using stefanfrings::StaticFileController;
 using stefanfrings::TemplateCache;
 
-void Startup::start()
+void Startup::start(quint16 port)
 {
     // Initialize the core application
     QCoreApplication *app = QCoreApplication::instance();
     QString configFileName = YACReader::getSettingsPath() + "/" + QCoreApplication::applicationName() + ".ini";
-
-    /*
-	// Configure logging into files
-	QSettings* mainLogSettings=new QSettings(configFileName,QSettings::IniFormat,app);
-	mainLogSettings->beginGroup("mainLogFile");
-    //QSettings* debugLogSettings=new QSettings(configFileName,QSettings::IniFormat,app);
-    //debugLogSettings->beginGroup("debugLogFile");
-
-    if(mainLogSettings->value("fileName").isNull())
-        mainLogSettings->setValue("fileName", QFileInfo(YACReader::getSettingsPath(), "server_log.log").absoluteFilePath());
-
-    if(mainLogSettings->value("maxSize").isNull())
-        mainLogSettings->setValue("maxSize",1048576);
-
-    if(mainLogSettings->value("maxBackups").isNull())
-        mainLogSettings->setValue("maxBackups",1);
-
-    if(mainLogSettings->value("minLevel").isNull())
-        mainLogSettings->setValue("minLevel",QtCriticalMsg);
-
-    Logger* logger=new FileLogger(mainLogSettings,10000,app);
-    logger->installMsgHandler();*/
 
     // Configure template loader and cache
     auto templateSettings = new QSettings(configFileName, QSettings::IniFormat, app);
@@ -134,6 +112,12 @@ void Startup::start()
 
     listener = new HttpListener(listenerSettings, new RequestMapper(app), app);
 
+    if (port != 0) {
+        if (listener->isListening()) {
+            listener->close();
+        }
+        listener->QTcpServer::listen(QHostAddress::Any, port);
+    }
     // if the requested port is busy, use random port
     if (!listener->isListening()) {
         listener->QTcpServer::listen(QHostAddress::Any, 0);

--- a/YACReaderLibrary/server/startup.h
+++ b/YACReaderLibrary/server/startup.h
@@ -26,7 +26,7 @@ public:
     /** Constructor */
     Startup();
     /** Start the server */
-    void start();
+    void start(quint16 port = 0);
     /** Stop the server */
     void stop();
 


### PR DESCRIPTION
Manual editing of a config file for setting a port is not ideal.
Solution: add a set-port command to save a port and also a
--port option to allow setting a temporary port during startup