### PR TITLE
Test, fix, improve, optimize ConcurrentQueue

### DIFF
--- a/YACReader.pro
+++ b/YACReader.pro
@@ -1,3 +1,4 @@
 TEMPLATE = subdirs
 SUBDIRS = YACReader YACReaderLibrary YACReaderLibraryServer
 YACReaderLibrary.depends = YACReader
+!CONFIG(no_tests): SUBDIRS += tests

--- a/YACReader/YACReader.pro
+++ b/YACReader/YACReader.pro
@@ -6,7 +6,7 @@ QMAKE_TARGET_BUNDLE_PREFIX = "com.yacreader"
 DEPENDPATH += . \
     release
 
-DEFINES += NOMINMAX YACREADER
+DEFINES += YACREADER
 
 #load default build flags
 include (../config.pri)

--- a/YACReaderLibrary/YACReaderLibrary.pro
+++ b/YACReaderLibrary/YACReaderLibrary.pro
@@ -160,6 +160,7 @@ HEADERS += comic_flow.h \
 }
 
 SOURCES += comic_flow.cpp \
+    ../common/concurrent_queue.cpp \
     create_library_dialog.cpp \
     db/comic_query_result_processor.cpp \
     db/folder_query_result_processor.cpp \

--- a/YACReaderLibrary/YACReaderLibrary.pro
+++ b/YACReaderLibrary/YACReaderLibrary.pro
@@ -12,7 +12,7 @@ INCLUDEPATH += . \
               ./comic_vine \
               ./comic_vine/model
 
-DEFINES += SERVER_RELEASE NOMINMAX YACREADER_LIBRARY
+DEFINES += SERVER_RELEASE YACREADER_LIBRARY
 
 # load default build flags
 include (../config.pri)

