### PR TITLE
Library: update toolbar title on history navigation

### DIFF
--- a/YACReaderLibrary/yacreader_navigation_controller.cpp
+++ b/YACReaderLibrary/yacreader_navigation_controller.cpp
@@ -219,6 +219,7 @@ void YACReaderNavigationController::selectedIndexFromHistory(const YACReaderLibr
     }
 
     loadIndexFromHistory(sourceContainer);
+    libraryWindow->setToolbarTitle(sourceContainer.getSourceModelIndex());
 }
 
 void YACReaderNavigationController::loadIndexFromHistory(const YACReaderLibrarySourceContainer &sourceContainer)
@@ -240,6 +241,7 @@ void YACReaderNavigationController::loadIndexFromHistory(const YACReaderLibraryS
         break;
     }
     case YACReaderLibrarySourceContainer::None:
+        QLOG_ERROR() << "Cannot load a source container of type None";
         break;
     }
 }


### PR DESCRIPTION
When _Back_ or _Forward_ action was triggered, the toolbar title was not updated to match the reselected entry.

I am calling `LibraryWindow::setToolbarTitle()` from `selectedIndexFromHistory()` rather than `loadIndexFromHistory()`, because the latter is also called from `YACReaderNavigationController::loadPreviousStatus()`, which in turn is called only from `LibraryWindow::setSearchFilter()` when the search line text becomes empty. The toolbar title is already correct and does not have to be updated in this case.

My code analysis and experiments have revealed that YACReader code never creates `YACReaderLibrarySourceContainer` objects of type `None`. This type could be removed altogether along with `YACReaderLibrarySourceContainer`'s
default constructor, but for `Q_DECLARE_METATYPE` macro's requirement. So `YACReaderNavigationController::loadIndexFromHistory()` now simply prints an error message instead of introducing a failure condition by returning false when the type is `None`.