### PR TITLE
Library: don't print errors when search edit's text changes

### DIFF
--- a/YACReaderLibrary/db/comic_model.cpp
+++ b/YACReaderLibrary/db/comic_model.cpp
@@ -606,8 +606,6 @@ void ComicModel::setModelData(QList<ComicItem *> *data, const QString &databaseP
 
     _data.clear();
 
-    QLOG_ERROR() << "-d2>" << data->size();
-
     _data.append(*data);
 
     endResetModel();


### PR DESCRIPTION
This was a temporary debug output. Not useful anymore.