### PR TITLE
Library: don't leak folderQueryResultProcessor at exit

### DIFF
--- a/YACReaderLibrary/library_window.cpp
+++ b/YACReaderLibrary/library_window.cpp
@@ -415,7 +415,7 @@ void LibraryWindow::doModels()
     //folders
     foldersModel = new FolderModel();
     foldersModelProxy = new FolderModelProxy();
-    folderQueryResultProcessor = new FolderQueryResultProcessor(foldersModel);
+    folderQueryResultProcessor.reset(new FolderQueryResultProcessor(foldersModel));
     //foldersModelProxy->setSourceModel(foldersModel);
     //comics
     comicsModel = new ComicModel(this);
@@ -1116,7 +1116,7 @@ void LibraryWindow::createConnections()
     //Search filter
     connect(searchEdit, SIGNAL(filterChanged(YACReader::SearchModifiers, QString)), this, SLOT(setSearchFilter(YACReader::SearchModifiers, QString)));
     connect(&comicQueryResultProcesor, &ComicQueryResultProcesor::newData, this, &LibraryWindow::setComicSearchFilterData);
-    connect(folderQueryResultProcessor, &FolderQueryResultProcessor::newData, this, &LibraryWindow::setFolderSearchFilterData);
+    connect(folderQueryResultProcessor.get(), &FolderQueryResultProcessor::newData, this, &LibraryWindow::setFolderSearchFilterData);
 
     //ContextMenus
     connect(openContainingFolderComicAction, SIGNAL(triggered()), this, SLOT(openContainingFolderComic()));

--- a/YACReaderLibrary/library_window.h
+++ b/YACReaderLibrary/library_window.h
@@ -14,6 +14,7 @@
 #include "folder_query_result_processor.h"
 
 #include <future>
+#include <memory>
 
 #ifdef Q_OS_MAC
 #include "yacreader_macosx_toolbar.h"
@@ -416,7 +417,7 @@ private:
 
     TrayIconController *trayIconController;
     ComicQueryResultProcesor comicQueryResultProcesor;
-    FolderQueryResultProcessor *folderQueryResultProcessor;
+    std::unique_ptr<FolderQueryResultProcessor> folderQueryResultProcessor;
 };
 
 #endif


### PR DESCRIPTION
`FolderQueryResultProcessor` has a `ConcurrentQueue` data member. The leak meant that the thread was not joined before exit.