### PR TITLE
fix: Replace QtScript with QJson*

### DIFF
--- a/YACReaderLibrary/YACReaderLibrary.pro
+++ b/YACReaderLibrary/YACReaderLibrary.pro
@@ -69,7 +69,7 @@ macx {
 
 #CONFIG += release
 CONFIG -= flat
-QT += sql network widgets script svg
+QT += sql network widgets svg
 !CONFIG(no_opengl) {
   QT += opengl
 }
@@ -231,8 +231,8 @@ SOURCES += comic_flow.cpp \
 }
 
 macx {
-	HEADERS += trayhandler.h
-	OBJECTIVE_SOURCES += trayhandler.mm
+   HEADERS += trayhandler.h
+   OBJECTIVE_SOURCES += trayhandler.mm
 }
 
 include(./server/server.pri)

--- a/YACReaderLibrary/comic_vine/comic_vine_all_volume_comics_retriever.cpp
+++ b/YACReaderLibrary/comic_vine/comic_vine_all_volume_comics_retriever.cpp
@@ -3,7 +3,9 @@
 #include "http_worker.h"
 #include "response_parser.h"
 
-#include <QtScript>
+#include <QJsonArray>
+#include <QJsonDocument>
+#include <QJsonObject>
 
 ComicVineAllVolumeComicsRetriever::ComicVineAllVolumeComicsRetriever(const QString &volumeURLString, QObject *parent)
     : QObject(parent), volumeURLString(volumeURLString)

--- a/YACReaderLibrary/comic_vine/comic_vine_dialog.h
+++ b/YACReaderLibrary/comic_vine/comic_vine_dialog.h
@@ -18,7 +18,6 @@ class SearchVolume;
 class SelectComic;
 class SelectVolume;
 class SortVolumeComics;
-class QScriptValue;
 
 //TODO this should use a QStateMachine
 //----------------------------------------
@@ -64,9 +63,9 @@ protected slots:
     void goToNextComic();
 
 private:
-    QString getCharacters(const QScriptValue &json_characters);
-    QMap<QString, QString> getAuthors(const QScriptValue &json_authors);
-    QPair<QString, QString> getFirstStoryArcIdAndName(const QScriptValue &json_story_arcs);
+    QString getCharacters(const QVariant &json_characters);
+    QMap<QString, QString> getAuthors(const QVariant &json_authors);
+    QPair<QString, QString> getFirstStoryArcIdAndName(const QVariant &json_story_arcs);
     QPair<QString, QString> getArcNumberAndArcCount(const QString &storyArcId, const QString &comicId);
 
     void toggleSkipButton();

--- a/YACReaderLibrary/comic_vine/model/volume_comics_model.cpp
+++ b/YACReaderLibrary/comic_vine/model/volume_comics_model.cpp
@@ -1,7 +1,8 @@
 #include "volume_comics_model.h"
 #include "qnaturalsorting.h"
 
