### PR TITLE
Remove unneeded QtOpenGL dependency

### DIFF
--- a/YACReader/YACReader.pro
+++ b/YACReader/YACReader.pro
@@ -69,9 +69,6 @@ macx {
 }
 
 QT += network widgets core multimedia svg
-!CONFIG(no_opengl) {
-    QT += opengl
-}
 
 #CONFIG += release
 CONFIG -= flat

--- a/YACReaderLibrary/YACReaderLibrary.pro
+++ b/YACReaderLibrary/YACReaderLibrary.pro
@@ -70,9 +70,6 @@ macx {
 #CONFIG += release
 CONFIG -= flat
 QT += sql network widgets svg
-!CONFIG(no_opengl) {
-  QT += opengl
-}
 
 # Input
 HEADERS += comic_flow.h \

--- a/common/gl/yacreader_flow_gl.cpp
+++ b/common/gl/yacreader_flow_gl.cpp
@@ -1,7 +1,6 @@
 #include "yacreader_flow_gl.h"
 
 #include <QtGui>
-#include <QtOpenGL>
 #include <QMatrix4x4>
 #include <cmath>
 


### PR DESCRIPTION
Qt OpenGL in Qt5 is a deprecated module that is discouraged for
new code usage. We have been including this module in our builds
despite not relying on its functionality for a long time now -
probably an oversight from porting to the newer functions.

Time to remove it.

IMPORTANT INFORMATION: In Qt6, a lot of functionality that was
provided by Qt GUI was moved into the 'new' Qt6 Qt OpenGL module.
Thus, even if it makes perfectly sense to remove it for Qt5 builds
we will likely have to restore it for Qt6 builds at a later time.