### PR TITLE
Azure: Update Windows builds to use VS 2019 and Qt 5.15.2

### DIFF
--- a/azure-pipelines-windows-template.yml
+++ b/azure-pipelines-windows-template.yml
@@ -1,10 +1,10 @@
 parameters:
   name: Windows_x64
   architecture: 'x64'
-  qt_version: '5.12.6'
-  qt_spec: 'msvc2017_64'
-  qt_aqt_spec: 'win64_msvc2017_64'
-  vc_redist_url: 'https://go.microsoft.com/fwlink/?LinkId=746572'
+  qt_version: '5.15.2'
+  qt_spec: 'msvc2019_64'
+  qt_aqt_spec: 'win64_msvc2019_64'
+  vc_redist_url: 'https://aka.ms/vs/16/release/vc_redist.x64.exe'
   vc_redist_file_name: 'vc_redist.x64.exe'
   vc_vars: 'vcvars64.bat'
 
@@ -12,7 +12,7 @@ jobs:
 - job: ${{ parameters.name }}
   dependsOn: CodeFormatValidation
   pool:
-    vmImage: 'vs2017-win2016'
+    vmImage: 'windows-2019'
   steps:
   - script: |
       pip install aqtinstall
@@ -26,7 +26,7 @@ jobs:
       wget "${{ parameters.vc_redist_url }}" -O $(Build.SourcesDirectory)\${{ parameters.vc_redist_file_name }}
     displayName: 'Install dependencies'
   - script: |
-      call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Enterprise\VC\Auxiliary\Build\${{ parameters.vc_vars }}"
+      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\${{ parameters.vc_vars }}"
       set PATH=C:\Qt\${{ parameters.qt_version }}\${{ parameters.qt_spec }}\bin;%PATH%
       set DEFINES_VAR=DEFINES+="BUILD_NUMBER=\\\\\\\"$(Build.BuildNumber)\\\\\\\""
       qmake CONFIG+="7zip" %DEFINES_VAR%

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -103,20 +103,20 @@ jobs:
   parameters:
     name: Windows_x64
     architecture: 'x64'
-    qt_version: '5.12.6'
-    qt_spec: 'msvc2017_64'
-    qt_aqt_spec: 'win64_msvc2017_64'
-    vc_redist_url: 'https://go.microsoft.com/fwlink/?LinkId=746572'
+    qt_version: '5.15.2'
+    qt_spec: 'msvc2019_64'
+    qt_aqt_spec: 'win64_msvc2019_64'
+    vc_redist_url: 'https://aka.ms/vs/16/release/vc_redist.x64.exe'
     vc_redist_file_name: 'vc_redist.x64.exe'
     vc_vars: 'vcvars64.bat'
 - template: azure-pipelines-windows-template.yml
   parameters:
     name: Windows_x86
     architecture: 'x86'
-    qt_version: '5.12.6'
-    qt_spec: 'msvc2017'
-    qt_aqt_spec: 'win32_msvc2017'
-    vc_redist_url: 'https://go.microsoft.com/fwlink/?LinkId=746571'
+    qt_version: '5.15.2'
+    qt_spec: 'msvc2019'
+    qt_aqt_spec: 'win32_msvc2019'
+    vc_redist_url: 'https://aka.ms/vs/16/release/vc_redist.x86.exe'
     vc_redist_file_name: 'vc_redist.x86.exe'
     vc_vars: 'vcvars32.bat'
 


### PR DESCRIPTION
Qt 5.15.2 and VS 2019 support all Windows platforms still supported
by YACReader. Update the build to take advantage of it.