### PR TITLE
index/numPages/numSlides: unsigned => int

### DIFF
--- a/YACReader/goto_dialog.cpp
+++ b/YACReader/goto_dialog.cpp
@@ -68,7 +68,7 @@ void GoToDialog::goTo()
     close();
 }
 
-void GoToDialog::setNumPages(unsigned int numPages)
+void GoToDialog::setNumPages(int numPages)
 {
     numPagesLabel->setText(tr("Total pages : ") + QString::number(numPages));
     v->setTop(numPages);

--- a/YACReader/goto_dialog.h
+++ b/YACReader/goto_dialog.h
@@ -23,7 +23,7 @@ private:
     void setupUI();
 public slots:
     void goTo();
-    void setNumPages(unsigned int numPages);
+    void setNumPages(int numPages);
     void open() override;
 signals:
     void goToPage(unsigned int page);

--- a/YACReader/goto_flow.cpp
+++ b/YACReader/goto_flow.cpp
@@ -96,7 +96,7 @@ void GoToFlow::centerSlide(int slide)
     }
 }
 
-void GoToFlow::setNumSlides(unsigned int slides)
+void GoToFlow::setNumSlides(int slides)
 {
     //	numPagesLabel->setText(tr("Total pages : ")+QString::number(slides));
     //	numPagesLabel->adjustSize();
@@ -120,7 +120,7 @@ void GoToFlow::setNumSlides(unsigned int slides)
     worker->reset();
 
     flow->clear();
-    for (unsigned int i = 0; i < slides; i++)
+    for (int i = 0; i < slides; ++i)
         flow->addSlide(QImage());
     flow->setCenterIndex(0);
 }

--- a/YACReader/goto_flow.h
+++ b/YACReader/goto_flow.h
@@ -58,7 +58,7 @@ private slots:
 public slots:
     void centerSlide(int slide) override;
     void reset() override;
-    void setNumSlides(unsigned int slides) override;
+    void setNumSlides(int slides) override;
     void setImageReady(int index, const QByteArray &image) override;
     void setFlowType(FlowType flowType) override;
     void updateConfig(QSettings *settings) override;

--- a/YACReader/goto_flow_gl.cpp
+++ b/YACReader/goto_flow_gl.cpp
@@ -64,7 +64,7 @@ void GoToFlowGL::setFlowType(FlowType flowType)
         flow->setPreset(defaultYACReaderFlowConfig);
 }
 
