### PR TITLE
Build/qt 5.9

### DIFF
--- a/YACReaderLibrary/comic_vine/model/volume_comics_model.cpp
+++ b/YACReaderLibrary/comic_vine/model/volume_comics_model.cpp
@@ -41,7 +41,7 @@ void VolumeComicsModel::load(const QString &json)
         _data.push_back(l);
     }
 
-    qSort(_data.begin(), _data.end(), lessThan);
+    std::sort(_data.begin(), _data.end(), lessThan);
 }
 
 /*void VolumeComicsModel::load(const QStringList &jsonList)

--- a/YACReaderLibrary/server/controllers/v2/foldercontentcontroller_v2.cpp
+++ b/YACReaderLibrary/server/controllers/v2/foldercontentcontroller_v2.cpp
@@ -52,7 +52,7 @@ void FolderContentControllerV2::serviceContent(const int &library, const qulongl
     QList<LibraryItem *> folderComics = DBHelper::getFolderComicsFromLibrary(library, folderId);
 
     folderContent.append(folderComics);
-    qSort(folderContent.begin(), folderContent.end(), LibraryItemSorter());
+    std::sort(folderContent.begin(), folderContent.end(), LibraryItemSorter());
 
     folderComics.clear();
 

--- a/config.pri
+++ b/config.pri
@@ -8,17 +8,36 @@ unix:QMAKE_CXXFLAGS_RELEASE += -DNDEBUG
 win32:QMAKE_CXXFLAGS_RELEASE += /DNDEBUG
 
 # check Qt version
-QT_VERSION = $$[QT_VERSION]
-QT_VERSION = $$split(QT_VERSION, ".")
-QT_VER_MAJ = $$member(QT_VERSION, 0)
-QT_VER_MIN = $$member(QT_VERSION, 1)
+defineTest(minQtVersion) {
+  maj = $$1
+  min = $$2
+  patch = $$3
+  isEqual(QT_MAJOR_VERSION, $$maj) {
+    isEqual(QT_MINOR_VERSION, $$min) {
+      isEqual(QT_PATCH_VERSION, $$patch) {
+        return(true)
+      }
+      greaterThan(QT_PATCH_VERSION, $$patch) {
+        return(true)
+      }
+    }
+    greaterThan(QT_MINOR_VERSION, $$min) {
+      return(true)
+    }
+  }
+  greaterThan(QT_MAJOR_VERSION, $$maj) {
+    return(true)
+  }
+  return(false)
+}
 
-lessThan(QT_VER_MAJ, 5) {
-error(YACReader requires Qt 5 or newer but Qt $$[QT_VERSION] was detected.)
-  }
-lessThan(QT_VER_MIN, 6):!CONFIG(no_opengl) {
-  error ("You need at least Qt 5.6 to compile YACReader or YACReaderLibrary.")
-  }
+!minQtVersion(5, 9, 0) {
+  error(YACReader requires Qt 5.9 or newer but $$[QT_VERSION] was detected)
+}
+
+minQtVersion(6, 0, 0) {
+  error(YACReader does not support building with Qt6 (yet))
+}
 
 # reduce log pollution
 CONFIG += silent

--- a/config.pri
+++ b/config.pri
@@ -39,6 +39,9 @@ minQtVersion(6, 0, 0) {
   error(YACReader does not support building with Qt6 (yet))
 }
 
+DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x050900
+DEFINES += QT_DEPRECATED_WARNINGS
+
 # reduce log pollution
 CONFIG += silent
 

--- a/custom_widgets/yacreader_treeview.cpp
+++ b/custom_widgets/yacreader_treeview.cpp
@@ -20,44 +20,13 @@ YACReaderTreeView::YACReaderTreeView(QWidget *parent)
 
 #ifdef Q_OS_MAC
 
-    bool oldStyle = true;
-    switch (QSysInfo::MacVersion()) {
-    case QSysInfo::MV_SNOWLEOPARD:
-    case QSysInfo::MV_LION:
-    case QSysInfo::MV_MOUNTAINLION:
-    case QSysInfo::MV_MAVERICKS:
-        oldStyle = true; //TODO fix this
-        break;
-    default:
-        oldStyle = false;
-        break;
-    }
+    setStyleSheet("QTreeView {background-color:transparent; border: none;}"
+                  "QTreeView::item:selected {background-color:#91c4f4; border-top: 1px solid #91c4f4; border-left:none;border-right:none;border-bottom:1px solid #91c4f4;}"
+                  "QTreeView::branch:selected {background-color:#91c4f4; border-top: 1px solid #91c4f4; border-left:none;border-right:none;border-bottom:1px solid #91c4f4;}"
+                  "QTreeView::branch:open:selected:has-children {image: url(':/images/sidebar/expanded_branch_osx.png');}"
+                  "QTreeView::branch:closed:selected:has-children {image: url(':/images/sidebar/collapsed_branch_osx.png');}"
 
-    if (oldStyle) {
-        setStyleSheet("QTreeView {background-color:transparent; border: none;}"
-                      "QTreeView::item:selected {background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #6BAFE4, stop: 1 #3984D2); border-top: 2px solid qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #5EA3DF, stop: 1 #73B8EA); border-left:none;border-right:none;border-bottom:1px solid #3577C2;}"
-                      "QTreeView::branch:selected {background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #6BAFE4, stop: 1 #3984D2); border-top: 2px solid qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #5EA3DF, stop: 1 #73B8EA); border-left:none;border-right:none;border-bottom:1px solid #3577C2;}"
-                      "QTreeView::branch:open:selected:has-children {image: url(':/images/sidebar/expanded_branch_osx.png');}"
-                      "QTreeView::branch:closed:selected:has-children {image: url(':/images/sidebar/collapsed_branch_osx.png');}"
-
-                      "QScrollBar:vertical { border: none; background: #EFEFEF; width: 9px; margin: 0 3px 0 0; }"
-                      "QScrollBar::handle:vertical { background: #DDDDDD; width: 7px; min-height: 20px; margin: 1px; border: 1px solid #D0D0D0; }"
-                      "QScrollBar::add-line:vertical { border: none; background: #EFEFEF; height: 10px; subcontrol-position: bottom; subcontrol-origin: margin; margin: 0 3px 0 0;}"
-
-                      "QScrollBar::sub-line:vertical {  border: none; background: #EFEFEF; height: 10px; subcontrol-position: top; subcontrol-origin: margin; margin: 0 3px 0 0;}"
-                      "QScrollBar::up-arrow:vertical {border:none;width: 9px;height: 6px;background: url(':/images/folders_view/line-up.png') center top no-repeat;}"
-                      "QScrollBar::down-arrow:vertical {border:none;width: 9px;height: 6px;background: url(':/images/folders_view/line-down.png') center top no-repeat;}"
-
-                      "QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical {background: none; }");
-    } else {
-        setStyleSheet("QTreeView {background-color:transparent; border: none;}"
-                      "QTreeView::item:selected {background-color:#91c4f4; border-top: 1px solid #91c4f4; border-left:none;border-right:none;border-bottom:1px solid #91c4f4;}"
-                      "QTreeView::branch:selected {background-color:#91c4f4; border-top: 1px solid #91c4f4; border-left:none;border-right:none;border-bottom:1px solid #91c4f4;}"
-                      "QTreeView::branch:open:selected:has-children {image: url(':/images/sidebar/expanded_branch_osx.png');}"
-                      "QTreeView::branch:closed:selected:has-children {image: url(':/images/sidebar/collapsed_branch_osx.png');}"
-
-        );
-    }
+    );
 
 #else
     setStyleSheet("QTreeView {background-color:transparent; border: none; color:#DDDFDF; outline:0; show-decoration-selected: 0;}"


### PR DESCRIPTION
This PR improves our Qt version check macros for Qt 5 and fixes a false positive in the check that triggered when attempting to build using Qt 6.

Additionally, it increases the minimum build requirement to Qt 5.9 and introduces Qt deprecation macros as they are standard with every new Qt project.

This means that with the merge of this PR all use of Qt functions deprecated with 5.9 or earlier will lead to a build failure and newer Qt versions will display warnings when using functions deprecated after 5.9. This will allow us to defend against such functions sneaking back in and to start migrating away from functions deprecated in later versions. This is also a necessary step for future Qt 6 compatibility.
