### PR TITLE
Render: Protect against race condition in setNumPages

### DIFF
--- a/YACReader/render.cpp
+++ b/YACReader/render.cpp
@@ -858,6 +858,9 @@ bool Render::hasLoadedComic()
 
 void Render::setNumPages(unsigned int numPages)
 {
+    if (sender() != comic) {
+        return;
+    }
     pagesReady.fill(false, numPages);
 }
 

--- a/YACReader/render.cpp
+++ b/YACReader/render.cpp
@@ -695,13 +695,12 @@ void Render::createComic(const QString &path)
     pagesEmited.clear();
 
     if (comic != nullptr) {
-        //comic->moveToThread(QApplication::instance()->thread());
         comic->invalidate();
-
         comic->disconnect();
+        // Dispatch pending events to guard against race conditons
+        QCoreApplication::sendPostedEvents(this);
         comic->deleteLater();
     }
-    //comic->moveToThread(QApplication::instance()->thread());
     comic = FactoryComic::newComic(path);
 
     if (comic == nullptr) //archivo no encontrado o no válido
@@ -858,9 +857,6 @@ bool Render::hasLoadedComic()
 
 void Render::setNumPages(unsigned int numPages)
 {
-    if (sender() != comic) {
-        return;
-    }
     pagesReady.fill(false, numPages);
 }
 


### PR DESCRIPTION
Switching comics too fast in YACReader can lead to an accumulation of comic threads which are in different stages of parsing, processing and ultimatively cleanup. While these threads and the comic objects are usually disconnected from the render when spawning a new thread, the nature of Qt's queued connection and thread scheduling by the operating system leads to the situation that the disconnection and thread cleanup does not take effect immediately.

As thread disconnection and cleanup is not reliable, race conditions occur.

This PR protects against a race condition where the number of pages the render tries to prepare is set via a signal from the comic object. If this value is set by a stray comic thread while loading a comic, the false value in combination with a bookmarked page index (also from the stray comic) can lead to the render code trying to access a nonexistent page, which leads to a segfault.

Less obvious symptoms which do not lead to crashing can be loading a comic with the wrong total pagecount (navigation problem) and all sort of undefined behavior.

One quick and very dirty way to protect against this is checking if the sender matches the current comic object. Note that while this fixes #211 it is not a fix for the underlying thread problems nor does it take care of all possible symptoms. It does not remove the race condition, it just prevents it from wreaking havoc.