### PR TITLE
Azure: Use qt@5 brew package to install Qt5 on macOS

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,8 +70,8 @@ jobs:
     vmImage: 'macOS-10.15'
   steps:
   - script: |
-      brew install qt
-      brew link qt --force
+      brew install qt@5
+      brew link qt@5 --force
       brew install create-dmg
       brew install node
       brew link --overwrite node


### PR DESCRIPTION
With the transition to Qt6 in brew our CI is now failing on macOS. This PR changes the brew package to the new Qt5 qt@5 package so we can build on mac again.