-#include <QtScript>
+#include <QJsonDocument>
+#include <QJsonParseError>
 
 bool lessThan(const QList<QString> &left, const QList<QString> &right)
 {
@@ -18,33 +19,29 @@ VolumeComicsModel::VolumeComicsModel(QObject *parent)
 
 void VolumeComicsModel::load(const QString &json)
 {
-    QScriptEngine engine;
-    QScriptValue sc;
-    sc = engine.evaluate("(" + json + ")");
+    QJsonParseError Err;
+    QVariantMap sc = QJsonDocument::fromJson(json.toUtf8(), &Err).toVariant().toMap();
 
-    if (!sc.property("error").isValid() && sc.property("error").toString() != "OK") {
+    if (Err.error != QJsonParseError::NoError) {
         qDebug("Error detected");
-    } else {
-        QScriptValueIterator it(sc.property("results"));
-        //bool test;
-        QScriptValue resultsValue;
-        while (it.hasNext()) {
-            it.next();
-            if (it.flags() & QScriptValue::SkipInEnumeration)
-                continue;
-            resultsValue = it.value();
-            QString issueNumber = resultsValue.property("issue_number").toString();
-            QScriptValue propertyName = resultsValue.property("name");
-            QString name = propertyName.isNull() ? "-" : propertyName.toString();
-            QString coverURL = resultsValue.property("image").property("medium_url").toString();
-            QString id = resultsValue.property("id").toString();
-            QStringList l;
-            l << issueNumber << name << coverURL << id;
-            _data.push_back(l);
-        }
-
-        qSort(_data.begin(), _data.end(), lessThan);
+        return;
     }
+
+    QListIterator<QVariant> it(sc.value("results").toList());
+    QVariantMap resultsValue;
+    while (it.hasNext()) {
+        resultsValue = it.next().toMap();
+        QString issueNumber = resultsValue.value("issue_number").toString();
+        QVariant propertyName = resultsValue.value("name");
+        QString name = propertyName.isNull() ? "-" : propertyName.toString();
+        QString coverURL = resultsValue.value("image").toMap().value("medium_url").toString();
+        QString id = resultsValue.value("id").toString();
+        QStringList l;
+        l << issueNumber << name << coverURL << id;
+        _data.push_back(l);
+    }
+
+    qSort(_data.begin(), _data.end(), lessThan);
 }
 
 /*void VolumeComicsModel::load(const QStringList &jsonList)

--- a/YACReaderLibrary/comic_vine/scraper_results_paginator.cpp
+++ b/YACReaderLibrary/comic_vine/scraper_results_paginator.cpp
@@ -4,7 +4,6 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QToolButton>
-#include <QtScript>
 
 ScraperResultsPaginator::ScraperResultsPaginator(QWidget *parent)
     : QWidget(parent), customLabel("items")

--- a/YACReaderLibrary/comic_vine/select_volume.cpp
+++ b/YACReaderLibrary/comic_vine/select_volume.cpp
@@ -1,19 +1,19 @@
 #include "select_volume.h"
 
-#include <QLabel>
-#include <QVBoxLayout>
+#include <QDesktopServices>
 #include <QHBoxLayout>
-#include <QScrollBar>
+#include <QHeaderView>
+#include <QJsonDocument>
+#include <QJsonParseError>
+#include <QLabel>
 #include <QModelIndex>
 #include <QScrollArea>
-#include <QDesktopServices>
-#include <QHeaderView>
-#include <QToolButton>
+#include <QScrollBar>
 #include <QSortFilterProxyModel>
+#include <QToolButton>
+#include <QVBoxLayout>
 
 #include "scraper_tableview.h"
-
-#include <QtScript>
 
 #include "volumes_model.h"
 #include "comic_vine_client.h"
@@ -149,18 +149,17 @@ void SelectVolume::setCover(const QByteArray &data)
 
 void SelectVolume::setDescription(const QString &jsonDetail)
 {
-    QScriptEngine engine;
-    QScriptValue sc;
-    sc = engine.evaluate("(" + jsonDetail + ")");
+    QJsonParseError Err;
+    QVariantMap sc = QJsonDocument::fromJson(jsonDetail.toUtf8(), &Err).toVariant().toMap();
 
-    if (!sc.property("error").isValid() && sc.property("error").toString() != "OK") {
+    if (Err.error != QJsonParseError::NoError) {
         qDebug("Error detected");
-    } else {
-
-        QScriptValue descriptionValues = sc.property("results").property("description");
-        bool valid = !descriptionValues.isNull() && descriptionValues.isValid();
-        detailLabel->setText(valid ? descriptionValues.toString().replace("<a", "<a style = 'color:#827A68; text-decoration:none;'") : tr("description unavailable"));
+        return;
     }
+
+    QVariant descriptionValues = sc.value("results").toMap().value("description");
+    bool valid = !descriptionValues.isNull() && descriptionValues.isValid();
+    detailLabel->setText(valid ? descriptionValues.toString().replace("<a", "<a style = 'color:#827A68; text-decoration:none;'") : tr("description unavailable"));
 }
 
 QString SelectVolume::getSelectedVolumeId()

--- a/azure-pipelines-windows-template.yml
+++ b/azure-pipelines-windows-template.yml
@@ -17,7 +17,7 @@ jobs:
   - script: |
       pip install aqtinstall
       mkdir C:\Qt
-      python -m aqt install -O c:\Qt ${{ parameters.qt_version }} windows desktop ${{ parameters.qt_aqt_spec }} -m qtscript
+      python -m aqt install -O c:\Qt ${{ parameters.qt_version }} windows desktop ${{ parameters.qt_aqt_spec }}
       dir C:\Qt\${{ parameters.qt_version }}\${{ parameters.qt_spec }}\bin
       choco install -y wget
       choco install innosetup

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -37,7 +37,7 @@ jobs:
       sudo add-apt-repository ppa:kubuntu-ppa/backports
       sudo apt-get update
       sudo apt-get install -y --allow-unauthenticated qt-default qt5-qmake \
-      qtbase5-dev qtmultimedia5-dev libpoppler-qt5-dev qtscript5-dev \
+      qtbase5-dev qtmultimedia5-dev libpoppler-qt5-dev \
       libqt5opengl5-dev libglu1-mesa-dev libunarr-dev qtdeclarative5-dev libqt5svg5-dev
     displayName: 'Install dependencies'
   - script: |

--- a/ci/win/build_installer.iss
+++ b/ci/win/build_installer.iss
@@ -38,7 +38,6 @@ Source: Qt5Multimedia.dll; DestDir: {app}
 Source: Qt5Network.dll; DestDir: {app}
 Source: Qt5Qml.dll; DestDir: {app}
 Source: Qt5Quick.dll; DestDir: {app}
-Source: Qt5Script.dll; DestDir: {app}
 Source: Qt5Sql.dll; DestDir: {app}
 Source: Qt5Svg.dll; DestDir: {app}
 Source: Qt5Widgets.dll; DestDir: {app}
@@ -140,7 +139,7 @@ procedure InitializeWizard();
 begin
 
   URLLabel := TNewStaticText.Create(WizardForm);
-  URLLabel.Caption:='Make a DONATION/Haz una DONACIÓN';
+  URLLabel.Caption:='Make a DONATION/Haz una DONACIï¿½N';
   URLLabel.Cursor:=crHand;
   URLLabel.OnClick:=@URLLabelOnClick;
   URLLabel.Parent:=WizardForm;
@@ -154,7 +153,7 @@ begin
 donationPage := CreateOutputMsgPage(wpWelcome,
   'Iformation', 'Please read the following information before continuing.',
   'YACReader is FREE software. If you like it, please, consider to make a DONATION'#13#13 +
-  'YACReader es software libre y GRATUITO. Si te gusta, por favor, considera realizar una DONACIÓN'#13#13)
+  'YACReader es software libre y GRATUITO. Si te gusta, por favor, considera realizar una DONACIï¿½N'#13#13)
 
 end;
 


### PR DESCRIPTION
QtScript is deprecated and this was needed to start supporting Qt6

This has been cherry-picked and fixed from: https://github.com/u19809/yacreader/tree/No-QtScript-and-Warnings all the code in the branch assumed that JSON object were all maps, but there are a bunch of objects coming from Comic Vine that are Arrays, so the hole thing was pretty much broken.