### PR TITLE
PageController*::service: remove unused libraryName variable

### DIFF
--- a/YACReaderLibrary/server/controllers/v1/folderinfocontroller.cpp
+++ b/YACReaderLibrary/server/controllers/v1/folderinfocontroller.cpp
@@ -19,7 +19,6 @@ void FolderInfoController::service(HttpRequest &request, HttpResponse &response)
     QString path = QUrl::fromPercentEncoding(request.getPath()).toUtf8();
     QStringList pathElements = path.split('/');
     int libraryId = pathElements.at(2).toInt();
-    QString libraryName = DBHelper::getLibraryName(libraryId);
     qulonglong parentId = pathElements.at(4).toULongLong();
 
     serviceComics(libraryId, parentId, response);

--- a/YACReaderLibrary/server/controllers/v1/pagecontroller.cpp
+++ b/YACReaderLibrary/server/controllers/v1/pagecontroller.cpp
@@ -11,8 +11,6 @@
 
 #include <QsLog.h>
 
-#include "db_helper.h"
-
 using stefanfrings::HttpRequest;
 using stefanfrings::HttpResponse;
 using stefanfrings::HttpSession;
@@ -31,7 +29,6 @@ void PageController::service(HttpRequest &request, HttpResponse &response)
     //qDebug("PageController: request to -> %s ",path2.data());
 
     QStringList pathElements = path.split('/');
-    QString libraryName = DBHelper::getLibraryName(pathElements.at(2).toInt());
     qulonglong comicId = pathElements.at(4).toULongLong();
     unsigned int page = pathElements.at(6).toUInt();
 

--- a/YACReaderLibrary/server/controllers/v2/folderinfocontroller_v2.cpp
+++ b/YACReaderLibrary/server/controllers/v2/folderinfocontroller_v2.cpp
@@ -19,7 +19,6 @@ void FolderInfoControllerV2::service(HttpRequest &request, HttpResponse &respons
     QString path = QUrl::fromPercentEncoding(request.getPath()).toUtf8();
     QStringList pathElements = path.split('/');
     int libraryId = pathElements.at(3).toInt();
-    QString libraryName = DBHelper::getLibraryName(libraryId);
     qulonglong parentId = pathElements.at(5).toULongLong();
 
     serviceComics(libraryId, parentId, response);

--- a/YACReaderLibrary/server/controllers/v2/pagecontroller_v2.cpp
+++ b/YACReaderLibrary/server/controllers/v2/pagecontroller_v2.cpp
@@ -11,8 +11,6 @@
 
 #include <QsLog.h>
 
-#include "db_helper.h"
-
 using stefanfrings::HttpRequest;
 using stefanfrings::HttpResponse;
 
@@ -33,7 +31,6 @@ void PageControllerV2::service(HttpRequest &request, HttpResponse &response)
     bool remote = path.endsWith("remote");
 
     QStringList pathElements = path.split('/');
-    QString libraryName = DBHelper::getLibraryName(pathElements.at(2).toInt());
     qulonglong comicId = pathElements.at(5).toULongLong();
     unsigned int page = pathElements.at(7).toUInt();
 

--- a/YACReaderLibrary/server/controllers/v2/readinglistinfocontroller_v2.cpp
+++ b/YACReaderLibrary/server/controllers/v2/readinglistinfocontroller_v2.cpp
@@ -20,7 +20,6 @@ void ReadingListInfoControllerV2::service(HttpRequest &request, HttpResponse &re
     QString path = QUrl::fromPercentEncoding(request.getPath()).toUtf8();
     QStringList pathElements = path.split('/');
     int libraryId = pathElements.at(3).toInt();
-    QString libraryName = DBHelper::getLibraryName(libraryId);
     qulonglong listId = pathElements.at(5).toULongLong();
 
     serviceComics(libraryId, listId, response);

--- a/YACReaderLibrary/server/controllers/v2/taginfocontroller_v2.cpp
+++ b/YACReaderLibrary/server/controllers/v2/taginfocontroller_v2.cpp
@@ -20,7 +20,6 @@ void TagInfoControllerV2::service(HttpRequest &request, HttpResponse &response)
     QString path = QUrl::fromPercentEncoding(request.getPath()).toUtf8();
     QStringList pathElements = path.split('/');
     int libraryId = pathElements.at(3).toInt();
-    QString libraryName = DBHelper::getLibraryName(libraryId);
     qulonglong listId = pathElements.at(5).toULongLong();
 
     serviceComics(libraryId, listId, response);

--- a/YACReaderLibrary/server/controllers/v2/updatecomiccontroller_v2.cpp
+++ b/YACReaderLibrary/server/controllers/v2/updatecomiccontroller_v2.cpp
@@ -21,7 +21,6 @@ void UpdateComicControllerV2::service(HttpRequest &request, HttpResponse &respon
     QString path = QUrl::fromPercentEncoding(request.getPath()).toUtf8();
     QStringList pathElements = path.split('/');
     qulonglong libraryId = pathElements.at(3).toULongLong();
-    QString libraryName = DBHelper::getLibraryName(libraryId);
     qulonglong comicId = pathElements.at(5).toULongLong();
 
     QString postData = QString::fromUtf8(request.getBody());


### PR DESCRIPTION
Hopefully the code does not rely on the side effects of the removed call to `DBHelper::getLibraryName()`.

If the call to `DBHelper::getLibraryName()` is useful, either the variable assignment should be removed or an explaining comment should be added.