--- a/YACReaderLibrary/db/comic_query_result_processor.cpp
+++ b/YACReaderLibrary/db/comic_query_result_processor.cpp
@@ -16,7 +16,7 @@ YACReader::ComicQueryResultProcessor::ComicQueryResultProcessor()
 
 void YACReader::ComicQueryResultProcessor::createModelData(const YACReader::SearchModifiers modifier, const QString &filter, const QString &databasePath)
 {
-    querySearchQueue.cancellPending();
+    querySearchQueue.cancelPending();
 
     querySearchQueue.enqueue([=] {
         QString connectionName = "";

--- a/YACReaderLibrary/db/folder_query_result_processor.cpp
+++ b/YACReaderLibrary/db/folder_query_result_processor.cpp
@@ -22,7 +22,7 @@ YACReader::FolderQueryResultProcessor::FolderQueryResultProcessor(FolderModel *m
 
 void YACReader::FolderQueryResultProcessor::createModelData(const YACReader::SearchModifiers modifier, const QString &filter, bool includeComics)
 {
-    querySearchQueue.cancellPending();
+    querySearchQueue.cancelPending();
 
     querySearchQueue.enqueue([=] {
         QString connectionName = "";

--- a/YACReaderLibraryServer/YACReaderLibraryServer.pro
+++ b/YACReaderLibraryServer/YACReaderLibraryServer.pro
@@ -10,7 +10,7 @@ INCLUDEPATH += ../YACReaderLibrary \
                 ../YACReaderLibrary/server \
                 ../YACReaderLibrary/db
 
-DEFINES += SERVER_RELEASE NOMINMAX YACREADER_LIBRARY
+DEFINES += SERVER_RELEASE YACREADER_LIBRARY
 # load default build flags
 # do a basic dependency check
 include(headless_config.pri)

--- a/azure-pipelines-windows-template-qt6.yml
+++ b/azure-pipelines-windows-template-qt6.yml
@@ -33,6 +33,11 @@ jobs:
       qmake CONFIG+="7zip" %DEFINES_VAR%
       nmake
     displayName: 'Build'
+  - script: |
+      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\${{ parameters.vc_vars }}"
+      set PATH=C:\Qt\${{ parameters.qt_version }}\${{ parameters.qt_spec }}\bin;%PATH%
+      nmake check TESTARGS="-maxwarnings 100000"
+    displayName: 'Run tests'
 #  - script: |
 #      set PATH=C:\Qt\${{ parameters.qt_version }}\${{ parameters.qt_spec }}\bin;%PATH%
 #      cd $(Build.SourcesDirectory)\ci\win

--- a/azure-pipelines-windows-template.yml
+++ b/azure-pipelines-windows-template.yml
@@ -34,6 +34,11 @@ jobs:
       nmake
     displayName: 'Build'
   - script: |
+      call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\VC\Auxiliary\Build\${{ parameters.vc_vars }}"
+      set PATH=C:\Qt\${{ parameters.qt_version }}\${{ parameters.qt_spec }}\bin;%PATH%
+      nmake check TESTARGS="-maxwarnings 100000"
+    displayName: 'Run tests'
+  - script: |
       set PATH=C:\Qt\${{ parameters.qt_version }}\${{ parameters.qt_spec }}\bin;%PATH%
       cd $(Build.SourcesDirectory)\ci\win
       .\create_installer.cmd ${{ parameters.architecture }} 7z $(Build.BuildNumber)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -72,6 +72,9 @@ jobs:
       qmake CONFIG+="unarr" $DEFINES_VAR
       make
     displayName: 'Build'
+  - script: |
+      make check TESTARGS="-maxwarnings 100000"
+    displayName: 'Run tests'
   - task: CopyFiles@2
     inputs:
       sourceFolder: $(Build.SourcesDirectory)/tarball
@@ -118,6 +121,11 @@ jobs:
       SKIP_CODESIGN="$(tr [A-Z] [a-z] <<< "$IS_FORK")"
       ./compileOSX.sh $VERSION $(Build.BuildNumber) $SKIP_CODESIGN
     displayName: 'Build'
+  - script: |
+      cd $(Build.SourcesDirectory)/tests
+      qmake
+      make check TESTARGS="-maxwarnings 100000"
+    displayName: 'Build and run tests'
   - task: CopyFiles@2
     inputs:
       contents: '*.dmg'

--- a/common/concurrent_queue.cpp
+++ b/common/concurrent_queue.cpp
@@ -1,0 +1,127 @@
+#include "concurrent_queue.h"
+
+#include <cassert>
+#include <cstddef>
+#include <mutex>
+#include <utility>
+
+using namespace YACReader;
+
+ConcurrentQueue::ConcurrentQueue(std::size_t threadCount)
+{
+    threads.reserve(threadCount);
+    for (; threadCount != 0; --threadCount)
+        threads.emplace_back(&ConcurrentQueue::nextJob, this);
+}
+
+ConcurrentQueue::~ConcurrentQueue()
+{
+    joinAll();
+}
+
+void ConcurrentQueue::enqueue(Job job)
+{
+    {
+        std::lock_guard<std::mutex> lock(jobsLeftMutex);
+        ++jobsLeft;
+    }
+
+    {
+        std::lock_guard<std::mutex> lock(queueMutex);
+        _queue.emplace(std::move(job));
+    }
+
+    jobAvailableVar.notify_one();
+}
+
+std::size_t ConcurrentQueue::cancelPending()
+{
+    decltype(_queue) oldQueue;
+    {
+        const std::lock_guard<std::mutex> lock(queueMutex);
+        // The mutex locking time is lower with swap() compared to assigning a
+        // temporary (which destroys _queue's elements and deallocates memory).
+        _queue.swap(oldQueue);
+    }
+
+    const auto size = oldQueue.size();
+    if (size != 0)
+        finalizeJobs(size);
+    return size;
+}
+
+void ConcurrentQueue::waitAll()
+{
+    std::unique_lock<std::mutex> lock(jobsLeftMutex);
+    if (jobsLeft > 0) {
+        _waitVar.wait(lock, [this] {
+            return jobsLeft == 0;
+        });
+    }
+}
+
+void ConcurrentQueue::nextJob()
+{
+    while (true) {
+        Job job;
+
+        {
+            std::unique_lock<std::mutex> lock(queueMutex);
+
+            if (bailout) {
+                return;
+            }
+
+            jobAvailableVar.wait(lock, [this] {
+                return _queue.size() > 0 || bailout;
+            });
+
+            if (bailout) {
+                return;
+            }
+
+            job = std::move(_queue.front());
+            _queue.pop();
+        }
+
+        job();
+        finalizeJobs(1);
+    }
+}
+
+void ConcurrentQueue::finalizeJobs(std::size_t count)
+{
+    assert(count > 0);
+
+    std::size_t remainingJobs;
+    {
+        std::lock_guard<std::mutex> lock(jobsLeftMutex);
+        assert(jobsLeft >= count);
+        jobsLeft -= count;
+        remainingJobs = jobsLeft;
+    }
+
+    if (remainingJobs == 0)
+        _waitVar.notify_all();
+}
+
+void ConcurrentQueue::joinAll()
+{
+    {
+        std::lock_guard<std::mutex> lock(queueMutex);
+
+        if (bailout) {
+            return;
+        }
+
+        bailout = true;
+    }
+
+    jobAvailableVar.notify_all();
+
+    for (auto &x : threads) {
+        if (x.joinable()) {
+            x.join();
+        }
+    }
+}

--- a/common/concurrent_queue.cpp
+++ b/common/concurrent_queue.cpp
@@ -59,7 +59,7 @@ std::size_t ConcurrentQueue::cancelPending()
     return size;
 }
 
-void ConcurrentQueue::waitAll()
+void ConcurrentQueue::waitAll() const
 {
     std::unique_lock<std::mutex> lock(jobsLeftMutex);
     _waitVar.wait(lock, [this] { return jobsLeft == 0; });

--- a/common/concurrent_queue.cpp
+++ b/common/concurrent_queue.cpp
@@ -62,11 +62,7 @@ std::size_t ConcurrentQueue::cancelPending()
 void ConcurrentQueue::waitAll()
 {
     std::unique_lock<std::mutex> lock(jobsLeftMutex);
-    if (jobsLeft > 0) {
-        _waitVar.wait(lock, [this] {
-            return jobsLeft == 0;
-        });
-    }
+    _waitVar.wait(lock, [this] { return jobsLeft == 0; });
 }
 
 void ConcurrentQueue::nextJob()
@@ -76,10 +72,6 @@ void ConcurrentQueue::nextJob()
 
         {
             std::unique_lock<std::mutex> lock(queueMutex);
-
-            if (bailout) {
-                return;
-            }
 
             jobAvailableVar.wait(lock, [this] {
                 return _queue.size() > 0 || bailout;

--- a/common/concurrent_queue.h
+++ b/common/concurrent_queue.h
@@ -113,7 +113,7 @@ private:
                 --jobsLeft;
             }
 
-            _waitVar.notify_one();
+            _waitVar.notify_all();
         }
     }
 

--- a/common/concurrent_queue.h
+++ b/common/concurrent_queue.h
@@ -8,6 +8,7 @@
 #include <functional>
 #include <condition_variable>
 #include <queue>
+#include <utility>
 #include <vector>
 
 namespace YACReader {
@@ -40,7 +41,7 @@ public:
 
         {
             std::lock_guard<std::mutex> lock(queueMutex);
-            _queue.emplace(job);
+            _queue.emplace(std::move(job));
         }
 
         jobAvailableVar.notify_one();
@@ -105,7 +106,7 @@ private:
                     return;
                 }
 
-                job = _queue.front();
+                job = std::move(_queue.front());
                 _queue.pop();
             }
 

--- a/common/concurrent_queue.h
+++ b/common/concurrent_queue.h
@@ -14,16 +14,13 @@ namespace YACReader {
 class ConcurrentQueue
 {
 public:
-    explicit ConcurrentQueue(int threadCount)
+    explicit ConcurrentQueue(std::size_t threadCount)
         : jobsLeft(0),
           bailout(false)
     {
-        threads = std::vector<std::thread>(threadCount);
-        for (int index = 0; index < threadCount; ++index) {
-            threads[index] = std::thread([this] {
-                this->nextJob();
-            });
-        }
+        threads.reserve(threadCount);
+        for (; threadCount != 0; --threadCount)
+            threads.emplace_back(&ConcurrentQueue::nextJob, this);
     }
 
     ~ConcurrentQueue()

--- a/common/concurrent_queue.h
+++ b/common/concurrent_queue.h
@@ -1,151 +1,53 @@
 #ifndef CONCURRENT_QUEUE_H
 #define CONCURRENT_QUEUE_H
 
-#include <cassert>
 #include <thread>
 #include <mutex>
 #include <functional>
 #include <condition_variable>
 #include <queue>
-#include <utility>
 #include <vector>
 
 namespace YACReader {
+//! All functions in this class are thread-safe in the Qt documentation sense.
 class ConcurrentQueue
 {
 public:
-    explicit ConcurrentQueue(std::size_t threadCount)
-        : jobsLeft(0),
-          bailout(false)
-    {
-        threads.reserve(threadCount);
-        for (; threadCount != 0; --threadCount)
-            threads.emplace_back(&ConcurrentQueue::nextJob, this);
-    }
+    //! @brief Creates and starts executing @p threadCount worker threads.
+    //! @note ConcurrentQueue is unable to execute jobs if @p threadCount == 0.
+    explicit ConcurrentQueue(std::size_t threadCount);
 
-    ~ConcurrentQueue()
-    {
-        joinAll();
-    }
+    //! Cancels all jobs that have not been picked up by worker threads yet,
+    //! waits for all worker threads to complete their jobs and joins them.
+    ~ConcurrentQueue();
 
-    void enqueue(std::function<void(void)> job)
-    {
-        {
-            std::lock_guard<std::mutex> lock(jobsLeftMutex);
-            ++jobsLeft;
-        }
+    using Job = std::function<void()>;
 
-        {
-            std::lock_guard<std::mutex> lock(queueMutex);
-            _queue.emplace(std::move(job));
-        }
-
-        jobAvailableVar.notify_one();
-    }
+    //! @brief Adds @p job to the queue.
+    //! @note A worker thread may start executing @p job immediately if it is idle.
+    //! Worker threads start executing jobs in the same order as they are enqueued.
+    void enqueue(Job job);
 
     //! @brief Cancels all jobs that have not been picked up by worker threads yet.
     //! @return The number of jobs that were canceled.
-    std::size_t cancelPending()
-    {
-        decltype(_queue) oldQueue;
-        {
-            const std::lock_guard<std::mutex> lock(queueMutex);
-            // The mutex locking time is lower with swap() compared to assigning a
-            // temporary (which destroys _queue's elements and deallocates memory).
-            _queue.swap(oldQueue);
-        }
+    std::size_t cancelPending();
 
-        const auto size = oldQueue.size();
-        if (size != 0)
-            finalizeJobs(size);
-        return size;
-    }
-
-    void waitAll()
-    {
-        std::unique_lock<std::mutex> lock(jobsLeftMutex);
-        if (jobsLeft > 0) {
-            _waitVar.wait(lock, [this] {
-                return jobsLeft == 0;
-            });
-        }
-    }
+    //! @brief Blocks the current thread until all enqueued jobs are completed.
+    void waitAll();
 
 private:
     std::vector<std::thread> threads;
-    std::queue<std::function<void(void)>> _queue;
-    std::size_t jobsLeft; //!< @invariant jobsLeft >= _queue.size()
-    bool bailout;
+    std::queue<Job> _queue;
+    std::size_t jobsLeft = 0; //!< @invariant jobsLeft >= _queue.size()
+    bool bailout = false;
     std::condition_variable jobAvailableVar;
     std::condition_variable _waitVar;
     std::mutex jobsLeftMutex;
     std::mutex queueMutex;
 
-    void nextJob()
-    {
-        while (true) {
-            std::function<void(void)> job;
-
-            {
-                std::unique_lock<std::mutex> lock(queueMutex);
-
-                if (bailout) {
-                    return;
-                }
-
-                jobAvailableVar.wait(lock, [this] {
-                    return _queue.size() > 0 || bailout;
-                });
-
-                if (bailout) {
-                    return;
-                }
-
-                job = std::move(_queue.front());
-                _queue.pop();
-            }
-
-            job();
-            finalizeJobs(1);
-        }
-    }
-
-    void finalizeJobs(std::size_t count)
-    {
-        assert(count > 0);
-
-        std::size_t remainingJobs;
-        {
-            std::lock_guard<std::mutex> lock(jobsLeftMutex);
-            assert(jobsLeft >= count);
-            jobsLeft -= count;
-            remainingJobs = jobsLeft;
-        }
-
-        if (remainingJobs == 0)
-            _waitVar.notify_all();
-    }
-
-    void joinAll()
-    {
-        {
-            std::lock_guard<std::mutex> lock(queueMutex);
-
-            if (bailout) {
-                return;
-            }
-
-            bailout = true;
-        }
-
-        jobAvailableVar.notify_all();
-
-        for (auto &x : threads) {
-            if (x.joinable()) {
-                x.join();
-            }
-        }
-    }
+    void nextJob();
+    void finalizeJobs(std::size_t count);
+    void joinAll();
 };
 
 }

--- a/common/concurrent_queue.h
+++ b/common/concurrent_queue.h
@@ -47,8 +47,8 @@ public:
     {
         std::unique_lock<std::mutex> lockQueue(queueMutex);
         std::unique_lock<std::mutex> lockJobsLeft(jobsLeftMutex);
-        _queue = std::queue<std::function<void(void)>>();
-        jobsLeft = 0;
+        jobsLeft -= _queue.size();
+        _queue = {};
     }
 
     void waitAll()

--- a/common/concurrent_queue.h
+++ b/common/concurrent_queue.h
@@ -43,7 +43,7 @@ public:
         jobAvailableVar.notify_one();
     }
 
-    void cancellPending()
+    void cancelPending()
     {
         std::unique_lock<std::mutex> lockQueue(queueMutex);
         std::unique_lock<std::mutex> lockJobsLeft(jobsLeftMutex);

--- a/common/concurrent_queue.h
+++ b/common/concurrent_queue.h
@@ -33,7 +33,7 @@ public:
     std::size_t cancelPending();
 
     //! @brief Blocks the current thread until all enqueued jobs are completed.
-    void waitAll();
+    void waitAll() const;
 
 private:
     //! @invariant all worker threads are joinable until the destructor is called.
@@ -42,8 +42,8 @@ private:
     std::size_t jobsLeft = 0; //!< @invariant jobsLeft >= _queue.size()
     bool bailout = false; //!< @invariant is false until the destructor is called.
     std::condition_variable jobAvailableVar;
-    std::condition_variable _waitVar;
-    std::mutex jobsLeftMutex;
+    mutable std::condition_variable _waitVar;
+    mutable std::mutex jobsLeftMutex;
     std::mutex queueMutex;
 
     void nextJob();

--- a/common/concurrent_queue.h
+++ b/common/concurrent_queue.h
@@ -36,10 +36,11 @@ public:
     void waitAll();
 
 private:
+    //! @invariant all worker threads are joinable until the destructor is called.
     std::vector<std::thread> threads;
     std::queue<Job> _queue;
     std::size_t jobsLeft = 0; //!< @invariant jobsLeft >= _queue.size()
-    bool bailout = false;
+    bool bailout = false; //!< @invariant is false until the destructor is called.
     std::condition_variable jobAvailableVar;
     std::condition_variable _waitVar;
     std::mutex jobsLeftMutex;
@@ -47,7 +48,6 @@ private:
 
     void nextJob();
     void finalizeJobs(std::size_t count);
-    void joinAll();
 };
 
 }

--- a/config.pri
+++ b/config.pri
@@ -5,6 +5,8 @@
 CONFIG += c++17
 win32:QMAKE_CXXFLAGS += /std:c++17 #enable c++17 explicitly in msvc
 
+DEFINES += NOMINMAX
+
 if(unix|mingw):QMAKE_CXXFLAGS_RELEASE += -DNDEBUG
 win32:msvc:QMAKE_CXXFLAGS_RELEASE += /DNDEBUG
 

--- a/tests/concurrent_queue_test/concurrent_queue_test.cpp
+++ b/tests/concurrent_queue_test/concurrent_queue_test.cpp
@@ -202,7 +202,7 @@ std::size_t cancelAndPrint(ConcurrentQueue &queue, const QueueControlMessagePrin
     return canceledCount;
 }
 
-void waitAndPrint(ConcurrentQueue &queue, const QueueControlMessagePrinter &printer)
+void waitAndPrint(const ConcurrentQueue &queue, const QueueControlMessagePrinter &printer)
 {
     printer.printBeginWaitingMessage();
     queue.waitAll();

--- a/tests/concurrent_queue_test/concurrent_queue_test.cpp
+++ b/tests/concurrent_queue_test/concurrent_queue_test.cpp
@@ -1,0 +1,268 @@
+#include "concurrent_queue.h"
+
+#include <QDebug>
+#include <QDebugStateSaver>
+#include <QMetaType>
+#include <QObject>
+#include <QString>
+#include <QTest>
+#include <QTime>
+#include <QVector>
+
+#include <atomic>
+#include <chrono>
+#include <numeric>
+#include <sstream>
+#include <thread>
+#include <vector>
+
+namespace chrono = std::chrono;
+using Clock = chrono::steady_clock;
+using YACReader::ConcurrentQueue;
+
+namespace {
+double toMilliseconds(Clock::duration duration)
+{
+    return chrono::duration_cast<chrono::microseconds>(duration).count() / 1000.0;
+}
+
+QString currentThreadInfo()
+{
+    std::ostringstream os;
+    os << std::this_thread::get_id();
+    return QString::fromStdString(os.str());
+}
+
+QDebug log()
+{
+    return qInfo().noquote() << currentThreadInfo() << '|'
+                             << QTime::currentTime().toString(Qt::ISODateWithMs) << '|';
+}
+
+using Total = std::atomic<int>;
+
+struct JobData {
+    int summand;
+    Clock::duration sleepingTime;
+};
+using JobDataSet = QVector<JobData>;
+
+int expectedTotal(const JobDataSet &jobs)
+{
+    return std::accumulate(jobs.cbegin(), jobs.cend(), 0,
+                           [](int total, JobData job) {
+                               return total + job.summand;
+                           });
+}
+
+int expectedTotal(const QVector<JobDataSet> &jobs)
+{
+    return std::accumulate(jobs.cbegin(), jobs.cend(), 0,
+                           [](int total, const JobDataSet &dataSet) {
+                               return total + expectedTotal(dataSet);
+                           });
+}
+
+class Id
+{
+public:
+    explicit Id(int threadId, int jobId)
+        : threadId { threadId }, jobId { jobId } { }
+
+    QString toString() const { return QStringLiteral("[%1.%2]").arg(threadId).arg(jobId); }
+
+private:
+    const int threadId;
+    const int jobId;
+};
+
+QDebug operator<<(QDebug debug, Id id)
+{
+    QDebugStateSaver saver(debug);
+    debug.noquote() << id.toString();
+    return debug;
+}
+
+class Job
+{
+public:
+    explicit Job(Total &total, JobData data, Id id)
+        : total { total }, data { data }, id { id } { }
+
+    void operator()()
+    {
+        log().nospace() << id << " sleep " << toMilliseconds(data.sleepingTime) << " ms...";
+        std::this_thread::sleep_for(data.sleepingTime);
+
+        const auto updatedTotal = (total += data.summand);
+        log().nospace() << id << " +" << data.summand << " => " << updatedTotal;
+    }
+
+private:
+    Total &total;
+    const JobData data;
+    const Id id;
+};
+
+class Enqueuer
+{
+public:
+    explicit Enqueuer(ConcurrentQueue &queue, Total &total, const JobDataSet &jobs, int threadId)
+        : queue { queue }, total { total }, jobs { jobs }, threadId { threadId } { }
+
+    void operator()()
+    {
+        const char *const jobStr = jobs.size() == 1 ? "job" : "jobs";
+        log() << QStringLiteral("#%1 enqueuing %2 %3...").arg(threadId).arg(jobs.size()).arg(jobStr);
+        for (int i = 0; i < jobs.size(); ++i)
+            queue.enqueue(Job(total, jobs.at(i), Id(threadId, i + 1)));
+        log() << QStringLiteral("#%1 enqueuing complete.").arg(threadId);
+    }
+
+private:
+    ConcurrentQueue &queue;
+    Total &total;
+    const JobDataSet jobs;
+    const int threadId;
+};
+
+}
+
+Q_DECLARE_METATYPE(JobData)
+
+class ConcurrentQueueTest : public QObject
+{
+    Q_OBJECT
+private slots:
+    void init();
+
+    void singleUserThread_data();
+    void singleUserThread();
+
+    void multipleUserThreads_data();
+    void multipleUserThreads();
+
+private:
+    static constexpr int primaryThreadId { 0 };
+
+    QString messageFormatString(int threadCount) const
+    {
+        auto format = QStringLiteral("#%1 %5 %2 %3 => %4").arg(primaryThreadId);
+        const char *const threadStr = threadCount == 1 ? "thread" : "threads";
+        return format.arg(threadCount).arg(threadStr).arg(total.load());
+    }
+
+    void printStartedMessage(int threadCount) const
+    {
+        log() << messageFormatString(threadCount).arg("started");
+    }
+    void printWaitedMessage(int threadCount) const
+    {
+        log() << messageFormatString(threadCount).arg("waited for");
+    }
+
+    Total total { 0 };
+};
+
+void ConcurrentQueueTest::init()
+{
+    total = 0;
+}
+
+void ConcurrentQueueTest::singleUserThread_data()
+{
+    QTest::addColumn<int>("threadCount");
+    QTest::addColumn<JobDataSet>("jobs");
+
+    using ms = chrono::milliseconds;
+
+    QTest::newRow("-") << 0 << JobDataSet {};
+    QTest::newRow("0") << 7 << JobDataSet {};
+    QTest::newRow("A") << 1 << JobDataSet { { 5, ms(0) } };
+    QTest::newRow("B") << 5 << JobDataSet { { 12, ms(1) } };
+    QTest::newRow("C") << 1 << JobDataSet { { 1, ms(0) }, { 5, ms(2) }, { 3, ms(1) } };
+    QTest::newRow("D") << 4 << JobDataSet { { 20, ms(1) }, { 8, ms(5) }, { 5, ms(2) } };
+    QTest::newRow("E") << 2 << JobDataSet { { 1, ms(2) }, { 2, ms(1) } };
+    QTest::newRow("F") << 3 << JobDataSet { { 8, ms(3) }, { 5, ms(4) }, { 2, ms(1) }, { 11, ms(1) }, { 100, ms(3) } };
+}
+
+void ConcurrentQueueTest::singleUserThread()
+{
+    QFETCH(const int, threadCount);
+    QFETCH(const JobDataSet, jobs);
+
+    ConcurrentQueue queue(threadCount);
+    printStartedMessage(threadCount);
+
+    Enqueuer(queue, total, jobs, primaryThreadId)();
+
+    queue.waitAll();
+    printWaitedMessage(threadCount);
+
+    QCOMPARE(total.load(), expectedTotal(jobs));
+}
+
+void ConcurrentQueueTest::multipleUserThreads_data()
+{
+    QTest::addColumn<int>("threadCount");
+    QTest::addColumn<QVector<JobDataSet>>("jobs");
+
+    using ms = chrono::milliseconds;
+
+    JobDataSet jobs1 { { 1, ms(1) } };
+    JobDataSet jobs2 { { 2, ms(4) } };
+    QVector<JobDataSet> allJobs { jobs1, jobs2 };
+    QTest::newRow("A1") << 1 << allJobs;
+    QTest::newRow("A2") << 2 << allJobs;
+
+    jobs1.push_back({ 5, ms(3) });
+    jobs2.push_back({ 10, ms(1) });
+    allJobs = { jobs1, jobs2 };
+    QTest::newRow("B1") << 2 << allJobs;
+    QTest::newRow("B2") << 3 << allJobs;
+    QTest::newRow("B3") << 8 << allJobs;
+
+    jobs1.push_back({ 20, ms(0) });
+    jobs2.push_back({ 40, ms(2) });
+    allJobs = { jobs1, jobs2 };
+    QTest::newRow("C") << 4 << allJobs;
+
+    JobDataSet jobs3 { { 80, ms(0) }, { 160, ms(2) }, { 320, ms(1) }, { 640, ms(0) }, { 2000, ms(3) } };
+    allJobs.push_back(jobs3);
+    QTest::newRow("D1") << 3 << allJobs;
+    QTest::newRow("D2") << 5 << allJobs;
+
+    JobDataSet jobs4 { { 4000, ms(1) }, { 8000, ms(3) } };
+    allJobs.push_back(jobs4);
+    QTest::newRow("E1") << 4 << allJobs;
+    QTest::newRow("E2") << 6 << allJobs;
+}
+
+void ConcurrentQueueTest::multipleUserThreads()
+{
+    QFETCH(const int, threadCount);
+    QFETCH(const QVector<JobDataSet>, jobs);
+
+    ConcurrentQueue queue(threadCount);
+    printStartedMessage(threadCount);
+
+    if (!jobs.empty()) {
+        std::vector<std::thread> enqueuerThreads;
+        enqueuerThreads.reserve(jobs.size() - 1);
+        for (int i = 1; i < jobs.size(); ++i)
+            enqueuerThreads.emplace_back(Enqueuer(queue, total, jobs.at(i), i));
+
+        Enqueuer(queue, total, jobs.constFirst(), primaryThreadId)();
+        for (auto &t : enqueuerThreads)
+            t.join();
+    }
+
+    queue.waitAll();
+    printWaitedMessage(threadCount);
+
+    QCOMPARE(total.load(), expectedTotal(jobs));
+}
+
+QTEST_APPLESS_MAIN(ConcurrentQueueTest)
+
+#include "concurrent_queue_test.moc"

--- a/tests/concurrent_queue_test/concurrent_queue_test.pro
+++ b/tests/concurrent_queue_test/concurrent_queue_test.pro
@@ -1,0 +1,7 @@
+include(../qt_test.pri)
+
+PATH_TO_common = ../../common
+
+INCLUDEPATH += $$PATH_TO_common
+HEADERS += $${PATH_TO_common}/concurrent_queue.h
+SOURCES += concurrent_queue_test.cpp

--- a/tests/concurrent_queue_test/concurrent_queue_test.pro
+++ b/tests/concurrent_queue_test/concurrent_queue_test.pro
@@ -4,4 +4,6 @@ PATH_TO_common = ../../common
 
 INCLUDEPATH += $$PATH_TO_common
 HEADERS += $${PATH_TO_common}/concurrent_queue.h
-SOURCES += concurrent_queue_test.cpp
+SOURCES += \
+    $${PATH_TO_common}/concurrent_queue.cpp \
+    concurrent_queue_test.cpp

--- a/tests/qt_test.pri
+++ b/tests/qt_test.pri
@@ -1,0 +1,9 @@
+QT += testlib
+QT -= gui
+
+CONFIG += qt console warn_on testcase no_testcase_installs
+CONFIG -= app_bundle
+
+TEMPLATE = app
+
+include(../config.pri)

--- a/tests/tests.pro
+++ b/tests/tests.pro
@@ -1,0 +1,2 @@
+TEMPLATE = subdirs
+SUBDIRS += concurrent_queue_test


### PR DESCRIPTION
See the commit messages for details.

I figured that *concurrent_queue_test* does not require any sophisticated testing framework features. Since Qt Test works just fine for this purpose, I decided not to try out *Catch2* (as discussed in #201) for now.

Downsides of setting up a *Catch2 v3* development version dependency right now:
1. The development version is not yet very stable or well-documented. So YACReader's testing code might require frequent revisions when *Catch2* is updated.
2. *Catch2* is built with CMake, which is the build system YACReader is going to adopt in the future (see #73). But until CMake is actually adopted, mixing qmake and CMake can be unwieldy and inconvenient.
3. YACReader code is generally poorly prepared for testing, so I don't expect many tests to be written in the nearest future. The refactoring necessary to improve testability can take a lot of time. Thus a more convenient testing framework is unlikely to be highly beneficial soon.
4. Perhaps by the time YACReader code is ready for extensive testing, another testing framework would become more suitable for this purpose.
5. Qt Test is part of Qt Base, is very stable and does not require additional dependencies. In the end, Qt Test can be used interchangeably with a more advanced testing framework, whichever is more convenient for each particular testing task.