### PR TITLE
Don't crash during a slow (>= 60 seconds) startup on X11

### DIFF
--- a/YACReader/main.cpp
+++ b/YACReader/main.cpp
@@ -98,6 +98,12 @@ int main(int argc, char *argv[])
 #else
     QApplication app(argc, argv);
 #endif
+    // Prevent SIGPIPE, then "ICE default IO error handler doing an exit(), pid = <PID>, errno = 32"
+    // crash on X11 when the first event loop starts at least 60 seconds after a Qt application
+    // launch. This can happen during a Debug launch of YACReader from Qt Creator if Qt debug
+    // symbols are installed in the system or a breakpoint is hit before any event loop is entered.
+    // This is a workaround for QTBUG-58709.
+    QCoreApplication::processEvents();
 
 #ifdef FORCE_ANGLE
     app.setAttribute(Qt::AA_UseOpenGLES);

--- a/YACReaderLibrary/main.cpp
+++ b/YACReaderLibrary/main.cpp
@@ -120,6 +120,11 @@ int main(int argc, char **argv)
 {
     qInstallMessageHandler(messageHandler);
     QApplication app(argc, argv);
+    // Prevent SIGPIPE, then "ICE default IO error handler doing an exit(), pid = <PID>, errno = 32"
+    // crash on X11 when the first event loop starts at least 60 seconds after a Qt application
+    // launch. This can happen during a Debug launch of YACReaderLibrary from Qt Creator if a
+    // breakpoint is hit before any event loop is entered. This is a workaround for QTBUG-58709.
+    QCoreApplication::processEvents();
 
 #ifdef FORCE_ANGLE
     app.setAttribute(Qt::AA_UseOpenGLES);


### PR DESCRIPTION
See the added source code comments and the commit message for details.

The patch I used for benchmarking (stupid GitHub won't let me attach a patch => had to zip it): [0001-Benchmark-QCoreApplication-processEvents-workaround.patch.zip](https://github.com/YACReader/yacreader/files/6075476/0001-Benchmark-QCoreApplication-processEvents-workaround.patch.zip).