-void GoToFlowGL::setNumSlides(unsigned int slides)
+void GoToFlowGL::setNumSlides(int slides)
 {
     flow->populate(slides);
     toolBar->setTop(slides);

--- a/YACReader/goto_flow_gl.h
+++ b/YACReader/goto_flow_gl.h
@@ -21,7 +21,7 @@ public:
     void reset() override;
     void centerSlide(int slide) override;
     void setFlowType(FlowType flowType) override;
-    void setNumSlides(unsigned int slides) override;
+    void setNumSlides(int slides) override;
     void setImageReady(int index, const QByteArray &image) override;
 
     void updateConfig(QSettings *settings);

--- a/YACReader/goto_flow_widget.h
+++ b/YACReader/goto_flow_widget.h
@@ -26,7 +26,7 @@ public slots:
     virtual void centerSlide(int slide) = 0;
     virtual void setPageNumber(int page);
     virtual void setFlowType(FlowType flowType) = 0;
-    virtual void setNumSlides(unsigned int slides) = 0;
+    virtual void setNumSlides(int slides) = 0;
     virtual void setImageReady(int index, const QByteArray &image) = 0;
     virtual void updateSize();
     virtual void updateConfig(QSettings *settings);

--- a/YACReader/render.cpp
+++ b/YACReader/render.cpp
@@ -633,7 +633,7 @@ void Render::prepareAvailablePage(int page)
         }
     } else {
         //check for last page in double page mode
-        if ((currentIndex == page) && (currentIndex + 1) >= (int)comic->numPages()) {
+        if (currentIndex == page && currentIndex + 1 >= comic->numPages()) {
             emit currentPageReady();
         } else if ((currentIndex == page && !buffer[currentPageBufferedIndex + 1]->isNull()) ||
                    (currentIndex + 1 == page && !buffer[currentPageBufferedIndex]->isNull())) {
@@ -718,8 +718,8 @@ void Render::createComic(const QString &path)
     connect(comic, SIGNAL(imageLoaded(int)), this, SLOT(pageRawDataReady(int)), Qt::QueuedConnection);
     connect(comic, SIGNAL(imageLoaded(int)), this, SIGNAL(imageLoaded(int)), Qt::QueuedConnection);
     connect(comic, SIGNAL(openAt(int)), this, SLOT(renderAt(int)), Qt::QueuedConnection);
-    connect(comic, SIGNAL(numPages(unsigned int)), this, SIGNAL(numPages(unsigned int)), Qt::QueuedConnection);
-    connect(comic, SIGNAL(numPages(unsigned int)), this, SLOT(setNumPages(unsigned int)), Qt::QueuedConnection);
+    connect(comic, &Comic::numPagesChanged, this, &Render::numPagesChanged, Qt::QueuedConnection);
+    connect(comic, &Comic::numPagesChanged, this, &Render::setNumPages, Qt::QueuedConnection);
     connect(comic, SIGNAL(imageLoaded(int, QByteArray)), this, SIGNAL(imageLoaded(int, QByteArray)), Qt::QueuedConnection);
     connect(comic, SIGNAL(isBookmark(bool)), this, SIGNAL(currentPageIsBookmark(bool)), Qt::QueuedConnection);
 
@@ -786,14 +786,14 @@ void Render::nextPage()
         currentIndex = nextPage;
         update();
         emit pageChanged(currentIndex);
-    } else if (hasLoadedComic() && ((unsigned int)currentIndex == numPages() - 1)) {
+    } else if (hasLoadedComic() && currentIndex == numPages() - 1) {
         emit isLast();
     }
 }
 void Render::nextDoublePage()
 {
     int nextPage;
-    if (currentIndex + 2 < (int)comic->numPages()) {
+    if (currentIndex + 2 < comic->numPages()) {
         nextPage = currentIndex + 2;
     } else {
         nextPage = currentIndex;
@@ -804,7 +804,7 @@ void Render::nextDoublePage()
         currentIndex = nextPage;
         update();
         emit pageChanged(currentIndex);
-    } else if (hasLoadedComic() && ((unsigned int)currentIndex >= numPages() - 2)) {
+    } else if (hasLoadedComic() && currentIndex >= numPages() - 2) {
         emit isLast();
     }
 }
@@ -840,11 +840,11 @@ void Render::previousDoublePage()
     }
 }
 
-unsigned int Render::getIndex()
+int Render::getIndex() const
 {
     return comic->getIndex();
 }
-unsigned int Render::numPages()
+int Render::numPages() const
 {
     return comic->numPages();
 }
@@ -856,7 +856,7 @@ bool Render::hasLoadedComic()
     return false;
 }
 
-void Render::setNumPages(unsigned int numPages)
+void Render::setNumPages(int numPages)
 {
     pagesReady.fill(false, numPages);
 }
