### PR TITLE
Support for third party qt image plugins

### DIFF
--- a/common/comic.cpp
+++ b/common/comic.cpp
@@ -23,6 +23,26 @@ enum YACReaderPageSortingMode {
 
 void comic_pages_sort(QList<QString> &pageNames, YACReaderPageSortingMode sortingMode);
 
+QStringList Comic::getSupportedImageFormats()
+{
+    QList<QByteArray> supportedImageFormats = QImageReader::supportedImageFormats();
+    QStringList supportedImageFormatStrings;
+    for (QByteArray item : supportedImageFormats) {
+        supportedImageFormatStrings.append(QString::fromLocal8Bit("*." + item));
+    }
+    return supportedImageFormatStrings;
+}
+
+QStringList Comic::getSupportedImageLiteralFormats()
+{
+    QList<QByteArray> supportedImageFormats = QImageReader::supportedImageFormats();
+    QStringList supportedImageFormatStrings;
+    for (QByteArray item : supportedImageFormats) {
+        supportedImageFormatStrings.append(QString::fromLocal8Bit(item));
+    }
+    return supportedImageFormatStrings;
+}
+
 const QStringList Comic::imageExtensions = QStringList() << "*.jpg"
                                                          << "*.jpeg"
                                                          << "*.png"

--- a/common/comic.h
+++ b/common/comic.h
@@ -76,8 +76,8 @@ public:
     //check if the comic has failed loading
     bool hasBeenAnErrorOpening();
 
-    inline static QStringList getSupportedImageFormats() { return imageExtensions; }
-    inline static QStringList getSupportedImageLiteralFormats() { return literalImageExtensions; }
+    static QStringList getSupportedImageFormats();
+    static QStringList getSupportedImageLiteralFormats();
 
     static bool fileIsComic(const QString &path);
     static QList<QString> findValidComicFiles(const QList<QUrl> &list);


### PR DESCRIPTION
Hi,
There is a qt plugin for AVIF image format here : https://github.com/novomesk/qt-avif-image-plugin/
We just need to drop **qavif.dll** there : imageformats/qavif.dll
This plugin is build with Microsoft Visual Studio 2019 and Qt **5.14.2** so the qt version must be updated on the azure pipeline.
I updated it from **5.12.6** to **5.15.1** and now it works well with avif images !
May be, you can add this plugin as a dependencies to be bundled with the installer ?
Thanks !
Regards,
Steve
