### PR TITLE
GridComicsView: highlight selected and hovered-over covers differently

### DIFF
--- a/YACReaderLibrary/qml/GridComicsView.qml
+++ b/YACReaderLibrary/qml/GridComicsView.qml
@@ -130,7 +130,7 @@ Rectangle {
                         rightMargin  : commonBorder ? -commonBorderWidth : -rBorderwidth
                     }
 
-                    border.color: (Qt.platform.os === "osx") ? selectedBorderColor : "#ffcc00"
+                    border.color: (dummyValue || !dummyValue) && comicsSelectionHelper.isSelectedIndex(index) ? (Qt.platform.os === "osx" ? selectedBorderColor : "#ffcc00") : "#996600"
                     border.width: 3
 
                     opacity: (dummyValue || !dummyValue) && (comicsSelectionHelper.isSelectedIndex(index) || mouseArea.containsMouse) ? 1 : 0


### PR DESCRIPTION
When the selected and the mouse-hovered-over cover have the same border colors, they cannot be distinguished. The difference is important because the selected/current comic is opened when the _Open current comic_ shortcut is activated. The identical highlighting is especially confusing during keyboard navigation.