@@ -977,7 +977,7 @@ void Render::fillBuffer()
     }
 
     for (int i = 1; i <= qMax(numLeftPages, numRightPages); i++) {
-        if ((currentIndex + i < (int)comic->numPages()) &&
+        if (currentIndex + i < comic->numPages() &&
             buffer[currentPageBufferedIndex + i]->isNull() &&
             i <= numRightPages &&
             pageRenders[currentPageBufferedIndex + i] == 0 &&
@@ -1049,7 +1049,7 @@ void Render::doubleMangaPageSwitch()
 QString Render::getCurrentPagesInformation()
 {
     QString s = QString::number(currentIndex + 1);
-    if (doublePage && (currentIndex + 1 < (int)comic->numPages())) {
+    if (doublePage && currentIndex + 1 < comic->numPages()) {
         if (currentPageIsDoublePage()) {
             if (doubleMangaPage)
                 s = QString::number(currentIndex + 2) + "-" + s;

--- a/YACReader/render.h
+++ b/YACReader/render.h
@@ -134,6 +134,9 @@ public:
     Render();
     ~Render() override;
 
+    int getIndex() const;
+    int numPages() const;
+
 public slots:
     void render();
     QPixmap *getCurrentPage();
@@ -150,7 +153,7 @@ public slots:
     void setComic(Comic *c);
     void prepareAvailablePage(int page);
     void update();
-    void setNumPages(unsigned int numPages);
+    void setNumPages(int numPages);
     void pageRawDataReady(int page);
     //--comic interface
     void nextPage();
@@ -165,8 +168,6 @@ public slots:
     void startLoad();
     void rotateRight();
     void rotateLeft();
-    unsigned int getIndex();
-    unsigned int numPages();
     bool hasLoadedComic();
     void updateBuffer();
     void fillBuffer();
@@ -189,7 +190,7 @@ signals:
     void imageLoaded(int index);
     void imageLoaded(int index, const QByteArray &image);
     void pageChanged(int index);
-    void numPages(unsigned int numPages);
+    void numPagesChanged(int numPages);
     void errorOpening();
     void errorOpening(QString);
     void crcError(QString);

--- a/YACReader/viewer.cpp
+++ b/YACReader/viewer.cpp
@@ -176,9 +176,8 @@ void Viewer::createConnections()
     connect(render, SIGNAL(errorOpening()), this, SLOT(showMessageErrorOpening()));
     connect(render, SIGNAL(errorOpening(QString)), this, SLOT(showMessageErrorOpening(QString)));
     connect(render, SIGNAL(crcError(QString)), this, SLOT(processCRCError(QString)));
-    connect(render, SIGNAL(numPages(unsigned int)), goToFlow, SLOT(setNumSlides(unsigned int)));
-    connect(render, SIGNAL(numPages(unsigned int)), goToDialog, SLOT(setNumPages(unsigned int)));
-    //connect(render,SIGNAL(numPages(unsigned int)),this,SLOT(updateInformation()));
+    connect(render, &Render::numPagesChanged, goToFlow, &GoToFlowWidget::setNumSlides);
+    connect(render, &Render::numPagesChanged, goToDialog, &GoToDialog::setNumPages);
     connect(render, SIGNAL(imageLoaded(int, QByteArray)), goToFlow, SLOT(setImageReady(int, QByteArray)));
     connect(render, SIGNAL(currentPageReady()), this, SLOT(updatePage()));
     connect(render, SIGNAL(processingPage()), this, SLOT(setLoadingMessage()));
@@ -1129,12 +1128,12 @@ void Viewer::showIsLastMessage()
     shouldOpenPrevious = false; //single page comic
 }
 
-unsigned int Viewer::getIndex()
+int Viewer::getIndex() const
 {
     return render->getIndex() + 1;
 }
 
-int Viewer::getCurrentPageNumber()
+int Viewer::getCurrentPageNumber() const
 {
     return render->getIndex();
 }

--- a/YACReader/viewer.h
+++ b/YACReader/viewer.h
@@ -103,7 +103,6 @@ public slots:
     void updateFilters(int brightness, int contrast, int gamma);
     void showIsCoverMessage();
     void showIsLastMessage();
-    int getCurrentPageNumber();
     void updateZoomRatio(int ratio);
     bool getIsMangaMode();
 
@@ -182,7 +181,8 @@ public:
     //Comic * getComic(){return comic;}
     const BookmarksDialog *getBookmarksDialog() { return bd; }
     //returns the current index starting in 1 [1,nPages]
-    unsigned int getIndex();
+    int getIndex() const;
+    int getCurrentPageNumber() const;
     void updateComic(ComicDB &comic);
 signals:
     void backgroundChanges();

--- a/YACReaderLibrary/server/controllers/v1/pagecontroller.cpp
+++ b/YACReaderLibrary/server/controllers/v1/pagecontroller.cpp
@@ -33,7 +33,7 @@ void PageController::service(HttpRequest &request, HttpResponse &response)
     QStringList pathElements = path.split('/');
     QString libraryName = DBHelper::getLibraryName(pathElements.at(2).toInt());
     qulonglong comicId = pathElements.at(4).toULongLong();
-    unsigned int page = pathElements.at(6).toUInt();
+    const int page = pathElements.at(6).toInt();
 
     //qDebug("lib name : %s",pathElements.at(2).data());
 

--- a/YACReaderLibrary/server/controllers/v2/pagecontroller_v2.cpp
+++ b/YACReaderLibrary/server/controllers/v2/pagecontroller_v2.cpp
@@ -35,7 +35,7 @@ void PageControllerV2::service(HttpRequest &request, HttpResponse &response)
     QStringList pathElements = path.split('/');
     QString libraryName = DBHelper::getLibraryName(pathElements.at(2).toInt());
     qulonglong comicId = pathElements.at(5).toULongLong();
-    unsigned int page = pathElements.at(7).toUInt();
+    const int page = pathElements.at(7).toInt();
 
     Comic *comicFile;
     qulonglong currentComicId;

--- a/common/comic.cpp
+++ b/common/comic.cpp
@@ -165,10 +165,10 @@ int Comic::previousPage()
     return _index;
 }
 //-----------------------------------------------------------------------------
-void Comic::setIndex(unsigned int index)
+void Comic::setIndex(int index)
 {
     int previousIndex = _index;
-    if (static_cast<int>(index) < _pages.size() - 1) {
+    if (index < _pages.size() - 1) {
         _index = index;
     } else {
         _index = _pages.size() - 1;
@@ -587,7 +587,7 @@ void FileComic::process()
     _loadedPages = QVector<bool>(_fileNames.size(), false);
 
     emit pageChanged(0); // this indicates new comic, index=0
-    emit numPages(_pages.size());
+    emit numPagesChanged(_pages.size());
     _loaded = true;
 
     _cfi = 0;
@@ -704,7 +704,7 @@ void FolderComic::process()
         emit(openAt(_index));
 
         emit pageChanged(0); // this indicates new comic, index=0
-        emit numPages(_pages.size());
+        emit numPagesChanged(_pages.size());
         _loaded = true;
 
         int count = 0;
@@ -830,7 +830,7 @@ void PDFComic::process()
 
     int nPages = pdfComic->numPages();
     emit pageChanged(0); // this indicates new comic, index=0
-    emit numPages(nPages);
+    emit numPagesChanged(nPages);
     _loaded = true;
     //QMessageBox::critical(NULL,QString("%1").arg(nPages),tr("Invalid PDF file"));
 

--- a/common/comic.h
+++ b/common/comic.h
@@ -63,9 +63,9 @@ public:
 		void loadFromPDF(const QString & pathPDF);*/
     int nextPage();
     int previousPage();
-    void setIndex(unsigned int index);
-    unsigned int getIndex() { return _index; };
-    unsigned int numPages() { return _pages.size(); }
+    void setIndex(int index);
+    int getIndex() const { return _index; }
+    int numPages() const { return _pages.size(); }
     //QPixmap * currentPage();
     bool loaded();
     //QPixmap * operator[](unsigned int index);
@@ -101,7 +101,7 @@ signals:
     void imageLoaded(int index, const QByteArray &image);
     void pageChanged(int index);
     void openAt(int index);
-    void numPages(unsigned int numPages);
+    void numPagesChanged(int numPages);
     void errorOpening();
     void errorOpening(QString);
     void crcErrorFound(QString);

--- a/common/pdf_comic.cpp
+++ b/common/pdf_comic.cpp
@@ -76,7 +76,7 @@ void PdfiumComic::closeComic()
     FPDF_CloseDocument(doc);
 }
 
-unsigned int PdfiumComic::numPages()
+int PdfiumComic::numPages()
 {
     if (doc) {
         QMutexLocker locker(&pdfmutex);

--- a/common/pdf_comic.h
+++ b/common/pdf_comic.h
@@ -14,7 +14,7 @@ public:
     ~MacOSXPDFComic();
     bool openComic(const QString &path);
     void closeComic();
-    unsigned int numPages();
+    int numPages();
     QImage getPage(const int page);
     //void releaseLastPageData();
 
@@ -33,7 +33,7 @@ public:
     ~PdfiumComic();
     bool openComic(const QString &path);
     void closeComic();
-    unsigned int numPages();
+    int numPages();
     QImage getPage(const int page);
 
 private:

--- a/common/pdf_comic.mm
+++ b/common/pdf_comic.mm
@@ -39,7 +39,7 @@ void MacOSXPDFComic::closeComic()
     //CGPDFDocumentRelease((CGPDFDocumentRef)document);
 }
 
-unsigned int MacOSXPDFComic::numPages()
+int MacOSXPDFComic::numPages()
 {
     return (int)CGPDFDocumentGetNumberOfPages((CGPDFDocumentRef)document);
 }


### PR DESCRIPTION
This change gets rid of a few GCC's *-Wsign-compare* warnings and several explicit casts because of different signedness.

Make several getters const member functions rather than slots.

Rename several signals from `numPages()` to `numPagesChanged()` to simplify using function pointer-based signal-slot connection syntax.