### PR TITLE
Enable/disable comics actions after updating search results

### DIFF
--- a/YACReaderLibrary/library_window.cpp
+++ b/YACReaderLibrary/library_window.cpp
@@ -2165,10 +2165,13 @@ void LibraryWindow::setComicSearchFilterData(QList<ComicItem *> *data, const QSt
     comicsViewsManager->comicsView->enableFilterMode(true);
     comicsViewsManager->comicsView->setModel(comicsModel); //TODO, columns are messed up after ResetModel some times, this shouldn't be necesary
 
-    if (comicsModel->rowCount() == 0)
+    if (comicsModel->rowCount() == 0) {
         comicsViewsManager->showNoSearchResultsView();
-    else
+        disableComicsActions(true);
+    } else {
         comicsViewsManager->showComicsView();
+        disableComicsActions(false);
+    }
 }
 
 void LibraryWindow::setFolderSearchFilterData(QMap<unsigned long long, FolderItem *> *filteredItems, FolderItem *root)


### PR DESCRIPTION
Before this commit starting a search when an empty folder or an empty reading list was selected left all comics actions disabled. Fixes #213.

When search mode is exited, we always call either `YACReaderNavigationController::loadFolderInfo()` or `YACReaderNavigationController::loadListInfo()`. Both of them call `LibraryWindow::disableComicsActions()`, so the enabled/disabled state of the comics actions stays up-to-date at all times.