### PR TITLE
Library: fix InfoComicsView crashes

### DIFF
--- a/YACReaderLibrary/qml/FlowView.qml
+++ b/YACReaderLibrary/qml/FlowView.qml
@@ -97,7 +97,8 @@ Rectangle {
         highlightMoveDuration: 250
 
         onCurrentIndexChanged: {
-            currentCoverChanged(currentIndex);
+            if (currentIndex !== -1)
+                currentCoverChanged(currentIndex);
         }
 
         delegate: Component {


### PR DESCRIPTION
InfoComicsView constructor is the only function that connects to
FlowView's currentCoverChanged signal. Neither of the slots connected to
this signal handles the argument value index==-1. So when FlowView emits
this signal with index==-1, YACReaderLibrary crashes. Returning early
from either ComicsView::updateInfoForIndex() or
InfoComicsView::setCurrentIndex() when index==-1 is not sufficient - the
crash happens in the other slot then. Let us skip emitting the signal in
FlowView if index==-1 rather than return early from both slots.

Steps to reproduce 1:
1. Launch YACReaderLibrary version that matches the version of the
default library database. Alternatively, select a compatible library
after starting the application.
2. If InfoComicsView is not active, switch to it.
3. (optional) Switch to another comics view out of InfoComicsView.
4. Quit YACReaderLibrary. The application crashes during exit - after
the "YACReaderLibrary closed with exit code : 0" message is printed.

Steps to reproduce 2:
1. Launch a YACReaderLibrary version newer than the version of the
default library database.
2. Click the "No" button in the "Update needed" dialog that pops up.
3. Change between comics views until InfoComicsView becomes active. If
this view was active at the beginning, switch through all the views to
get back to it. At this point YACReaderLibrary crashes.