### PR TITLE
Add CONFIG += silent to build to reduce log pollution

### DIFF
--- a/config.pri
+++ b/config.pri
@@ -15,6 +15,9 @@ lessThan(QT_VER_MIN, 6):!CONFIG(no_opengl) {
   error ("You need at least Qt 5.6 to compile YACReader or YACReaderLibrary.")
   }
 
+# reduce log pollution
+CONFIG += silent
+
 # Disable coverflow for arm targets
 isEmpty(QMAKE_TARGET.arch) {
   QMAKE_TARGET.arch = $$QMAKE_HOST.arch


### PR DESCRIPTION
Qmake by default creates lots of unnecessary information during builds which makes it hard to extract warnings and errors from the log.

This PR adds the undocumented silent parameter to make it less talkactive.