### PR TITLE
Clazy autorefactoring for SIGNAL/SLOT to new syntax

### DIFF
--- a/YACReader/bookmarks_dialog.cpp
+++ b/YACReader/bookmarks_dialog.cpp
@@ -69,7 +69,7 @@ BookmarksDialog::BookmarksDialog(QWidget *parent)
 
     cancel = new QPushButton(tr("Close"));
     cancel->setFlat(true);
-    connect(cancel, SIGNAL(clicked()), this, SLOT(hide()));
+    connect(cancel, &QAbstractButton::clicked, this, &QWidget::hide);
     buttons->addStretch();
     buttons->addWidget(cancel);
 

--- a/YACReader/goto_dialog.cpp
+++ b/YACReader/goto_dialog.cpp
@@ -21,9 +21,9 @@ void GoToDialog::setupUI()
     textLabel->setAlignment(Qt::AlignRight | Qt::AlignVCenter);
 
     accept = new QPushButton(tr("Go To"));
-    connect(accept, SIGNAL(clicked()), this, SLOT(goTo()));
+    connect(accept, &QAbstractButton::clicked, this, &GoToDialog::goTo);
     cancel = new QPushButton(tr("Cancel"));
-    connect(cancel, SIGNAL(clicked()), this, SLOT(close()));
+    connect(cancel, &QAbstractButton::clicked, this, &QWidget::close);
 
     auto topLayout = new QHBoxLayout;
 

--- a/YACReader/goto_flow.cpp
+++ b/YACReader/goto_flow.cpp
@@ -29,7 +29,7 @@ GoToFlow::GoToFlow(QWidget *parent, FlowType flowType)
     : GoToFlowWidget(parent), ready(false)
 {
     updateTimer = new QTimer;
-    connect(updateTimer, SIGNAL(timeout()), this, SLOT(updateImageData()));
+    connect(updateTimer, &QTimer::timeout, this, &GoToFlow::updateImageData);
 
     worker = new PageLoader(&mutexGoToFlow);
 
@@ -38,13 +38,13 @@ GoToFlow::GoToFlow(QWidget *parent, FlowType flowType)
     imageSize = Configuration::getConfiguration().getGotoSlideSize();
 
     flow->setSlideSize(imageSize);
-    connect(flow, SIGNAL(centerIndexChanged(int)), this, SLOT(setPageNumber(int)));
-    connect(flow, SIGNAL(selected(unsigned int)), this, SIGNAL(goToPage(unsigned int)));
+    connect(flow, &PictureFlow::centerIndexChanged, this, &GoToFlowWidget::setPageNumber);
+    connect(flow, &YACReaderFlow::selected, this, &GoToFlow::goToPage);
     connect(flow, &PictureFlow::centerIndexChanged, this, &GoToFlow::preload);
     connect(flow, &PictureFlow::centerIndexChangedSilent, this, &GoToFlow::preload);
 
     connect(toolBar, SIGNAL(goTo(unsigned int)), this, SIGNAL(goToPage(unsigned int)));
-    connect(toolBar, SIGNAL(setCenter(unsigned int)), flow, SLOT(showSlide(unsigned int)));
+    connect(toolBar, &GoToFlowToolBar::setCenter, flow, &PictureFlow::showSlide);
 
     mainLayout->addWidget(flow);
     toolBar->raise();

--- a/YACReader/goto_flow.cpp
+++ b/YACReader/goto_flow.cpp
@@ -43,7 +43,7 @@ GoToFlow::GoToFlow(QWidget *parent, FlowType flowType)
     connect(flow, &PictureFlow::centerIndexChanged, this, &GoToFlow::preload);
     connect(flow, &PictureFlow::centerIndexChangedSilent, this, &GoToFlow::preload);
 
-    connect(toolBar, SIGNAL(goTo(unsigned int)), this, SIGNAL(goToPage(unsigned int)));
+    connect(toolBar, &GoToFlowToolBar::goToPage, this, &GoToFlow::goToPage);
     connect(toolBar, &GoToFlowToolBar::setCenter, flow, &PictureFlow::showSlide);
 
     mainLayout->addWidget(flow);

--- a/YACReader/goto_flow.h
+++ b/YACReader/goto_flow.h
@@ -63,9 +63,6 @@ public slots:
     void setFlowType(FlowType flowType) override;
     void updateConfig(QSettings *settings) override;
     void setFlowRightToLeft(bool b) override;
-
-signals:
-    void goToPage(unsigned int page);
 };
 
 //-----------------------------------------------------------------------------

--- a/YACReader/goto_flow_gl.cpp
+++ b/YACReader/goto_flow_gl.cpp
@@ -21,11 +21,11 @@ GoToFlowGL::GoToFlowGL(QWidget *parent, FlowType flowType)
     imageSize = Configuration::getConfiguration().getGotoSlideSize();
 
     flow->setSlideSize(imageSize);
-    connect(flow, SIGNAL(centerIndexChanged(int)), this, SLOT(setPageNumber(int)));
-    connect(flow, SIGNAL(selected(unsigned int)), this, SIGNAL(goToPage(unsigned int)));
+    connect(flow, &YACReaderFlowGL::centerIndexChanged, this, &GoToFlowWidget::setPageNumber);
+    connect(flow, &YACReaderFlowGL::selected, this, &GoToFlowGL::goToPage);
 
     connect(toolBar, SIGNAL(goTo(unsigned int)), this, SIGNAL(goToPage(unsigned int)));
-    connect(toolBar, SIGNAL(setCenter(unsigned int)), flow, SLOT(setCenterIndex(unsigned int)));
+    connect(toolBar, &GoToFlowToolBar::setCenter, flow, &YACReaderFlowGL::setCenterIndex);
 
     mainLayout->addWidget(flow);
     toolBar->raise();

--- a/YACReader/goto_flow_gl.cpp
+++ b/YACReader/goto_flow_gl.cpp
@@ -24,7 +24,7 @@ GoToFlowGL::GoToFlowGL(QWidget *parent, FlowType flowType)
     connect(flow, &YACReaderFlowGL::centerIndexChanged, this, &GoToFlowWidget::setPageNumber);
     connect(flow, &YACReaderFlowGL::selected, this, &GoToFlowGL::goToPage);
 
-    connect(toolBar, SIGNAL(goTo(unsigned int)), this, SIGNAL(goToPage(unsigned int)));
+    connect(toolBar, &GoToFlowToolBar::goToPage, this, &GoToFlowGL::goToPage);
     connect(toolBar, &GoToFlowToolBar::setCenter, flow, &YACReaderFlowGL::setCenterIndex);
 
     mainLayout->addWidget(flow);

--- a/YACReader/goto_flow_gl.h
+++ b/YACReader/goto_flow_gl.h
@@ -27,9 +27,6 @@ public:
     void updateConfig(QSettings *settings);
     void setFlowRightToLeft(bool b) override;
 
-signals:
-    void goToPage(unsigned int page);
-
 private:
     YACReaderPageFlowGL *flow;
     void keyPressEvent(QKeyEvent *event) override;

--- a/YACReader/goto_flow_toolbar.cpp
+++ b/YACReader/goto_flow_toolbar.cpp
@@ -57,7 +57,7 @@ GoToFlowToolBar::GoToFlowToolBar(QWidget *parent)
     centerButton->setStyleSheet(centerButtonCSS);
     centerButton->setFixedSize(26, 50);
     centerButton->setAttribute(Qt::WA_LayoutUsesWidgetRect, true);
-    connect(centerButton, SIGNAL(clicked()), this, SLOT(centerSlide()));
+    connect(centerButton, &QAbstractButton::clicked, this, &GoToFlowToolBar::centerSlide);
 
     QString goToButtonCSS = "QPushButton {background-image: url(:/images/imgGoToSlide.png); width: 100%; height:100%; background-repeat: none; border: none;} "
                             "QPushButton:focus { border: none; outline: none;}"

--- a/YACReader/goto_flow_toolbar.cpp
+++ b/YACReader/goto_flow_toolbar.cpp
@@ -112,7 +112,7 @@ void GoToFlowToolBar::goTo()
 {
     unsigned int page = edit->text().toInt();
     if (page >= 1 && page <= v->top()) {
-        emit(goTo(page - 1));
+        emit(goToPage(page - 1));
     }
 }
 

--- a/YACReader/goto_flow_toolbar.cpp
+++ b/YACReader/goto_flow_toolbar.cpp
@@ -32,7 +32,7 @@ GoToFlowToolBar::GoToFlowToolBar(QWidget *parent)
             "  border-radius: 1px;"
             "}");
 
-    connect(slider, &QSlider::valueChanged, this, [&](int v) { emit(setCenter(v)); });
+    connect(slider, &QSlider::valueChanged, this, [this](int v) { emit(setCenter(v)); });
 
     pageHint = new QLabel("<b>" + tr("Page : ") + "</b>", this);
     v = new QIntValidator(this);
@@ -47,7 +47,7 @@ GoToFlowToolBar::GoToFlowToolBar(QWidget *parent)
     //edit->resize(QSize(54,50));
     edit->setSizePolicy(QSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed));
     //edit->setAutoFillBackground(false);
-    connect(edit, SIGNAL(returnPressed()), this, SLOT(goTo()));
+    connect(edit, &QLineEdit::returnPressed, this, &GoToFlowToolBar::goTo);
 
     QString centerButtonCSS = "QPushButton {background-image: url(:/images/imgCenterSlide.png); width: 100%; height:100%; background-repeat: none; border: none;} "
                               "QPushButton:focus { border: none; outline: none;}"
@@ -68,7 +68,7 @@ GoToFlowToolBar::GoToFlowToolBar(QWidget *parent)
     goToButton->setFixedSize(32, 50);
     goToButton->setAttribute(Qt::WA_LayoutUsesWidgetRect, true);
 
-    connect(goToButton, SIGNAL(clicked()), this, SLOT(goTo()));
+    connect(goToButton, &QPushButton::clicked, this, &GoToFlowToolBar::goTo);
 
     normalLayout->setMargin(0);
     normalLayout->setSpacing(0);
@@ -110,7 +110,7 @@ void GoToFlowToolBar::setTop(int numPages)
 void GoToFlowToolBar::goTo()
 {
     if (edit->text().toInt() != 0)
-        emit(goTo(edit->text().toInt() - 1));
+        emit(goToPage(edit->text().toInt() - 1));
 }
 
 void GoToFlowToolBar::centerSlide()

--- a/YACReader/goto_flow_toolbar.h
+++ b/YACReader/goto_flow_toolbar.h
@@ -34,7 +34,7 @@ public slots:
     void updateOptions();
 signals:
     void setCenter(unsigned int);
-    void goTo(unsigned int);
+    void goToPage(unsigned int);
 };
 
 #endif

--- a/YACReader/goto_flow_widget.h
+++ b/YACReader/goto_flow_widget.h
@@ -31,6 +31,8 @@ public slots:
     virtual void updateSize();
     virtual void updateConfig(QSettings *settings);
     virtual void setFlowRightToLeft(bool b) = 0;
+signals:
+    void goToPage(unsigned int);
 
 protected:
     void keyPressEvent(QKeyEvent *event) override;

--- a/YACReader/main_window_viewer.cpp
+++ b/YACReader/main_window_viewer.cpp
@@ -213,7 +213,7 @@ void MainWindowViewer::createActions()
     openAction->setToolTip(tr("Open a comic"));
     openAction->setData(OPEN_ACTION_Y);
     openAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(OPEN_ACTION_Y));
-    connect(openAction, SIGNAL(triggered()), this, SLOT(open()));
+    connect(openAction, &QAction::triggered, this, QOverload<>::of(&MainWindowViewer::open));
 
 #ifdef Q_OS_MAC
     newInstanceAction = new QAction(tr("New instance"), this);
@@ -438,7 +438,7 @@ void MainWindowViewer::createActions()
     optionsAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(OPTIONS_ACTION_Y));
     optionsAction->setIcon(QIcon(":/images/viewer_toolbar/options.png"));
 
-    connect(optionsAction, SIGNAL(triggered()), optionsDialog, SLOT(show()));
+    connect(optionsAction, &QAction::triggered, optionsDialog, &OptionsDialog::show);
 
     helpAboutAction = new QAction(tr("Help"), this);
     helpAboutAction->setToolTip(tr("Help, About YACReader"));

--- a/YACReader/main_window_viewer.cpp
+++ b/YACReader/main_window_viewer.cpp
@@ -139,11 +139,11 @@ void MainWindowViewer::setupUI()
     //setUnifiedTitleAndToolBarOnMac(true);
 
     viewer = new Viewer(this);
-    connect(viewer, SIGNAL(reset()), this, SLOT(processReset()));
+    connect(viewer, &Viewer::reset, this, &MainWindowViewer::processReset);
     //detected end of comic
-    connect(viewer, SIGNAL(openNextComic()), this, SLOT(openNextComic()));
+    connect(viewer, &Viewer::openNextComic, this, &MainWindowViewer::openNextComic);
     //detected start of comic
-    connect(viewer, SIGNAL(openPreviousComic()), this, SLOT(openPreviousComic()));
+    connect(viewer, &Viewer::openPreviousComic, this, &MainWindowViewer::openPreviousComic);
 
     setCentralWidget(viewer);
     int heightDesktopResolution = QApplication::desktop()->screenGeometry().height();
@@ -163,15 +163,15 @@ void MainWindowViewer::setupUI()
     had->loadHelp(":/files/helpYACReader.html");
 
     optionsDialog = new OptionsDialog(this);
-    connect(optionsDialog, SIGNAL(accepted()), viewer, SLOT(updateOptions()));
-    connect(optionsDialog, SIGNAL(optionsChanged()), this, SLOT(reloadOptions()));
-    connect(optionsDialog, SIGNAL(changedFilters(int, int, int)), viewer, SLOT(updateFilters(int, int, int)));
+    connect(optionsDialog, &QDialog::accepted, viewer, &Viewer::updateOptions);
+    connect(optionsDialog, &YACReaderOptionsDialog::optionsChanged, this, &MainWindowViewer::reloadOptions);
+    connect(optionsDialog, &OptionsDialog::changedFilters, viewer, &Viewer::updateFilters);
     connect(optionsDialog, &OptionsDialog::changedImageOptions, viewer, &Viewer::updatePage);
 
     optionsDialog->restoreOptions(settings);
     //shortcutsDialog = new ShortcutsDialog(this);
     editShortcutsDialog = new EditShortcutsDialog(this);
-    connect(optionsDialog, SIGNAL(editShortcuts()), editShortcutsDialog, SLOT(show()));
+    connect(optionsDialog, &YACReaderOptionsDialog::editShortcuts, editShortcutsDialog, &QWidget::show);
 
     createActions();
     setUpShortcutsManagement();
@@ -240,13 +240,13 @@ void MainWindowViewer::createActions()
     openFolderAction->setToolTip(tr("Open image folder"));
     openFolderAction->setData(OPEN_FOLDER_ACTION_Y);
     openFolderAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(OPEN_FOLDER_ACTION_Y));
-    connect(openFolderAction, SIGNAL(triggered()), this, SLOT(openFolder()));
+    connect(openFolderAction, &QAction::triggered, this, &MainWindowViewer::openFolder);
 
     openLatestComicAction = new QAction(tr("Open latest comic"), this);
     openLatestComicAction->setToolTip(tr("Open the latest comic opened in the previous reading session"));
     openLatestComicAction->setData(OPEN_LATEST_COMIC_Y);
     openLatestComicAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(OPEN_LATEST_COMIC_Y));
-    connect(openLatestComicAction, SIGNAL(triggered()), this, SLOT(openLatestComic()));
+    connect(openLatestComicAction, &QAction::triggered, this, &MainWindowViewer::openLatestComic);
 
     QAction *recentFileAction = nullptr;
     //TODO: Replace limit with a configurable value
@@ -267,7 +267,7 @@ void MainWindowViewer::createActions()
     saveImageAction->setDisabled(true);
     saveImageAction->setData(SAVE_IMAGE_ACTION_Y);
     saveImageAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(SAVE_IMAGE_ACTION_Y));
-    connect(saveImageAction, SIGNAL(triggered()), this, SLOT(saveImage()));
+    connect(saveImageAction, &QAction::triggered, this, &MainWindowViewer::saveImage);
 
     openComicOnTheLeftAction = new QAction(tr("Previous Comic"), this);
     openComicOnTheLeftAction->setIcon(QIcon(":/images/viewer_toolbar/openPrevious.png"));
@@ -292,7 +292,7 @@ void MainWindowViewer::createActions()
     goToPageOnTheLeftAction->setDisabled(true);
     goToPageOnTheLeftAction->setData(PREV_ACTION_Y);
     goToPageOnTheLeftAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(PREV_ACTION_Y));
-    connect(goToPageOnTheLeftAction, SIGNAL(triggered()), viewer, SLOT(left()));
+    connect(goToPageOnTheLeftAction, &QAction::triggered, viewer, &Viewer::left);
 
     goToPageOnTheRightAction = new QAction(tr("&Next"), this);
     goToPageOnTheRightAction->setIcon(QIcon(":/images/viewer_toolbar/next.png"));
@@ -301,7 +301,7 @@ void MainWindowViewer::createActions()
     goToPageOnTheRightAction->setDisabled(true);
     goToPageOnTheRightAction->setData(NEXT_ACTION_Y);
     goToPageOnTheRightAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(NEXT_ACTION_Y));
-    connect(goToPageOnTheRightAction, SIGNAL(triggered()), viewer, SLOT(right()));
+    connect(goToPageOnTheRightAction, &QAction::triggered, viewer, &Viewer::right);
 
     adjustHeightAction = new QAction(tr("Fit Height"), this);
     adjustHeightAction->setIcon(QIcon(":/images/viewer_toolbar/toHeight.png"));
@@ -312,7 +312,7 @@ void MainWindowViewer::createActions()
     adjustHeightAction->setData(ADJUST_HEIGHT_ACTION_Y);
     adjustHeightAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(ADJUST_HEIGHT_ACTION_Y));
     adjustHeightAction->setCheckable(true);
-    connect(adjustHeightAction, SIGNAL(triggered()), this, SLOT(fitToHeight()));
+    connect(adjustHeightAction, &QAction::triggered, this, &MainWindowViewer::fitToHeight);
 
     adjustWidthAction = new QAction(tr("Fit Width"), this);
     adjustWidthAction->setIcon(QIcon(":/images/viewer_toolbar/toWidth.png"));
@@ -323,7 +323,7 @@ void MainWindowViewer::createActions()
     adjustWidthAction->setData(ADJUST_WIDTH_ACTION_Y);
     adjustWidthAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(ADJUST_WIDTH_ACTION_Y));
     adjustWidthAction->setCheckable(true);
-    connect(adjustWidthAction, SIGNAL(triggered()), this, SLOT(fitToWidth()));
+    connect(adjustWidthAction, &QAction::triggered, this, &MainWindowViewer::fitToWidth);
 
     adjustToFullSizeAction = new QAction(tr("Show full size"), this);
     adjustToFullSizeAction->setIcon(QIcon(":/images/viewer_toolbar/full.png"));
@@ -332,7 +332,7 @@ void MainWindowViewer::createActions()
     adjustToFullSizeAction->setData(ADJUST_TO_FULL_SIZE_ACTION_Y);
     adjustToFullSizeAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(ADJUST_TO_FULL_SIZE_ACTION_Y));
     adjustToFullSizeAction->setCheckable(true);
-    connect(adjustToFullSizeAction, SIGNAL(triggered()), this, SLOT(adjustToFullSizeSwitch()));
+    connect(adjustToFullSizeAction, &QAction::triggered, this, &MainWindowViewer::adjustToFullSizeSwitch);
 
     fitToPageAction = new QAction(tr("Fit to page"), this);
     fitToPageAction->setIcon(QIcon(":/images/viewer_toolbar/fitToPage.png"));
@@ -340,7 +340,7 @@ void MainWindowViewer::createActions()
     fitToPageAction->setData(FIT_TO_PAGE_ACTION_Y);
     fitToPageAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(FIT_TO_PAGE_ACTION_Y));
     fitToPageAction->setCheckable(true);
-    connect(fitToPageAction, SIGNAL(triggered()), this, SLOT(fitToPageSwitch()));
+    connect(fitToPageAction, &QAction::triggered, this, &MainWindowViewer::fitToPageSwitch);
 
     //fit modes have to be exclusive and checkable
     auto fitModes = new QActionGroup(this);
@@ -370,7 +370,7 @@ void MainWindowViewer::createActions()
     resetZoomAction->setDisabled(true);
     resetZoomAction->setData(RESET_ZOOM_ACTION_Y);
     resetZoomAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(RESET_ZOOM_ACTION_Y));
-    connect(resetZoomAction, SIGNAL(triggered()), this, SLOT(resetZoomLevel()));
+    connect(resetZoomAction, &QAction::triggered, this, &MainWindowViewer::resetZoomLevel);
 
     showZoomSliderlAction = new QAction(tr("Show zoom slider"), this);
     showZoomSliderlAction->setIcon(QIcon(":/images/viewer_toolbar/zoom.png"));
@@ -380,27 +380,27 @@ void MainWindowViewer::createActions()
     increasePageZoomAction->setDisabled(true);
     increasePageZoomAction->setData(ZOOM_PLUS_ACTION_Y);
     increasePageZoomAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(ZOOM_PLUS_ACTION_Y));
-    connect(increasePageZoomAction, SIGNAL(triggered()), this, SLOT(increasePageZoomLevel()));
+    connect(increasePageZoomAction, &QAction::triggered, this, &MainWindowViewer::increasePageZoomLevel);
 
     decreasePageZoomAction = new QAction(tr("Zoom-"), this);
     decreasePageZoomAction->setDisabled(true);
     decreasePageZoomAction->setData(ZOOM_MINUS_ACTION_Y);
     decreasePageZoomAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(ZOOM_MINUS_ACTION_Y));
-    connect(decreasePageZoomAction, SIGNAL(triggered()), this, SLOT(decreasePageZoomLevel()));
+    connect(decreasePageZoomAction, &QAction::triggered, this, &MainWindowViewer::decreasePageZoomLevel);
 
     leftRotationAction = new QAction(tr("Rotate image to the left"), this);
     leftRotationAction->setIcon(QIcon(":/images/viewer_toolbar/rotateL.png"));
     leftRotationAction->setDisabled(true);
     leftRotationAction->setData(LEFT_ROTATION_ACTION_Y);
     leftRotationAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(LEFT_ROTATION_ACTION_Y));
-    connect(leftRotationAction, SIGNAL(triggered()), viewer, SLOT(rotateLeft()));
+    connect(leftRotationAction, &QAction::triggered, viewer, &Viewer::rotateLeft);
 
     rightRotationAction = new QAction(tr("Rotate image to the right"), this);
     rightRotationAction->setIcon(QIcon(":/images/viewer_toolbar/rotateR.png"));
     rightRotationAction->setDisabled(true);
     rightRotationAction->setData(RIGHT_ROTATION_ACTION_Y);
     rightRotationAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(RIGHT_ROTATION_ACTION_Y));
-    connect(rightRotationAction, SIGNAL(triggered()), viewer, SLOT(rotateRight()));
+    connect(rightRotationAction, &QAction::triggered, viewer, &Viewer::rotateRight);
 
     doublePageAction = new QAction(tr("Double page mode"), this);
     doublePageAction->setToolTip(tr("Switch to double page mode"));
@@ -410,7 +410,7 @@ void MainWindowViewer::createActions()
     doublePageAction->setChecked(Configuration::getConfiguration().getDoublePage());
     doublePageAction->setData(DOUBLE_PAGE_ACTION_Y);
     doublePageAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(DOUBLE_PAGE_ACTION_Y));
-    connect(doublePageAction, SIGNAL(triggered()), viewer, SLOT(doublePageSwitch()));
+    connect(doublePageAction, &QAction::triggered, viewer, &Viewer::doublePageSwitch);
 
     //inversed pictures mode
     doubleMangaPageAction = new QAction(tr("Double page manga mode"), this);
@@ -421,7 +421,7 @@ void MainWindowViewer::createActions()
     doubleMangaPageAction->setChecked(Configuration::getConfiguration().getDoubleMangaPage());
     doubleMangaPageAction->setData(DOUBLE_MANGA_PAGE_ACTION_Y);
     doubleMangaPageAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(DOUBLE_MANGA_PAGE_ACTION_Y));
-    connect(doubleMangaPageAction, SIGNAL(triggered()), viewer, SLOT(doubleMangaPageSwitch()));
+    connect(doubleMangaPageAction, &QAction::triggered, viewer, &Viewer::doubleMangaPageSwitch);
     connect(doubleMangaPageAction, &QAction::triggered, this, &MainWindowViewer::doubleMangaPageSwitch);
 
     goToPageAction = new QAction(tr("Go To"), this);
@@ -430,7 +430,7 @@ void MainWindowViewer::createActions()
     goToPageAction->setToolTip(tr("Go to page ..."));
     goToPageAction->setData(GO_TO_PAGE_ACTION_Y);
     goToPageAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(GO_TO_PAGE_ACTION_Y));
-    connect(goToPageAction, SIGNAL(triggered()), viewer, SLOT(showGoToDialog()));
+    connect(goToPageAction, &QAction::triggered, viewer, &Viewer::showGoToDialog);
 
     optionsAction = new QAction(tr("Options"), this);
     optionsAction->setToolTip(tr("YACReader options"));
@@ -445,7 +445,7 @@ void MainWindowViewer::createActions()
     helpAboutAction->setIcon(QIcon(":/images/viewer_toolbar/help.png"));
     helpAboutAction->setData(HELP_ABOUT_ACTION_Y);
     helpAboutAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(HELP_ABOUT_ACTION_Y));
-    connect(helpAboutAction, SIGNAL(triggered()), had, SLOT(show()));
+    connect(helpAboutAction, &QAction::triggered, had, &QWidget::show);
 
     showMagnifyingGlassAction = new QAction(tr("Magnifying glass"), this);
     showMagnifyingGlassAction->setToolTip(tr("Switch Magnifying glass"));
@@ -454,7 +454,7 @@ void MainWindowViewer::createActions()
     showMagnifyingGlassAction->setCheckable(true);
     showMagnifyingGlassAction->setData(SHOW_MAGNIFYING_GLASS_ACTION_Y);
     showMagnifyingGlassAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(SHOW_MAGNIFYING_GLASS_ACTION_Y));
-    connect(showMagnifyingGlassAction, SIGNAL(triggered()), viewer, SLOT(magnifyingGlassSwitch()));
+    connect(showMagnifyingGlassAction, &QAction::triggered, viewer, &Viewer::magnifyingGlassSwitch);
 
     setBookmarkAction = new QAction(tr("Set bookmark"), this);
     setBookmarkAction->setToolTip(tr("Set a bookmark on the current page"));
@@ -463,9 +463,9 @@ void MainWindowViewer::createActions()
     setBookmarkAction->setCheckable(true);
     setBookmarkAction->setData(SET_BOOKMARK_ACTION_Y);
     setBookmarkAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(SET_BOOKMARK_ACTION_Y));
-    connect(setBookmarkAction, SIGNAL(triggered(bool)), viewer, SLOT(setBookmark(bool)));
-    connect(viewer, SIGNAL(pageAvailable(bool)), setBookmarkAction, SLOT(setEnabled(bool)));
-    connect(viewer, SIGNAL(pageIsBookmark(bool)), setBookmarkAction, SLOT(setChecked(bool)));
+    connect(setBookmarkAction, &QAction::triggered, viewer, &Viewer::setBookmark);
+    connect(viewer, &Viewer::pageAvailable, setBookmarkAction, &QAction::setEnabled);
+    connect(viewer, &Viewer::pageIsBookmark, setBookmarkAction, &QAction::setChecked);
 
     showBookmarksAction = new QAction(tr("Show bookmarks"), this);
     showBookmarksAction->setToolTip(tr("Show the bookmarks of the current comic"));
@@ -473,27 +473,27 @@ void MainWindowViewer::createActions()
     showBookmarksAction->setDisabled(true);
     showBookmarksAction->setData(SHOW_BOOKMARKS_ACTION_Y);
     showBookmarksAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(SHOW_BOOKMARKS_ACTION_Y));
-    connect(showBookmarksAction, SIGNAL(triggered()), viewer->getBookmarksDialog(), SLOT(show()));
+    connect(showBookmarksAction, &QAction::triggered, viewer->getBookmarksDialog(), &QWidget::show);
 
     showShorcutsAction = new QAction(tr("Show keyboard shortcuts"), this);
     showShorcutsAction->setIcon(QIcon(":/images/viewer_toolbar/shortcuts.png"));
     showShorcutsAction->setData(SHOW_SHORCUTS_ACTION_Y);
     showShorcutsAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(SHOW_SHORCUTS_ACTION_Y));
     //connect(showShorcutsAction, SIGNAL(triggered()),shortcutsDialog,SLOT(show()));
-    connect(showShorcutsAction, SIGNAL(triggered()), editShortcutsDialog, SLOT(show()));
+    connect(showShorcutsAction, &QAction::triggered, editShortcutsDialog, &QWidget::show);
 
     showInfoAction = new QAction(tr("Show Info"), this);
     showInfoAction->setIcon(QIcon(":/images/viewer_toolbar/info.png"));
     showInfoAction->setDisabled(true);
     showInfoAction->setData(SHOW_INFO_ACTION_Y);
     showInfoAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(SHOW_INFO_ACTION_Y));
-    connect(showInfoAction, SIGNAL(triggered()), viewer, SLOT(informationSwitch()));
+    connect(showInfoAction, &QAction::triggered, viewer, &Viewer::informationSwitch);
 
     closeAction = new QAction(tr("Close"), this);
     closeAction->setIcon(QIcon(":/images/viewer_toolbar/close.png"));
     closeAction->setData(CLOSE_ACTION_Y);
     closeAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(CLOSE_ACTION_Y));
-    connect(closeAction, SIGNAL(triggered()), this, SLOT(close()));
+    connect(closeAction, &QAction::triggered, this, &QWidget::close);
 
     showDictionaryAction = new QAction(tr("Show Dictionary"), this);
     showDictionaryAction->setIcon(QIcon(":/images/viewer_toolbar/translator.png"));
@@ -501,7 +501,7 @@ void MainWindowViewer::createActions()
     showDictionaryAction->setDisabled(true);
     showDictionaryAction->setData(SHOW_DICTIONARY_ACTION_Y);
     showDictionaryAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(SHOW_DICTIONARY_ACTION_Y));
-    connect(showDictionaryAction, SIGNAL(triggered()), viewer, SLOT(translatorSwitch()));
+    connect(showDictionaryAction, &QAction::triggered, viewer, &Viewer::translatorSwitch);
 
     //deprecated
     alwaysOnTopAction = new QAction(tr("Always on top"), this);
@@ -511,19 +511,19 @@ void MainWindowViewer::createActions()
     alwaysOnTopAction->setChecked(Configuration::getConfiguration().getAlwaysOnTop());
     alwaysOnTopAction->setData(ALWAYS_ON_TOP_ACTION_Y);
     alwaysOnTopAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(ALWAYS_ON_TOP_ACTION_Y));
-    connect(alwaysOnTopAction, SIGNAL(triggered()), this, SLOT(alwaysOnTopSwitch()));
+    connect(alwaysOnTopAction, &QAction::triggered, this, &MainWindowViewer::alwaysOnTopSwitch);
 
     showFlowAction = new QAction(tr("Show go to flow"), this);
     showFlowAction->setIcon(QIcon(":/images/viewer_toolbar/flow.png"));
     showFlowAction->setDisabled(true);
     showFlowAction->setData(SHOW_FLOW_ACTION_Y);
     showFlowAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(SHOW_FLOW_ACTION_Y));
-    connect(showFlowAction, SIGNAL(triggered()), viewer, SLOT(goToFlowSwitch()));
+    connect(showFlowAction, &QAction::triggered, viewer, &Viewer::goToFlowSwitch);
 
     showEditShortcutsAction = new QAction(tr("Edit shortcuts"), this);
     showEditShortcutsAction->setData(SHOW_EDIT_SHORTCUTS_ACTION_Y);
     showEditShortcutsAction->setShortcut(ShortcutsManager::getShortcutsManager().getShortcut(SHOW_EDIT_SHORTCUTS_ACTION_Y));
-    connect(showEditShortcutsAction, SIGNAL(triggered()), editShortcutsDialog, SLOT(show()));
+    connect(showEditShortcutsAction, &QAction::triggered, editShortcutsDialog, &QWidget::show);
 }
 
 void MainWindowViewer::createToolBars()
@@ -584,9 +584,9 @@ void MainWindowViewer::createToolBars()
 
     comicToolBar->addAction(showZoomSliderlAction);
 
-    connect(showZoomSliderlAction, SIGNAL(triggered()), this, SLOT(toggleFitToWidthSlider()));
-    connect(zoomSliderAction, SIGNAL(zoomRatioChanged(int)), viewer, SLOT(updateZoomRatio(int)));
-    connect(viewer, SIGNAL(zoomUpdated(int)), zoomSliderAction, SLOT(updateZoomRatio(int)));
+    connect(showZoomSliderlAction, &QAction::triggered, this, &MainWindowViewer::toggleFitToWidthSlider);
+    connect(zoomSliderAction, &YACReaderSlider::zoomRatioChanged, viewer, &Viewer::updateZoomRatio);
+    connect(viewer, &Viewer::zoomUpdated, zoomSliderAction, &YACReaderSlider::updateZoomRatio);
 
     comicToolBar->addAction(leftRotationAction);
     comicToolBar->addAction(rightRotationAction);
@@ -1217,8 +1217,8 @@ void MainWindowViewer::checkNewVersion()
     if (lastCheck.isNull() || lastCheck.daysTo(current) >= conf.getNumDaysBetweenVersionChecks()) {
         versionChecker = new HttpVersionChecker();
 
-        connect(versionChecker, SIGNAL(newVersionDetected()),
-                this, SLOT(newVersion()));
+        connect(versionChecker, &HttpVersionChecker::newVersionDetected,
+                this, &MainWindowViewer::newVersion);
 
         QTimer::singleShot(100, versionChecker, &HttpVersionChecker::get);
 

--- a/YACReader/notifications_label_widget.cpp
+++ b/YACReader/notifications_label_widget.cpp
@@ -19,7 +19,7 @@ NotificationsLabelWidget::NotificationsLabelWidget(QWidget *parent)
     anim->setEndValue(0.0);
     anim->setEasingCurve(QEasingCurve::InExpo);
 
-    connect(anim, SIGNAL(finished()), this, SLOT(hide()));
+    connect(anim, &QAbstractAnimation::finished, this, &QWidget::hide);
 
     textLabel = new QLabel(this);
     textLabel->setAlignment(Qt::AlignVCenter | Qt::AlignHCenter);

--- a/YACReader/options_dialog.cpp
+++ b/YACReader/options_dialog.cpp
@@ -53,7 +53,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     path->addWidget(pathFindButton = new QPushButton(QIcon(":/images/find_folder.png"), ""));
     pathBox->setLayout(path);
 
-    connect(pathFindButton, SIGNAL(clicked()), this, SLOT(findFolder()));
+    connect(pathFindButton, &QAbstractButton::clicked, this, &OptionsDialog::findFolder);
 
     auto colorSelection = new QHBoxLayout;
     backgroundColor = new QLabel();
@@ -63,7 +63,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     backgroundColor->setAutoFillBackground(true);
 
     colorDialog = new QColorDialog(Qt::red, this);
-    connect(colorDialog, SIGNAL(colorSelected(QColor)), this, SLOT(updateColor(QColor)));
+    connect(colorDialog, &QColorDialog::colorSelected, this, &OptionsDialog::updateColor);
 
     QGroupBox *colorBox = new QGroupBox(tr("Background color"));
     //backgroundColor->setMinimumWidth(100);
@@ -72,26 +72,26 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     colorSelection->setStretchFactor(backgroundColor, 1);
     colorSelection->setStretchFactor(selectBackgroundColorButton, 0);
     //colorSelection->addStretch();
-    connect(selectBackgroundColorButton, SIGNAL(clicked()), colorDialog, SLOT(show()));
+    connect(selectBackgroundColorButton, &QAbstractButton::clicked, colorDialog, &QWidget::show);
     colorBox->setLayout(colorSelection);
 
     brightnessS = new YACReaderSpinSliderWidget(this, true);
     brightnessS->setRange(0, 100);
     //brightnessS->setText(tr("Brightness"));
     brightnessS->setTracking(false);
-    connect(brightnessS, SIGNAL(valueChanged(int)), this, SLOT(brightnessChanged(int)));
+    connect(brightnessS, &YACReaderSpinSliderWidget::valueChanged, this, &OptionsDialog::brightnessChanged);
 
     contrastS = new YACReaderSpinSliderWidget(this, true);
     contrastS->setRange(0, 250);
     //contrastS->setText(tr("Contrast"));
     contrastS->setTracking(false);
-    connect(contrastS, SIGNAL(valueChanged(int)), this, SLOT(contrastChanged(int)));
+    connect(contrastS, &YACReaderSpinSliderWidget::valueChanged, this, &OptionsDialog::contrastChanged);
 
     gammaS = new YACReaderSpinSliderWidget(this, true);
     gammaS->setRange(0, 250);
     //gammaS->setText(tr("Gamma"));
     gammaS->setTracking(false);
-    connect(gammaS, SIGNAL(valueChanged(int)), this, SLOT(gammaChanged(int)));
+    connect(gammaS, &YACReaderSpinSliderWidget::valueChanged, this, &OptionsDialog::gammaChanged);
     //connect(brightnessS,SIGNAL(valueChanged(int)),this,SIGNAL(changedOptions()));
 
     quickNavi = new QCheckBox(tr("Quick Navigation Mode"));
@@ -126,7 +126,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     layoutImage->addWidget(contrastS, 1, 1);
     layoutImage->addWidget(gammaS, 2, 1);
     QPushButton *pushButton = new QPushButton(tr("Reset"));
-    connect(pushButton, SIGNAL(pressed()), this, SLOT(resetImageConfig()));
+    connect(pushButton, &QAbstractButton::pressed, this, &OptionsDialog::resetImageConfig);
     layoutImage->addWidget(pushButton, 3, 0);
     layoutImage->setColumnStretch(1, 1);
 

--- a/YACReader/render.cpp
+++ b/YACReader/render.cpp
@@ -710,16 +710,16 @@ void Render::createComic(const QString &path)
         return;
     }
 
-    connect(comic, SIGNAL(errorOpening()), this, SIGNAL(errorOpening()), Qt::QueuedConnection);
-    connect(comic, SIGNAL(errorOpening(QString)), this, SIGNAL(errorOpening(QString)), Qt::QueuedConnection);
+    connect(comic, QOverload<>::of(&Comic::errorOpening), this, QOverload<>::of(&Render::errorOpening), Qt::QueuedConnection);
+    connect(comic, QOverload<QString>::of(&Comic::errorOpening), this, QOverload<QString>::of(&Render::errorOpening), Qt::QueuedConnection);
     connect(comic, &Comic::crcErrorFound, this, &Render::crcError, Qt::QueuedConnection);
-    connect(comic, SIGNAL(errorOpening()), this, SLOT(reset()), Qt::QueuedConnection);
-    connect(comic, SIGNAL(imageLoaded(int)), this, SLOT(pageRawDataReady(int)), Qt::QueuedConnection);
-    connect(comic, SIGNAL(imageLoaded(int)), this, SIGNAL(imageLoaded(int)), Qt::QueuedConnection);
+    connect(comic, QOverload<>::of(&Comic::errorOpening), this, &Render::reset, Qt::QueuedConnection);
+    connect(comic, QOverload<int>::of(&Comic::imageLoaded), this, &Render::pageRawDataReady, Qt::QueuedConnection);
+    connect(comic, QOverload<int>::of(&Comic::imageLoaded), this, QOverload<int>::of(&Render::imageLoaded), Qt::QueuedConnection);
     connect(comic, &Comic::openAt, this, &Render::renderAt, Qt::QueuedConnection);
-    connect(comic, SIGNAL(numPages(unsigned int)), this, SIGNAL(numPages(unsigned int)), Qt::QueuedConnection);
-    connect(comic, SIGNAL(numPages(unsigned int)), this, SLOT(setNumPages(unsigned int)), Qt::QueuedConnection);
-    connect(comic, SIGNAL(imageLoaded(int, QByteArray)), this, SIGNAL(imageLoaded(int, QByteArray)), Qt::QueuedConnection);
+    connect(comic, QOverload<unsigned int>::of(&Comic::numPages), this, QOverload<unsigned int>::of(&Render::numPages), Qt::QueuedConnection);
+    connect(comic, QOverload<unsigned int>::of(&Comic::numPages), this, QOverload<unsigned int>::of(&Render::setNumPages), Qt::QueuedConnection);
+    connect(comic, QOverload<int, const QByteArray &>::of(&Comic::imageLoaded), this, QOverload<int, const QByteArray &>::of(&Render::imageLoaded), Qt::QueuedConnection);
     connect(comic, &Comic::isBookmark, this, &Render::currentPageIsBookmark, Qt::QueuedConnection);
 
     connect(comic, &Comic::bookmarksUpdated, this, &Render::bookmarksUpdated, Qt::QueuedConnection);
@@ -746,10 +746,10 @@ void Render::startLoad()
 
     comic->moveToThread(thread);
 
-    connect(comic, SIGNAL(errorOpening()), thread, SLOT(quit()), Qt::QueuedConnection);
-    connect(comic, SIGNAL(errorOpening(QString)), thread, SLOT(quit()), Qt::QueuedConnection);
+    connect(comic, QOverload<>::of(&Comic::errorOpening), thread, &QThread::quit, Qt::QueuedConnection);
+    connect(comic, QOverload<QString>::of(&Comic::errorOpening), thread, &QThread::quit, Qt::QueuedConnection);
     connect(comic, &Comic::imagesLoaded, thread, &QThread::quit, Qt::QueuedConnection);
-    connect(comic, SIGNAL(destroyed()), thread, SLOT(quit()), Qt::QueuedConnection);
+    connect(comic, &Comic::destroyed, thread, &QThread::quit, Qt::QueuedConnection);
     connect(comic, &Comic::invalidated, thread, &QThread::quit, Qt::QueuedConnection);
     connect(thread, &QThread::started, comic, &Comic::process);
     connect(thread, &QThread::finished, thread, &QObject::deleteLater);

--- a/YACReader/render.cpp
+++ b/YACReader/render.cpp
@@ -751,7 +751,7 @@ void Render::startLoad()
     connect(comic, &Comic::imagesLoaded, thread, &QThread::quit, Qt::QueuedConnection);
     connect(comic, SIGNAL(destroyed()), thread, SLOT(quit()), Qt::QueuedConnection);
     connect(comic, &Comic::invalidated, thread, &QThread::quit, Qt::QueuedConnection);
-    connect(thread, SIGNAL(started()), comic, SLOT(process()));
+    connect(thread, &QThread::started, comic, &Comic::process);
     connect(thread, &QThread::finished, thread, &QObject::deleteLater);
 
     if (thread != nullptr)

--- a/YACReader/shortcuts_dialog.cpp
+++ b/YACReader/shortcuts_dialog.cpp
@@ -18,7 +18,7 @@ ShortcutsDialog::ShortcutsDialog(QWidget *parent)
     auto mainLayout = new QVBoxLayout;
 
     close = new QPushButton(tr("Close"));
-    connect(close, SIGNAL(clicked()), this, SLOT(close()));
+    connect(close, &QAbstractButton::clicked, this, &QWidget::close);
 
     auto bottomLayout = new QHBoxLayout;
     bottomLayout->addStretch();

--- a/YACReader/translator.cpp
+++ b/YACReader/translator.cpp
@@ -13,6 +13,7 @@
 #include <QHBoxLayout>
 #include <QVBoxLayout>
 #include "translator.h"
+#include "viewer.h"
 
 #include "yacreader_busy_widget.h"
 
@@ -33,7 +34,7 @@
 
 #define APPID "417CEAD93449502CC3C9B69FED26C54118E62BCC"
 
-YACReaderTranslator::YACReaderTranslator(QWidget *parent)
+YACReaderTranslator::YACReaderTranslator(Viewer *parent)
     : QWidget(parent), drag(false)
 {
     QString scrollBarStyle = "QScrollBar:vertical { border: none; background: #404040; width: 7px; margin: 0 3px 0 0; }"
@@ -68,7 +69,7 @@ YACReaderTranslator::YACReaderTranslator(QWidget *parent)
     titleBar->addWidget(close);
     titleBar->setContentsMargins(0, 0, 0, 0);
     titleBar->setSpacing(0);
-    connect(close, SIGNAL(clicked()), this->parent(), SLOT(animateHideTranslator()));
+    connect(close, &QAbstractButton::clicked, parent, &Viewer::animateHideTranslator);
 
     layout->addLayout(titleBar);
 

--- a/YACReader/translator.cpp
+++ b/YACReader/translator.cpp
@@ -157,9 +157,9 @@ YACReaderTranslator::YACReaderTranslator(QWidget *parent)
 
     show();
 
-    connect(searchButton, SIGNAL(pressed()), this, SLOT(translate()));
-    connect(speakButton, SIGNAL(pressed()), this, SLOT(play()));
-    connect(clearButton, SIGNAL(pressed()), this, SLOT(clear()));
+    connect(searchButton, &QAbstractButton::pressed, this, &YACReaderTranslator::translate);
+    connect(speakButton, &QAbstractButton::pressed, this, &YACReaderTranslator::play);
+    connect(clearButton, &QAbstractButton::pressed, this, &YACReaderTranslator::clear);
 
     //multimedia/phonon
 #if QT_VERSION >= 0x050000
@@ -191,16 +191,16 @@ void YACReaderTranslator::translate()
     QString to = this->to->itemData(this->to->currentIndex()).toString();
 
     TranslationLoader *translationLoader = new TranslationLoader(text, from, to);
-    connect(translationLoader, SIGNAL(requestFinished(QString)), this, SLOT(setTranslation(QString)));
-    connect(translationLoader, SIGNAL(error()), this, SLOT(error()));
-    connect(translationLoader, SIGNAL(timeOut()), this, SLOT(error()));
-    connect(translationLoader, SIGNAL(finished()), translationLoader, SLOT(deleteLater()));
+    connect(translationLoader, &TranslationLoader::requestFinished, this, &YACReaderTranslator::setTranslation);
+    connect(translationLoader, &TranslationLoader::error, this, &YACReaderTranslator::error);
+    connect(translationLoader, &TranslationLoader::timeOut, this, &YACReaderTranslator::error);
+    connect(translationLoader, &QThread::finished, translationLoader, &QObject::deleteLater);
 
     TextToSpeachLoader *tts = new TextToSpeachLoader(text, from);
-    connect(tts, SIGNAL(requestFinished(QUrl)), this, SLOT(setSpeak(QUrl)));
-    connect(tts, SIGNAL(error()), this, SLOT(error()));
-    connect(tts, SIGNAL(timeOut()), this, SLOT(error()));
-    connect(tts, SIGNAL(finished()), tts, SLOT(deleteLater()));
+    connect(tts, &TextToSpeachLoader::requestFinished, this, &YACReaderTranslator::setSpeak);
+    connect(tts, &TextToSpeachLoader::error, this, &YACReaderTranslator::error);
+    connect(tts, &TextToSpeachLoader::timeOut, this, &YACReaderTranslator::error);
+    connect(tts, &QThread::finished, tts, &QObject::deleteLater);
 
     translationLoader->start();
     tts->start();
@@ -348,8 +348,8 @@ void TranslationLoader::run()
     QTimer tT;
 
     tT.setSingleShot(true);
-    connect(&tT, SIGNAL(timeout()), &q, SLOT(quit()));
-    connect(&manager, SIGNAL(finished(QNetworkReply *)), &q, SLOT(quit()));
+    connect(&tT, &QTimer::timeout, &q, &QEventLoop::quit);
+    connect(&manager, &QNetworkAccessManager::finished, &q, &QEventLoop::quit);
 
     QString url = "http://api.microsofttranslator.com/V2/Ajax.svc/Translate?appid=%1&from=%2&to=%3&text=%4&contentType=text/plain";
     url = url.arg(APPID).arg(from).arg(to).arg(text);
@@ -391,8 +391,8 @@ void TextToSpeachLoader::run()
     QTimer tT;
 
     tT.setSingleShot(true);
-    connect(&tT, SIGNAL(timeout()), &q, SLOT(quit()));
-    connect(&manager, SIGNAL(finished(QNetworkReply *)), &q, SLOT(quit()));
+    connect(&tT, &QTimer::timeout, &q, &QEventLoop::quit);
+    connect(&manager, &QNetworkAccessManager::finished, &q, &QEventLoop::quit);
 
     QString url = "http://api.microsofttranslator.com/V2/Ajax.svc/Speak?appid=%1&language=%2&text=%3&contentType=text/plain";
     url = url.arg(APPID).arg(language).arg(text);

--- a/YACReader/translator.h
+++ b/YACReader/translator.h
@@ -13,6 +13,7 @@ class YACReaderBusyWidget;
 #include <QWidget>
 #include <QThread>
 #include <QUrl>
+#include "viewer.h"
 
 #if QT_VERSION >= 0x050000
 class QMediaPlayer;
@@ -25,7 +26,7 @@ class YACReaderTranslator : public QWidget
 {
     Q_OBJECT
 public:
-    YACReaderTranslator(QWidget *parent = nullptr);
+    YACReaderTranslator(Viewer *parent = nullptr);
     ~YACReaderTranslator() override;
 
 public slots:

--- a/YACReader/viewer.cpp
+++ b/YACReader/viewer.cpp
@@ -172,19 +172,17 @@ void Viewer::createConnections()
     connect(bd, &BookmarksDialog::goToPage, this, &Viewer::goTo);
 
     //render
-    connect(render, SIGNAL(errorOpening()), this, SLOT(resetContent()));
-    connect(render, SIGNAL(errorOpening()), this, SLOT(showMessageErrorOpening()));
-    connect(render, SIGNAL(errorOpening(QString)), this, SLOT(showMessageErrorOpening(QString)));
+    connect(render, QOverload<>::of(&Render::errorOpening), this, &Viewer::resetContent);
+    connect(render, QOverload<>::of(&Render::errorOpening), this, QOverload<>::of(&Viewer::showMessageErrorOpening));
+    connect(render, QOverload<QString>::of(&Render::errorOpening), this, QOverload<QString>::of(&Viewer::showMessageErrorOpening));
     connect(render, &Render::crcError, this, &Viewer::processCRCError);
-    connect(render, SIGNAL(numPages(unsigned int)), goToFlow, SLOT(setNumSlides(unsigned int)));
-    connect(render, SIGNAL(numPages(unsigned int)), goToDialog, SLOT(setNumPages(unsigned int)));
-    //connect(render,SIGNAL(numPages(unsigned int)),this,SLOT(updateInformation()));
-    connect(render, SIGNAL(imageLoaded(int, QByteArray)), goToFlow, SLOT(setImageReady(int, QByteArray)));
+    connect(render, QOverload<unsigned int>::of(&Render::numPages), goToFlow, &GoToFlowWidget::setNumSlides);
+    connect(render, QOverload<unsigned int>::of(&Render::numPages), goToDialog, &GoToDialog::setNumPages);
+    connect(render, QOverload<int, const QByteArray &>::of(&Render::imageLoaded), goToFlow, &GoToFlowWidget::setImageReady);
     connect(render, &Render::currentPageReady, this, &Viewer::updatePage);
     connect(render, &Render::processingPage, this, &Viewer::setLoadingMessage);
     connect(render, &Render::currentPageIsBookmark, this, &Viewer::pageIsBookmark);
     connect(render, &Render::pageChanged, this, &Viewer::updateInformation);
-    //connect(render,SIGNAL(bookmarksLoaded(Bookmarks)),this,SLOT(setBookmarks(Bookmarks)));
 
     connect(render, &Render::isLast, this, &Viewer::showIsLastMessage);
     connect(render, &Render::isCover, this, &Viewer::showIsCoverMessage);

--- a/YACReader/viewer.cpp
+++ b/YACReader/viewer.cpp
@@ -115,9 +115,9 @@ Viewer::Viewer(QWidget *parent)
 
     //animations
     verticalScroller = new QPropertyAnimation(verticalScrollBar(), "sliderPosition");
-    connect(verticalScroller, SIGNAL(valueChanged(const QVariant &)), this, SIGNAL(backgroundChanges()));
+    connect(verticalScroller, &QVariantAnimation::valueChanged, this, &Viewer::backgroundChanges);
     horizontalScroller = new QPropertyAnimation(horizontalScrollBar(), "sliderPosition");
-    connect(horizontalScroller, SIGNAL(valueChanged(const QVariant &)), this, SIGNAL(backgroundChanges()));
+    connect(horizontalScroller, &QVariantAnimation::valueChanged, this, &Viewer::backgroundChanges);
     groupScroller = new QParallelAnimationGroup();
     groupScroller->addAnimation(verticalScroller);
     groupScroller->addAnimation(horizontalScroller);
@@ -155,41 +155,41 @@ void Viewer::createConnections()
     connect(this, SIGNAL(backgroundChanges()), mglass, SLOT(updateImage()));
 
     //goToDialog
-    connect(goToDialog, SIGNAL(goToPage(unsigned int)), this, SLOT(goTo(unsigned int)));
+    connect(goToDialog, &GoToDialog::goToPage, this, &Viewer::goTo);
 
     //goToFlow goTo
     connect(goToFlow, SIGNAL(goToPage(unsigned int)), this, SLOT(goTo(unsigned int)));
 
     //current time
     auto t = new QTimer(this);
-    connect(t, SIGNAL(timeout()), this, SLOT(updateInformation()));
+    connect(t, &QTimer::timeout, this, &Viewer::updateInformation);
     t->start(1000);
 
     //hide cursor
-    connect(hideCursorTimer, SIGNAL(timeout()), this, SLOT(hideCursor()));
+    connect(hideCursorTimer, &QTimer::timeout, this, &Viewer::hideCursor);
 
     //bookmarks
-    connect(bd, SIGNAL(goToPage(unsigned int)), this, SLOT(goTo(unsigned int)));
+    connect(bd, &BookmarksDialog::goToPage, this, &Viewer::goTo);
 
     //render
     connect(render, SIGNAL(errorOpening()), this, SLOT(resetContent()));
     connect(render, SIGNAL(errorOpening()), this, SLOT(showMessageErrorOpening()));
     connect(render, SIGNAL(errorOpening(QString)), this, SLOT(showMessageErrorOpening(QString)));
-    connect(render, SIGNAL(crcError(QString)), this, SLOT(processCRCError(QString)));
+    connect(render, &Render::crcError, this, &Viewer::processCRCError);
     connect(render, SIGNAL(numPages(unsigned int)), goToFlow, SLOT(setNumSlides(unsigned int)));
     connect(render, SIGNAL(numPages(unsigned int)), goToDialog, SLOT(setNumPages(unsigned int)));
     //connect(render,SIGNAL(numPages(unsigned int)),this,SLOT(updateInformation()));
     connect(render, SIGNAL(imageLoaded(int, QByteArray)), goToFlow, SLOT(setImageReady(int, QByteArray)));
-    connect(render, SIGNAL(currentPageReady()), this, SLOT(updatePage()));
-    connect(render, SIGNAL(processingPage()), this, SLOT(setLoadingMessage()));
-    connect(render, SIGNAL(currentPageIsBookmark(bool)), this, SIGNAL(pageIsBookmark(bool)));
-    connect(render, SIGNAL(pageChanged(int)), this, SLOT(updateInformation()));
+    connect(render, &Render::currentPageReady, this, &Viewer::updatePage);
+    connect(render, &Render::processingPage, this, &Viewer::setLoadingMessage);
+    connect(render, &Render::currentPageIsBookmark, this, &Viewer::pageIsBookmark);
+    connect(render, &Render::pageChanged, this, &Viewer::updateInformation);
     //connect(render,SIGNAL(bookmarksLoaded(Bookmarks)),this,SLOT(setBookmarks(Bookmarks)));
 
-    connect(render, SIGNAL(isLast()), this, SLOT(showIsLastMessage()));
-    connect(render, SIGNAL(isCover()), this, SLOT(showIsCoverMessage()));
+    connect(render, &Render::isLast, this, &Viewer::showIsLastMessage);
+    connect(render, &Render::isCover, this, &Viewer::showIsCoverMessage);
 
-    connect(render, SIGNAL(bookmarksUpdated()), this, SLOT(setBookmarks()));
+    connect(render, &Render::bookmarksUpdated, this, &Viewer::setBookmarks);
 }
 
 //Deprecated
@@ -841,8 +841,8 @@ void Viewer::showGoToFlow()
 void Viewer::animateShowGoToFlow()
 {
     if (goToFlow->isHidden() && showGoToFlowAnimation->state() != QPropertyAnimation::Running) {
-        disconnect(showGoToFlowAnimation, SIGNAL(finished()), goToFlow, SLOT(hide()));
-        connect(showGoToFlowAnimation, SIGNAL(finished()), this, SLOT(moveCursoToGoToFlow()));
+        disconnect(showGoToFlowAnimation, &QAbstractAnimation::finished, goToFlow, &QWidget::hide);
+        connect(showGoToFlowAnimation, &QAbstractAnimation::finished, this, &Viewer::moveCursoToGoToFlow);
         showGoToFlowAnimation->setStartValue(QPoint((width() - goToFlow->width()) / 2, height() - 10));
         showGoToFlowAnimation->setEndValue(QPoint((width() - goToFlow->width()) / 2, height() - goToFlow->height()));
         showGoToFlowAnimation->start();
@@ -856,8 +856,8 @@ void Viewer::animateShowGoToFlow()
 void Viewer::animateHideGoToFlow()
 {
     if (goToFlow->isVisible() && showGoToFlowAnimation->state() != QPropertyAnimation::Running) {
-        connect(showGoToFlowAnimation, SIGNAL(finished()), goToFlow, SLOT(hide()));
-        disconnect(showGoToFlowAnimation, SIGNAL(finished()), this, SLOT(moveCursoToGoToFlow()));
+        connect(showGoToFlowAnimation, &QAbstractAnimation::finished, goToFlow, &QWidget::hide);
+        disconnect(showGoToFlowAnimation, &QAbstractAnimation::finished, this, &Viewer::moveCursoToGoToFlow);
         showGoToFlowAnimation->setStartValue(QPoint((width() - goToFlow->width()) / 2, height() - goToFlow->height()));
         showGoToFlowAnimation->setEndValue(QPoint((width() - goToFlow->width()) / 2, height()));
         showGoToFlowAnimation->start();
@@ -1018,7 +1018,7 @@ void Viewer::updateBackgroundColor(const QColor &color)
 void Viewer::animateShowTranslator()
 {
     if (translator->isHidden() && translatorAnimation->state() != QPropertyAnimation::Running) {
-        disconnect(translatorAnimation, SIGNAL(finished()), translator, SLOT(hide()));
+        disconnect(translatorAnimation, &QAbstractAnimation::finished, translator, &QWidget::hide);
         if (translatorXPos == -10000)
             translatorXPos = (width() - translator->width()) / 2;
         int x = qMax(0, qMin(translatorXPos, width() - translator->width()));
@@ -1036,7 +1036,7 @@ void Viewer::animateShowTranslator()
 void Viewer::animateHideTranslator()
 {
     if (translator->isVisible() && translatorAnimation->state() != QPropertyAnimation::Running) {
-        connect(translatorAnimation, SIGNAL(finished()), translator, SLOT(hide()));
+        connect(translatorAnimation, &QAbstractAnimation::finished, translator, &QWidget::hide);
         translatorAnimation->setStartValue(QPoint(translatorXPos = translator->pos().x(), translator->pos().y()));
         if ((translator->width() / 2) + translator->pos().x() <= width() / 2)
             translatorAnimation->setEndValue(QPoint(-translator->width(), translator->pos().y()));

--- a/YACReader/viewer.cpp
+++ b/YACReader/viewer.cpp
@@ -152,7 +152,7 @@ Viewer::~Viewer()
 void Viewer::createConnections()
 {
     //magnifyingGlass (update mg after a background change
-    connect(this, SIGNAL(backgroundChanges()), mglass, SLOT(updateImage()));
+    connect(this, &Viewer::backgroundChanges, mglass, QOverload<>::of(&MagnifyingGlass::updateImage));
 
     //goToDialog
     connect(goToDialog, &GoToDialog::goToPage, this, &Viewer::goTo);

--- a/YACReader/viewer.cpp
+++ b/YACReader/viewer.cpp
@@ -158,7 +158,7 @@ void Viewer::createConnections()
     connect(goToDialog, &GoToDialog::goToPage, this, &Viewer::goTo);
 
     //goToFlow goTo
-    connect(goToFlow, SIGNAL(goToPage(unsigned int)), this, SLOT(goTo(unsigned int)));
+    connect(goToFlow, &GoToFlowWidget::goToPage, this, &Viewer::goTo);
 
     //current time
     auto t = new QTimer(this);

--- a/YACReader/width_slider.cpp
+++ b/YACReader/width_slider.cpp
@@ -11,7 +11,7 @@ YACReaderSliderAction::YACReaderSliderAction(QWidget *parent)
     widget = new YACReaderSlider();
     setDefaultWidget(widget);
 
-    connect(widget, SIGNAL(zoomRatioChanged(int)), this, SIGNAL(zoomRatioChanged(int)));
+    connect(widget, &YACReaderSlider::zoomRatioChanged, this, &YACReaderSliderAction::zoomRatioChanged);
 }
 
 void YACReaderSliderAction::updateText(int value)

--- a/YACReaderLibrary/add_label_dialog.cpp
+++ b/YACReaderLibrary/add_label_dialog.cpp
@@ -47,9 +47,9 @@ AddLabelDialog::AddLabelDialog(QWidget *parent)
     setLayout(layout);
 
     //connections
-    connect(edit, SIGNAL(textChanged(QString)), this, SLOT(validateName(QString)));
-    connect(cancelButton, SIGNAL(clicked()), this, SLOT(close()));
-    connect(acceptButton, SIGNAL(clicked()), this, SLOT(accept()));
+    connect(edit, &QLineEdit::textChanged, this, &AddLabelDialog::validateName);
+    connect(cancelButton, &QAbstractButton::clicked, this, &QWidget::close);
+    connect(acceptButton, &QAbstractButton::clicked, this, &QDialog::accept);
 }
 
 YACReader::LabelColors AddLabelDialog::selectedColor()

--- a/YACReaderLibrary/add_library_dialog.cpp
+++ b/YACReaderLibrary/add_library_dialog.cpp
@@ -16,22 +16,22 @@ void AddLibraryDialog::setupUI()
     textLabel = new QLabel(tr("Comics folder : "));
     path = new QLineEdit;
     textLabel->setBuddy(path);
-    connect(path, SIGNAL(textChanged(QString)), this, SLOT(pathSetted(QString)));
+    connect(path, &QLineEdit::textChanged, this, &AddLibraryDialog::pathSetted);
 
     nameLabel = new QLabel(tr("Library name : "));
     nameEdit = new QLineEdit;
     nameLabel->setBuddy(nameEdit);
-    connect(nameEdit, SIGNAL(textChanged(QString)), this, SLOT(nameSetted(QString)));
+    connect(nameEdit, &QLineEdit::textChanged, this, &AddLibraryDialog::nameSetted);
 
     accept = new QPushButton(tr("Add"));
     accept->setDisabled(true);
-    connect(accept, SIGNAL(clicked()), this, SLOT(add()));
+    connect(accept, &QAbstractButton::clicked, this, &AddLibraryDialog::add);
 
     cancel = new QPushButton(tr("Cancel"));
     connect(cancel, SIGNAL(clicked()), this, SLOT(close()));
 
     find = new QPushButton(QIcon(":/images/find_folder.png"), "");
-    connect(find, SIGNAL(clicked()), this, SLOT(findPath()));
+    connect(find, &QAbstractButton::clicked, this, &AddLibraryDialog::findPath);
 
     auto content = new QGridLayout;
 

--- a/YACReaderLibrary/add_library_dialog.cpp
+++ b/YACReaderLibrary/add_library_dialog.cpp
@@ -28,7 +28,7 @@ void AddLibraryDialog::setupUI()
     connect(accept, &QAbstractButton::clicked, this, &AddLibraryDialog::add);
 
     cancel = new QPushButton(tr("Cancel"));
-    connect(cancel, SIGNAL(clicked()), this, SLOT(close()));
+    connect(cancel, &QPushButton::close, this, &AddLibraryDialog::close);
 
     find = new QPushButton(QIcon(":/images/find_folder.png"), "");
     connect(find, &QAbstractButton::clicked, this, &AddLibraryDialog::findPath);

--- a/YACReaderLibrary/add_library_dialog.cpp
+++ b/YACReaderLibrary/add_library_dialog.cpp
@@ -28,7 +28,7 @@ void AddLibraryDialog::setupUI()
     connect(accept, &QAbstractButton::clicked, this, &AddLibraryDialog::add);
 
     cancel = new QPushButton(tr("Cancel"));
-    connect(cancel, &QPushButton::close, this, &AddLibraryDialog::close);
+    connect(cancel, &QPushButton::clicked, this, &AddLibraryDialog::close);
 
     find = new QPushButton(QIcon(":/images/find_folder.png"), "");
     connect(find, &QAbstractButton::clicked, this, &AddLibraryDialog::findPath);

--- a/YACReaderLibrary/classic_comics_view.cpp
+++ b/YACReaderLibrary/classic_comics_view.cpp
@@ -135,8 +135,9 @@ void ClassicComicsView::setModel(ComicModel *model)
     } else {
         connect(model, &QAbstractItemModel::dataChanged, this, &ClassicComicsView::applyModelChanges, Qt::UniqueConnection);
         connect(model, &QAbstractItemModel::rowsRemoved, this, &ClassicComicsView::removeItemsFromFlow, Qt::UniqueConnection);
-        connect(model, SIGNAL(resortedIndexes(QList<int>)), comicFlow, SLOT(resortCovers(QList<int>)), Qt::UniqueConnection);
-        connect(model, SIGNAL(newSelectedIndex(QModelIndex)), this, SLOT(setCurrentIndex(QModelIndex)), Qt::UniqueConnection);
+        //TODO: Missing method resortCovers?
+        connect(model, &ComicModel::resortedIndexes, comicFlow, &ComicFlowWidget::resortCovers, Qt::UniqueConnection);
+        connect(model, &ComicModel::newSelectedIndex, this, &ClassicComicsView::setCurrentIndex, Qt::UniqueConnection);
 
         tableView->setModel(model);
         if (model->rowCount() > 0)

--- a/YACReaderLibrary/classic_comics_view.cpp
+++ b/YACReaderLibrary/classic_comics_view.cpp
@@ -64,15 +64,15 @@ ClassicComicsView::ClassicComicsView(QWidget *parent)
         tableView->horizontalHeader()->restoreState(settings->value(COMICS_VIEW_HEADERS).toByteArray());
 
     //connections---------------------------------------------
-    connect(tableView, SIGNAL(clicked(QModelIndex)), this, SLOT(centerComicFlow(QModelIndex)));
-    connect(tableView, SIGNAL(doubleClicked(QModelIndex)), this, SLOT(selectedComicForOpening(QModelIndex)));
-    connect(comicFlow, SIGNAL(centerIndexChanged(int)), this, SLOT(updateTableView(int)));
-    connect(tableView, SIGNAL(comicRated(int, QModelIndex)), this, SIGNAL(comicRated(int, QModelIndex)));
-    connect(comicFlow, SIGNAL(selected(uint)), this, SIGNAL(selected(uint)));
-    connect(tableView->horizontalHeader(), SIGNAL(sectionMoved(int, int, int)), this, SLOT(saveTableHeadersStatus()));
-    connect(tableView->horizontalHeader(), SIGNAL(sectionResized(int, int, int)), this, SLOT(saveTableHeadersStatus()));
-    connect(comicFlow, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(requestedViewContextMenu(QPoint)));
-    connect(tableView, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(requestedItemContextMenu(QPoint)));
+    connect(tableView, &QAbstractItemView::clicked, this, &ClassicComicsView::centerComicFlow);
+    connect(tableView, &QAbstractItemView::doubleClicked, this, &ClassicComicsView::selectedComicForOpening);
+    connect(comicFlow, &ComicFlowWidget::centerIndexChanged, this, &ClassicComicsView::updateTableView);
+    connect(tableView, &YACReaderTableView::comicRated, this, &ComicsView::comicRated);
+    connect(comicFlow, &ComicFlowWidget::selected, this, &ComicsView::selected);
+    connect(tableView->horizontalHeader(), &QHeaderView::sectionMoved, this, &ClassicComicsView::saveTableHeadersStatus);
+    connect(tableView->horizontalHeader(), &QHeaderView::sectionResized, this, &ClassicComicsView::saveTableHeadersStatus);
+    connect(comicFlow, &QWidget::customContextMenuRequested, this, &ClassicComicsView::requestedViewContextMenu);
+    connect(tableView, &QWidget::customContextMenuRequested, this, &ClassicComicsView::requestedItemContextMenu);
     layout->addWidget(sVertical);
     setLayout(layout);
 
@@ -94,7 +94,7 @@ ClassicComicsView::ClassicComicsView(QWidget *parent)
     hideFlowViewAction->setCheckable(true);
     hideFlowViewAction->setChecked(false);
 
-    connect(hideFlowViewAction, SIGNAL(toggled(bool)), this, SLOT(hideComicFlow(bool)));
+    connect(hideFlowViewAction, &QAction::toggled, this, &ClassicComicsView::hideComicFlow);
 }
 
 void ClassicComicsView::hideComicFlow(bool hide)
@@ -133,8 +133,8 @@ void ClassicComicsView::setModel(ComicModel *model)
     if (model == NULL) {
         comicFlow->clear();
     } else {
-        connect(model, SIGNAL(dataChanged(QModelIndex, QModelIndex, QVector<int>)), this, SLOT(applyModelChanges(QModelIndex, QModelIndex, QVector<int>)), Qt::UniqueConnection);
-        connect(model, SIGNAL(rowsRemoved(QModelIndex, int, int)), this, SLOT(removeItemsFromFlow(QModelIndex, int, int)), Qt::UniqueConnection);
+        connect(model, &QAbstractItemModel::dataChanged, this, &ClassicComicsView::applyModelChanges, Qt::UniqueConnection);
+        connect(model, &QAbstractItemModel::rowsRemoved, this, &ClassicComicsView::removeItemsFromFlow, Qt::UniqueConnection);
         connect(model, SIGNAL(resortedIndexes(QList<int>)), comicFlow, SLOT(resortCovers(QList<int>)), Qt::UniqueConnection);
         connect(model, SIGNAL(newSelectedIndex(QModelIndex)), this, SLOT(setCurrentIndex(QModelIndex)), Qt::UniqueConnection);
 

--- a/YACReaderLibrary/comic_flow.cpp
+++ b/YACReaderLibrary/comic_flow.cpp
@@ -7,10 +7,10 @@ ComicFlow::ComicFlow(QWidget *parent, FlowType flowType)
     : YACReaderFlow(parent, flowType), worker(new WorkerThread<QImage>)
 {
     resetWorkerIndex();
-    connect(&updateTimer, SIGNAL(timeout()), this, SLOT(updateImageData()));
+    connect(&updateTimer, &QTimer::timeout, this, &ComicFlow::updateImageData);
 
-    connect(this, SIGNAL(centerIndexChanged(int)), this, SLOT(preload()));
-    connect(this, SIGNAL(centerIndexChangedSilent(int)), this, SLOT(preload()));
+    connect(this, &PictureFlow::centerIndexChanged, this, &ComicFlow::preload);
+    connect(this, &PictureFlow::centerIndexChangedSilent, this, &ComicFlow::preload);
 
     setReflectionEffect(PlainReflection);
 }

--- a/YACReaderLibrary/comic_flow_widget.cpp
+++ b/YACReaderLibrary/comic_flow_widget.cpp
@@ -10,8 +10,8 @@ ComicFlowWidgetSW::ComicFlowWidgetSW(QWidget *parent)
 {
     flow = new ComicFlow(parent);
 
-    connect(flow, SIGNAL(centerIndexChanged(int)), this, SIGNAL(centerIndexChanged(int)));
-    connect(flow, SIGNAL(selected(unsigned int)), this, SIGNAL(selected(unsigned int)));
+    connect(flow, &PictureFlow::centerIndexChanged, this, &ComicFlowWidget::centerIndexChanged);
+    connect(flow, &YACReaderFlow::selected, this, &ComicFlowWidget::selected);
 
     auto l = new QVBoxLayout;
     l->addWidget(flow);
@@ -155,8 +155,8 @@ ComicFlowWidgetGL::ComicFlowWidgetGL(QWidget *parent)
 {
     flow = new YACReaderComicFlowGL(parent);
 
-    connect(flow, SIGNAL(centerIndexChanged(int)), this, SIGNAL(centerIndexChanged(int)));
-    connect(flow, SIGNAL(selected(unsigned int)), this, SIGNAL(selected(unsigned int)));
+    connect(flow, &YACReaderFlowGL::centerIndexChanged, this, &ComicFlowWidget::centerIndexChanged);
+    connect(flow, &YACReaderFlowGL::selected, this, &ComicFlowWidget::selected);
 
     auto l = new QVBoxLayout;
     l->addWidget(flow);

--- a/YACReaderLibrary/comic_vine/api_key_dialog.cpp
+++ b/YACReaderLibrary/comic_vine/api_key_dialog.cpp
@@ -23,14 +23,14 @@ ApiKeyDialog::ApiKeyDialog(QWidget *parent)
     info->setOpenExternalLinks(true);
     edit = new QLineEdit();
     edit->setPlaceholderText(tr("Paste here your Comic Vine API key"));
-    connect(edit, SIGNAL(textChanged(QString)), this, SLOT(enableAccept(QString)));
+    connect(edit, &QLineEdit::textChanged, this, &ApiKeyDialog::enableAccept);
 
     acceptButton = new QPushButton(tr("Accept"));
     acceptButton->setDisabled(true);
-    connect(acceptButton, SIGNAL(clicked()), this, SLOT(saveApiKey()));
+    connect(acceptButton, &QAbstractButton::clicked, this, &ApiKeyDialog::saveApiKey);
 
     cancelButton = new QPushButton(tr("Cancel"));
-    connect(cancelButton, SIGNAL(clicked()), this, SLOT(reject()));
+    connect(cancelButton, &QAbstractButton::clicked, this, &QDialog::reject);
 
     layout->addWidget(info);
     layout->addWidget(edit);

--- a/YACReaderLibrary/comic_vine/comic_vine_all_volume_comics_retriever.cpp
+++ b/YACReaderLibrary/comic_vine/comic_vine_all_volume_comics_retriever.cpp
@@ -20,10 +20,10 @@ void ComicVineAllVolumeComicsRetriever::getAllVolumeComics()
 void ComicVineAllVolumeComicsRetriever::getAllVolumeComics(int range)
 {
     HttpWorker *search = new HttpWorker(volumeURLString.arg(range));
-    connect(search, SIGNAL(dataReady(const QByteArray &)), this, SLOT(appendVolumeComicsInfo(const QByteArray &)));
-    connect(search, SIGNAL(timeout()), this, SIGNAL(timeOut()));
-    connect(search, SIGNAL(timeout()), this, SIGNAL(finished()));
-    connect(search, SIGNAL(finished()), search, SLOT(deleteLater()));
+    connect(search, &HttpWorker::dataReady, this, &ComicVineAllVolumeComicsRetriever::appendVolumeComicsInfo);
+    connect(search, &HttpWorker::timeout, this, &ComicVineAllVolumeComicsRetriever::timeOut);
+    connect(search, &HttpWorker::timeout, this, &ComicVineAllVolumeComicsRetriever::finished);
+    connect(search, &QThread::finished, search, &QObject::deleteLater);
     search->get();
 }
 

--- a/YACReaderLibrary/comic_vine/comic_vine_client.cpp
+++ b/YACReaderLibrary/comic_vine/comic_vine_client.cpp
@@ -64,9 +64,9 @@ ComicVineClient::~ComicVineClient()
 void ComicVineClient::search(const QString &query, int page)
 {
     HttpWorker *search = new HttpWorker(QString(CV_SEARCH).replace(CV_WEB_ADDRESS, baseURL).replace(CV_API_KEY, settings->value(COMIC_VINE_API_KEY, CV_API_KEY_DEFAULT).toString()).arg(query).arg(page));
-    connect(search, SIGNAL(dataReady(const QByteArray &)), this, SLOT(proccessVolumesSearchData(const QByteArray &)));
-    connect(search, SIGNAL(timeout()), this, SIGNAL(timeOut()));
-    connect(search, SIGNAL(finished()), search, SLOT(deleteLater()));
+    connect(search, &HttpWorker::dataReady, this, &ComicVineClient::proccessVolumesSearchData);
+    connect(search, &HttpWorker::timeout, this, &ComicVineClient::timeOut);
+    connect(search, &QThread::finished, search, &QObject::deleteLater);
     search->get();
 }
 //CV_SEARCH result
@@ -102,18 +102,18 @@ void ComicVineClient::proccessComicDetailData(const QByteArray &data)
 void ComicVineClient::getSeriesDetail(const QString &id)
 {
     HttpWorker *search = new HttpWorker(QString(CV_SERIES_DETAIL).replace(CV_WEB_ADDRESS, baseURL).replace(CV_API_KEY, settings->value(COMIC_VINE_API_KEY, CV_API_KEY_DEFAULT).toString()).arg(id));
-    connect(search, SIGNAL(dataReady(const QByteArray &)), this, SLOT(proccessSeriesDetailData(const QByteArray &)));
-    connect(search, SIGNAL(timeout()), this, SIGNAL(timeOut()));
-    connect(search, SIGNAL(finished()), search, SLOT(deleteLater()));
+    connect(search, &HttpWorker::dataReady, this, &ComicVineClient::proccessSeriesDetailData);
+    connect(search, &HttpWorker::timeout, this, &ComicVineClient::timeOut);
+    connect(search, &QThread::finished, search, &QObject::deleteLater);
     search->get();
 }
 
 void ComicVineClient::getSeriesCover(const QString &url)
 {
     auto search = new HttpWorker(url);
-    connect(search, SIGNAL(dataReady(const QByteArray &)), this, SIGNAL(seriesCover(const QByteArray &)));
-    connect(search, SIGNAL(timeout()), this, SIGNAL(timeOut())); //TODO
-    connect(search, SIGNAL(finished()), search, SLOT(deleteLater()));
+    connect(search, &HttpWorker::dataReady, this, &ComicVineClient::seriesCover);
+    connect(search, &HttpWorker::timeout, this, &ComicVineClient::timeOut); //TODO
+    connect(search, &QThread::finished, search, &QObject::deleteLater);
     search->get();
 }
 
@@ -121,9 +121,9 @@ void ComicVineClient::getSeriesCover(const QString &url)
 void ComicVineClient::getVolumeComicsInfo(const QString &idVolume, int page)
 {
     HttpWorker *search = new HttpWorker(QString(CV_COMICS_INFO).replace(CV_WEB_ADDRESS, baseURL).replace(CV_API_KEY, settings->value(COMIC_VINE_API_KEY, CV_API_KEY_DEFAULT).toString()).arg(idVolume).arg((page - 1) * 100)); //page doesn't work for search, using offset instead
-    connect(search, SIGNAL(dataReady(const QByteArray &)), this, SLOT(processVolumeComicsInfo(const QByteArray &)));
-    connect(search, SIGNAL(timeout()), this, SIGNAL(timeOut())); //TODO
-    connect(search, SIGNAL(finished()), search, SLOT(deleteLater()));
+    connect(search, &HttpWorker::dataReady, this, &ComicVineClient::processVolumeComicsInfo);
+    connect(search, &HttpWorker::timeout, this, &ComicVineClient::timeOut); //TODO
+    connect(search, &QThread::finished, search, &QObject::deleteLater);
     search->get();
 }
 
@@ -170,9 +170,9 @@ void ComicVineClient::getComicDetailAsync(const QString &id)
 {
     HttpWorker *search = new HttpWorker(QString(CV_COMIC_DETAIL).replace(CV_WEB_ADDRESS, baseURL).replace(CV_API_KEY, settings->value(COMIC_VINE_API_KEY, CV_API_KEY_DEFAULT).toString()).arg(id));
 
-    connect(search, SIGNAL(dataReady(const QByteArray &)), this, SLOT(proccessComicDetailData(const QByteArray &)));
-    connect(search, SIGNAL(timeout()), this, SIGNAL(timeOut()));
-    connect(search, SIGNAL(finished()), search, SLOT(deleteLater()));
+    connect(search, &HttpWorker::dataReady, this, &ComicVineClient::proccessComicDetailData);
+    connect(search, &HttpWorker::timeout, this, &ComicVineClient::timeOut);
+    connect(search, &QThread::finished, search, &QObject::deleteLater);
     search->get();
 }
 
@@ -197,9 +197,9 @@ QByteArray ComicVineClient::getStoryArcDetail(const QString &id, bool &outError,
 void ComicVineClient::getComicCover(const QString &url)
 {
     auto search = new HttpWorker(url);
-    connect(search, SIGNAL(dataReady(const QByteArray &)), this, SIGNAL(comicCover(QByteArray)));
-    connect(search, SIGNAL(timeout()), this, SIGNAL(timeOut())); //TODO
-    connect(search, SIGNAL(finished()), search, SLOT(deleteLater()));
+    connect(search, &HttpWorker::dataReady, this, &ComicVineClient::comicCover);
+    connect(search, &HttpWorker::timeout, this, &ComicVineClient::timeOut); //TODO
+    connect(search, &QThread::finished, search, &QObject::deleteLater);
     search->get();
 }
 

--- a/YACReaderLibrary/comic_vine/comic_vine_dialog.cpp
+++ b/YACReaderLibrary/comic_vine/comic_vine_dialog.cpp
@@ -106,17 +106,17 @@ void ComicVineDialog::doStackedWidgets()
 
 void ComicVineDialog::doConnections()
 {
-    connect(closeButton, SIGNAL(clicked()), this, SLOT(close()));
-    connect(nextButton, SIGNAL(clicked()), this, SLOT(goNext()));
-    connect(backButton, SIGNAL(clicked()), this, SLOT(goBack()));
-    connect(searchButton, SIGNAL(clicked()), this, SLOT(search()));
-    connect(skipButton, SIGNAL(clicked()), this, SLOT(goToNextComic()));
+    connect(closeButton, &QAbstractButton::clicked, this, &QWidget::close);
+    connect(nextButton, &QAbstractButton::clicked, this, &ComicVineDialog::goNext);
+    connect(backButton, &QAbstractButton::clicked, this, &ComicVineDialog::goBack);
+    connect(searchButton, &QAbstractButton::clicked, this, &ComicVineDialog::search);
+    connect(skipButton, &QAbstractButton::clicked, this, &ComicVineDialog::goToNextComic);
 
-    connect(selectVolumeWidget, SIGNAL(loadPage(QString, int)), this, SLOT(searchVolume(QString, int)));
-    connect(selectComicWidget, SIGNAL(loadPage(QString, int)), this, SLOT(getVolumeComicsInfo(QString, int)));
-    connect(sortVolumeComicsWidget, SIGNAL(loadPage(QString, int)), this, SLOT(getVolumeComicsInfo(QString, int)));
+    connect(selectVolumeWidget, &ScraperSelector::loadPage, this, &ComicVineDialog::searchVolume);
+    connect(selectComicWidget, &ScraperSelector::loadPage, this, &ComicVineDialog::getVolumeComicsInfo);
+    connect(sortVolumeComicsWidget, &ScraperSelector::loadPage, this, &ComicVineDialog::getVolumeComicsInfo);
 
-    connect(this, SIGNAL(accepted()), this, SLOT(close()), Qt::QueuedConnection);
+    connect(this, &QDialog::accepted, this, &QWidget::close, Qt::QueuedConnection);
 }
 
 void ComicVineDialog::goNext()
@@ -749,9 +749,9 @@ void ComicVineDialog::searchVolume(const QString &v, int page)
     currentVolumeSearchString = v;
 
     auto comicVineClient = new ComicVineClient;
-    connect(comicVineClient, SIGNAL(searchResult(QString)), this, SLOT(debugClientResults(QString)));
-    connect(comicVineClient, SIGNAL(timeOut()), this, SLOT(queryTimeOut()));
-    connect(comicVineClient, SIGNAL(finished()), comicVineClient, SLOT(deleteLater()));
+    connect(comicVineClient, &ComicVineClient::searchResult, this, &ComicVineDialog::debugClientResults);
+    connect(comicVineClient, &ComicVineClient::timeOut, this, &ComicVineDialog::queryTimeOut);
+    connect(comicVineClient, &ComicVineClient::finished, comicVineClient, &QObject::deleteLater);
     comicVineClient->search(v, page);
 
     status = SearchingVolume;
@@ -765,11 +765,11 @@ void ComicVineDialog::getVolumeComicsInfo(const QString &vID, int /* page */)
 
     auto comicVineClient = new ComicVineClient;
     if (mode == Volume)
-        connect(comicVineClient, SIGNAL(volumeComicsInfo(QString)), this, SLOT(showSortVolumeComics(QString)));
+        connect(comicVineClient, &ComicVineClient::volumeComicsInfo, this, &ComicVineDialog::showSortVolumeComics);
     else
-        connect(comicVineClient, SIGNAL(volumeComicsInfo(QString)), this, SLOT(showSelectComic(QString)));
-    connect(comicVineClient, SIGNAL(timeOut()), this, SLOT(queryTimeOut()));
-    connect(comicVineClient, SIGNAL(finished()), comicVineClient, SLOT(deleteLater()));
+        connect(comicVineClient, &ComicVineClient::volumeComicsInfo, this, &ComicVineDialog::showSelectComic);
+    connect(comicVineClient, &ComicVineClient::timeOut, this, &ComicVineDialog::queryTimeOut);
+    connect(comicVineClient, &ComicVineClient::finished, comicVineClient, &QObject::deleteLater);
 
     QLOG_TRACE() << vID;
 

--- a/YACReaderLibrary/comic_vine/scraper_results_paginator.cpp
+++ b/YACReaderLibrary/comic_vine/scraper_results_paginator.cpp
@@ -24,8 +24,8 @@ ScraperResultsPaginator::ScraperResultsPaginator(QWidget *parent)
     previousPage->setIconSize(pp.size());
     previousPage->setIcon(pp);
 
-    connect(nextPage, SIGNAL(clicked()), this, SIGNAL(loadNextPage()));
-    connect(previousPage, SIGNAL(clicked()), this, SIGNAL(loadPreviousPage()));
+    connect(nextPage, &QAbstractButton::clicked, this, &ScraperResultsPaginator::loadNextPage);
+    connect(previousPage, &QAbstractButton::clicked, this, &ScraperResultsPaginator::loadPreviousPage);
 
     numElements = new QLabel(tr("Number of volumes found : %1"));
     numElements->setStyleSheet(labelStylesheet);

--- a/YACReaderLibrary/comic_vine/scraper_scroll_label.cpp
+++ b/YACReaderLibrary/comic_vine/scraper_scroll_label.cpp
@@ -29,7 +29,7 @@ ScraperScrollLabel::ScraperScrollLabel(QWidget *parent)
             "QScrollBar::down-arrow:vertical {border:none;width: 9px;height: 6px;background: url(':/images/folders_view/line-down.png') center top no-repeat;}"
             "QScrollBar::add-page:vertical, QScrollBar::sub-page:vertical, QScrollBar::add-page:horizontal, QScrollBar::sub-page:horizontal {background: none; }");
 
-    connect(textLabel, SIGNAL(linkActivated(QString)), this, SLOT(openLink(QString)));
+    connect(textLabel, &QLabel::linkActivated, this, &ScraperScrollLabel::openLink);
 }
 
 void ScraperScrollLabel::setAltText(const QString &text)

--- a/YACReaderLibrary/comic_vine/scraper_selector.cpp
+++ b/YACReaderLibrary/comic_vine/scraper_selector.cpp
@@ -4,8 +4,8 @@ ScraperSelector::ScraperSelector(QWidget *parent)
     : QWidget(parent)
 {
     paginator = new ScraperResultsPaginator;
-    connect(paginator, SIGNAL(loadNextPage()), this, SLOT(loadNextPage()));
-    connect(paginator, SIGNAL(loadPreviousPage()), this, SLOT(loadPreviousPage()));
+    connect(paginator, &ScraperResultsPaginator::loadNextPage, this, &ScraperSelector::loadNextPage);
+    connect(paginator, &ScraperResultsPaginator::loadPreviousPage, this, &ScraperSelector::loadPreviousPage);
 }
 
 void ScraperSelector::load(const QString &json, const QString &searchString)

--- a/YACReaderLibrary/comic_vine/select_comic.cpp
+++ b/YACReaderLibrary/comic_vine/select_comic.cpp
@@ -33,7 +33,7 @@ SelectComic::SelectComic(QWidget *parent)
 
     tableComics = new ScraperTableView(this);
     //connections
-    connect(tableComics, SIGNAL(clicked(QModelIndex)), this, SLOT(loadComicInfo(QModelIndex)));
+    connect(tableComics, &QAbstractItemView::clicked, this, &SelectComic::loadComicInfo);
 
     paginator->setCustomLabel(tr("comics"));
 
@@ -95,13 +95,13 @@ void SelectComic::loadComicInfo(const QModelIndex &mi)
     detailLabel->setAltText(loadingStyle.arg(tr("loading description")));
 
     auto comicVineClient = new ComicVineClient;
-    connect(comicVineClient, SIGNAL(comicCover(const QByteArray &)), this, SLOT(setCover(const QByteArray &)));
-    connect(comicVineClient, SIGNAL(finished()), comicVineClient, SLOT(deleteLater()));
+    connect(comicVineClient, &ComicVineClient::comicCover, this, &SelectComic::setCover);
+    connect(comicVineClient, &ComicVineClient::finished, comicVineClient, &QObject::deleteLater);
     comicVineClient->getComicCover(coverURL);
 
     auto comicVineClient2 = new ComicVineClient;
-    connect(comicVineClient2, SIGNAL(comicDetail(QString)), this, SLOT(setDescription(QString)));
-    connect(comicVineClient2, SIGNAL(finished()), comicVineClient2, SLOT(deleteLater()));
+    connect(comicVineClient2, &ComicVineClient::comicDetail, this, &SelectComic::setDescription);
+    connect(comicVineClient2, &ComicVineClient::finished, comicVineClient2, &QObject::deleteLater);
     comicVineClient2->getComicDetailAsync(id);
 }
 

--- a/YACReaderLibrary/comic_vine/select_volume.cpp
+++ b/YACReaderLibrary/comic_vine/select_volume.cpp
@@ -55,7 +55,7 @@ SelectVolume::SelectVolume(QWidget *parent)
     //tableVolumes->horizontalHeader()->setSortIndicatorShown(false);
     connect(tableVolumes->horizontalHeader(), SIGNAL(sectionClicked(int)), tableVolumes, SLOT(sortByColumn(int)));
     //connections
-    connect(tableVolumes, SIGNAL(clicked(QModelIndex)), this, SLOT(loadVolumeInfo(QModelIndex)));
+    connect(tableVolumes, &QAbstractItemView::clicked, this, &SelectVolume::loadVolumeInfo);
 
     paginator->setCustomLabel(tr("volumes"));
 
@@ -122,13 +122,13 @@ void SelectVolume::loadVolumeInfo(const QModelIndex &omi)
     detailLabel->setAltText(loadingStyle.arg(tr("loading description")));
 
     auto comicVineClient = new ComicVineClient;
-    connect(comicVineClient, SIGNAL(seriesCover(const QByteArray &)), this, SLOT(setCover(const QByteArray &)));
-    connect(comicVineClient, SIGNAL(finished()), comicVineClient, SLOT(deleteLater()));
+    connect(comicVineClient, &ComicVineClient::seriesCover, this, &SelectVolume::setCover);
+    connect(comicVineClient, &ComicVineClient::finished, comicVineClient, &QObject::deleteLater);
     comicVineClient->getSeriesCover(coverURL);
 
     auto comicVineClient2 = new ComicVineClient;
-    connect(comicVineClient2, SIGNAL(seriesDetail(QString)), this, SLOT(setDescription(QString)));
-    connect(comicVineClient2, SIGNAL(finished()), comicVineClient2, SLOT(deleteLater()));
+    connect(comicVineClient2, &ComicVineClient::seriesDetail, this, &SelectVolume::setDescription);
+    connect(comicVineClient2, &ComicVineClient::finished, comicVineClient2, &QObject::deleteLater);
     comicVineClient2->getSeriesDetail(id);
 }
 

--- a/YACReaderLibrary/comic_vine/select_volume.cpp
+++ b/YACReaderLibrary/comic_vine/select_volume.cpp
@@ -53,7 +53,9 @@ SelectVolume::SelectVolume(QWidget *parent)
     tableVolumes->horizontalHeader()->setClickable(true);
 #endif
     //tableVolumes->horizontalHeader()->setSortIndicatorShown(false);
-    connect(tableVolumes->horizontalHeader(), SIGNAL(sectionClicked(int)), tableVolumes, SLOT(sortByColumn(int)));
+    connect(tableVolumes->horizontalHeader(), &QHeaderView::sectionClicked,
+            [=](int index) { tableVolumes->horizontalHeader()->sortIndicatorSection() == index ? tableVolumes->sortByColumn(index, tableVolumes->horizontalHeader()->sortIndicatorOrder() == Qt::AscendingOrder ? Qt::DescendingOrder : Qt::AscendingOrder)
+                                                                                               : tableVolumes->sortByColumn(index, Qt::AscendingOrder); });
     //connections
     connect(tableVolumes, &QAbstractItemView::clicked, this, &SelectVolume::loadVolumeInfo);
 

--- a/YACReaderLibrary/comic_vine/sort_volume_comics.cpp
+++ b/YACReaderLibrary/comic_vine/sort_volume_comics.cpp
@@ -134,11 +134,11 @@ void SortVolumeComics::synchronizeScroll(int pos)
     QScrollBar *tableFilesScrollBar = tableFiles->verticalScrollBar();
 
     if (senderObject == tableVolumeComicsScrollBar) {
-        disconnect(tableFilesScrollBar, SIGNAL(valueChanged(int)), this, 0);
+        disconnect(tableFilesScrollBar, &QAbstractSlider::valueChanged, this, nullptr);
         tableFilesScrollBar->setValue(pos);
         connect(tableFilesScrollBar, &QAbstractSlider::valueChanged, this, &SortVolumeComics::synchronizeScroll);
     } else {
-        disconnect(tableVolumeComicsScrollBar, SIGNAL(valueChanged(int)), this, 0);
+        disconnect(tableVolumeComicsScrollBar, &QAbstractSlider::valueChanged, this, nullptr);
         tableVolumeComicsScrollBar->setValue(pos);
         connect(tableVolumeComicsScrollBar, &QAbstractSlider::valueChanged, this, &SortVolumeComics::synchronizeScroll);
     }

--- a/YACReaderLibrary/comic_vine/sort_volume_comics.cpp
+++ b/YACReaderLibrary/comic_vine/sort_volume_comics.cpp
@@ -32,8 +32,8 @@ SortVolumeComics::SortVolumeComics(QWidget *parent)
     //moveDownButtonIL = new ScrapperToolButton(ScrapperToolButton::RIGHT);
     //moveDownButtonIL->setIcon(QIcon(":/images/comic_vine/rowDown.png"));
 
-    connect(moveUpButtonCL, SIGNAL(clicked()), this, SLOT(moveUpCL()));
-    connect(moveDownButtonCL, SIGNAL(clicked()), this, SLOT(moveDownCL()));
+    connect(moveUpButtonCL, &QAbstractButton::clicked, this, &SortVolumeComics::moveUpCL);
+    connect(moveDownButtonCL, &QAbstractButton::clicked, this, &SortVolumeComics::moveDownCL);
     //connect(moveUpButtonIL,SIGNAL(clicked()),this,SLOT(moveUpIL()));
     //connect(moveUpButtonIL,SIGNAL(clicked()),this,SLOT(moveDownIL()));
 
@@ -49,8 +49,8 @@ SortVolumeComics::SortVolumeComics(QWidget *parent)
 
     //content->addWidget(tableVolumes,0,Qt::AlignRight|Qt::AlignTop);
 
-    connect(tableVolumeComics->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(synchronizeScroll(int)));
-    connect(tableFiles->verticalScrollBar(), SIGNAL(valueChanged(int)), this, SLOT(synchronizeScroll(int)));
+    connect(tableVolumeComics->verticalScrollBar(), &QAbstractSlider::valueChanged, this, &SortVolumeComics::synchronizeScroll);
+    connect(tableFiles->verticalScrollBar(), &QAbstractSlider::valueChanged, this, &SortVolumeComics::synchronizeScroll);
 
     //connect(tableVolumeComics, SIGNAL(pressed(QModelIndex)), tableFiles, SLOT(setCurrentIndex(QModelIndex)));
     //connect(tableFiles, SIGNAL(pressed(QModelIndex)), tableVolumeComics, SLOT(setCurrentIndex(QModelIndex)));
@@ -93,8 +93,8 @@ SortVolumeComics::SortVolumeComics(QWidget *parent)
     tableFiles->addAction(restoreAllItems);
     //tableFiles->addAction(restoreItems);
 
-    connect(removeItemFromList, SIGNAL(triggered()), this, SLOT(removeSelectedComics()));
-    connect(restoreAllItems, SIGNAL(triggered()), this, SLOT(restoreAllComics()));
+    connect(removeItemFromList, &QAction::triggered, this, &SortVolumeComics::removeSelectedComics);
+    connect(restoreAllItems, &QAction::triggered, this, &SortVolumeComics::restoreAllComics);
     //connect(restoreItems,SIGNAL(triggered()),this,SLOT(showRemovedComicsSelector()));
 }
 
@@ -136,11 +136,11 @@ void SortVolumeComics::synchronizeScroll(int pos)
     if (senderObject == tableVolumeComicsScrollBar) {
         disconnect(tableFilesScrollBar, SIGNAL(valueChanged(int)), this, 0);
         tableFilesScrollBar->setValue(pos);
-        connect(tableFilesScrollBar, SIGNAL(valueChanged(int)), this, SLOT(synchronizeScroll(int)));
+        connect(tableFilesScrollBar, &QAbstractSlider::valueChanged, this, &SortVolumeComics::synchronizeScroll);
     } else {
         disconnect(tableVolumeComicsScrollBar, SIGNAL(valueChanged(int)), this, 0);
         tableVolumeComicsScrollBar->setValue(pos);
-        connect(tableVolumeComicsScrollBar, SIGNAL(valueChanged(int)), this, SLOT(synchronizeScroll(int)));
+        connect(tableVolumeComicsScrollBar, &QAbstractSlider::valueChanged, this, &SortVolumeComics::synchronizeScroll);
     }
 }
 

--- a/YACReaderLibrary/create_library_dialog.cpp
+++ b/YACReaderLibrary/create_library_dialog.cpp
@@ -17,23 +17,23 @@ void CreateLibraryDialog::setupUI()
     textLabel = new QLabel(tr("Comics folder : "));
     path = new QLineEdit;
     textLabel->setBuddy(path);
-    connect(path, SIGNAL(textChanged(QString)), this, SLOT(pathSetted(QString)));
+    connect(path, &QLineEdit::textChanged, this, &CreateLibraryDialog::pathSetted);
 
     nameLabel = new QLabel(tr("Library Name : "));
     nameEdit = new QLineEdit;
     nameLabel->setBuddy(nameEdit);
-    connect(nameEdit, SIGNAL(textChanged(QString)), this, SLOT(nameSetted(QString)));
+    connect(nameEdit, &QLineEdit::textChanged, this, &CreateLibraryDialog::nameSetted);
 
     accept = new QPushButton(tr("Create"));
     accept->setDisabled(true);
     connect(accept, SIGNAL(clicked()), this, SLOT(create()));
 
     cancel = new QPushButton(tr("Cancel"));
-    connect(cancel, SIGNAL(clicked()), this, SIGNAL(cancelCreate()));
+    connect(cancel, &QAbstractButton::clicked, this, &CreateLibraryDialog::cancelCreate);
     connect(cancel, SIGNAL(clicked()), this, SLOT(close()));
 
     find = new QPushButton(QIcon(":/images/find_folder.png"), "");
-    connect(find, SIGNAL(clicked()), this, SLOT(findPath()));
+    connect(find, &QAbstractButton::clicked, this, &CreateLibraryDialog::findPath);
 
     auto content = new QGridLayout;
 
@@ -160,7 +160,7 @@ UpdateLibraryDialog::UpdateLibraryDialog(QWidget *parent)
     bottom->addStretch();
     bottom->addWidget(cancel = new QPushButton(tr("Cancel")));
 
-    connect(cancel, SIGNAL(clicked()), this, SIGNAL(cancelUpdate()));
+    connect(cancel, &QAbstractButton::clicked, this, &UpdateLibraryDialog::cancelUpdate);
     connect(cancel, SIGNAL(clicked()), this, SLOT(close()));
 
     mainLayout->addStretch();

--- a/YACReaderLibrary/create_library_dialog.cpp
+++ b/YACReaderLibrary/create_library_dialog.cpp
@@ -26,11 +26,11 @@ void CreateLibraryDialog::setupUI()
 
     accept = new QPushButton(tr("Create"));
     accept->setDisabled(true);
-    connect(accept, SIGNAL(clicked()), this, SLOT(create()));
+    connect(accept, &QAbstractButton::clicked, this, &CreateLibraryDialog::create);
 
     cancel = new QPushButton(tr("Cancel"));
     connect(cancel, &QAbstractButton::clicked, this, &CreateLibraryDialog::cancelCreate);
-    connect(cancel, SIGNAL(clicked()), this, SLOT(close()));
+    connect(cancel, &QAbstractButton::clicked, this, &CreateLibraryDialog::close);
 
     find = new QPushButton(QIcon(":/images/find_folder.png"), "");
     connect(find, &QAbstractButton::clicked, this, &CreateLibraryDialog::findPath);
@@ -161,7 +161,7 @@ UpdateLibraryDialog::UpdateLibraryDialog(QWidget *parent)
     bottom->addWidget(cancel = new QPushButton(tr("Cancel")));
 
     connect(cancel, &QAbstractButton::clicked, this, &UpdateLibraryDialog::cancelUpdate);
-    connect(cancel, SIGNAL(clicked()), this, SLOT(close()));
+    connect(cancel, &QAbstractButton::clicked, this, &UpdateLibraryDialog::close);
 
     mainLayout->addStretch();
 

--- a/YACReaderLibrary/db/comic_model.cpp
+++ b/YACReaderLibrary/db/comic_model.cpp
@@ -18,8 +18,6 @@
 ComicModel::ComicModel(QObject *parent)
     : QAbstractItemModel(parent)
 {
-    connect(this, SIGNAL(beforeReset()), this, SIGNAL(modelAboutToBeReset()));
-    connect(this, SIGNAL(reset()), this, SIGNAL(modelReset()));
 }
 
 ComicModel::ComicModel(QSqlQuery &sqlquery, QObject *parent)

--- a/YACReaderLibrary/db/comic_model.h
+++ b/YACReaderLibrary/db/comic_model.h
@@ -160,8 +160,6 @@ private:
     qulonglong sourceId;
 
 signals:
-    void beforeReset();
-    void reset();
     void isEmpty();
     void searchNumResults(int);
     void resortedIndexes(QList<int>);

--- a/YACReaderLibrary/db/folder_model.cpp
+++ b/YACReaderLibrary/db/folder_model.cpp
@@ -56,8 +56,6 @@ void drawMacOSXFinishedFolderIcon()
 FolderModel::FolderModel(QObject *parent)
     : QAbstractItemModel(parent), rootItem(0)
 {
-    connect(this, SIGNAL(beforeReset()), this, SIGNAL(modelAboutToBeReset()));
-    connect(this, SIGNAL(reset()), this, SIGNAL(modelReset()));
 }
 
 FolderModel::FolderModel(QSqlQuery &sqlquery, QObject *parent)

--- a/YACReaderLibrary/db/folder_model.h
+++ b/YACReaderLibrary/db/folder_model.h
@@ -102,10 +102,6 @@ private:
     QMap<unsigned long long int, FolderItem *> items; //relación entre folders
 
     QString _databasePath;
-
-signals:
-    void beforeReset();
-    void reset();
 };
 
 #endif

--- a/YACReaderLibrary/empty_folder_widget.cpp
+++ b/YACReaderLibrary/empty_folder_widget.cpp
@@ -125,7 +125,7 @@ EmptyFolderWidget::EmptyFolderWidget(QWidget *parent)
 
     setAcceptDrops(true);
 
-    connect(foldersView, SIGNAL(clicked(QModelIndex)), this, SLOT(onItemClicked(QModelIndex)));
+    connect(foldersView, &QAbstractItemView::clicked, this, &EmptyFolderWidget::onItemClicked);
 }
 
 void EmptyFolderWidget::setSubfolders(const QModelIndex &mi, const QStringList &foldersNames)

--- a/YACReaderLibrary/export_comics_info_dialog.cpp
+++ b/YACReaderLibrary/export_comics_info_dialog.cpp
@@ -17,14 +17,14 @@ ExportComicsInfoDialog::ExportComicsInfoDialog(QWidget *parent)
 
     accept = new QPushButton(tr("Create"));
     accept->setDisabled(true);
-    connect(accept, SIGNAL(clicked()), this, SLOT(exportComicsInfo()));
+    connect(accept, &QAbstractButton::clicked, this, &ExportComicsInfoDialog::exportComicsInfo);
 
     cancel = new QPushButton(tr("Cancel"));
     connect(cancel, SIGNAL(clicked()), this, SLOT(close()));
-    connect(cancel, SIGNAL(clicked()), this, SIGNAL(rejected()));
+    connect(cancel, &QAbstractButton::clicked, this, &QDialog::rejected);
 
     find = new QPushButton(QIcon(":/images/find_folder.png"), "");
-    connect(find, SIGNAL(clicked()), this, SLOT(findPath()));
+    connect(find, &QAbstractButton::clicked, this, &ExportComicsInfoDialog::findPath);
 
     auto libraryLayout = new QHBoxLayout;
 

--- a/YACReaderLibrary/export_comics_info_dialog.cpp
+++ b/YACReaderLibrary/export_comics_info_dialog.cpp
@@ -20,7 +20,7 @@ ExportComicsInfoDialog::ExportComicsInfoDialog(QWidget *parent)
     connect(accept, &QAbstractButton::clicked, this, &ExportComicsInfoDialog::exportComicsInfo);
 
     cancel = new QPushButton(tr("Cancel"));
-    connect(cancel, SIGNAL(clicked()), this, SLOT(close()));
+    connect(cancel, &QAbstractButton::clicked, this, &ExportComicsInfoDialog::close);
     connect(cancel, &QAbstractButton::clicked, this, &QDialog::rejected);
 
     find = new QPushButton(QIcon(":/images/find_folder.png"), "");

--- a/YACReaderLibrary/export_library_dialog.cpp
+++ b/YACReaderLibrary/export_library_dialog.cpp
@@ -14,14 +14,14 @@ ExportLibraryDialog::ExportLibraryDialog(QWidget *parent)
 
     accept = new QPushButton(tr("Create"));
     accept->setDisabled(true);
-    connect(accept, SIGNAL(clicked()), this, SLOT(exportLibrary()));
+    connect(accept, &QAbstractButton::clicked, this, &ExportLibraryDialog::exportLibrary);
 
     cancel = new QPushButton(tr("Cancel"));
     connect(cancel, SIGNAL(clicked()), this, SLOT(close()));
-    connect(cancel, SIGNAL(clicked()), this, SIGNAL(rejected()));
+    connect(cancel, &QAbstractButton::clicked, this, &QDialog::rejected);
 
     find = new QPushButton(QIcon(":/images/find_folder.png"), "");
-    connect(find, SIGNAL(clicked()), this, SLOT(findPath()));
+    connect(find, &QAbstractButton::clicked, this, &ExportLibraryDialog::findPath);
 
     auto libraryLayout = new QHBoxLayout;
 

--- a/YACReaderLibrary/export_library_dialog.cpp
+++ b/YACReaderLibrary/export_library_dialog.cpp
@@ -17,7 +17,7 @@ ExportLibraryDialog::ExportLibraryDialog(QWidget *parent)
     connect(accept, &QAbstractButton::clicked, this, &ExportLibraryDialog::exportLibrary);
 
     cancel = new QPushButton(tr("Cancel"));
-    connect(cancel, SIGNAL(clicked()), this, SLOT(close()));
+    connect(cancel, &QAbstractButton::clicked, this, &ExportLibraryDialog::close);
     connect(cancel, &QAbstractButton::clicked, this, &QDialog::rejected);
 
     find = new QPushButton(QIcon(":/images/find_folder.png"), "");

--- a/YACReaderLibrary/grid_comics_view.cpp
+++ b/YACReaderLibrary/grid_comics_view.cpp
@@ -213,7 +213,7 @@ void GridComicsView::createCoverSizeSliderWidget()
     coverSizeSliderWidget->setLayout(horizontalLayout);
     //TODO add shortcuts (ctrl-+ and ctrl-- for zooming in out, + ctrl-0 for reseting the zoom)
 
-    connect(coverSizeSlider, SIGNAL(valueChanged(int)), this, SLOT(setCoversSize(int)));
+    connect(coverSizeSlider, &QAbstractSlider::valueChanged, this, &GridComicsView::setCoversSize);
 
     int coverSize = settings->value(COMICS_GRID_COVER_SIZES, YACREADER_MIN_COVER_WIDTH).toInt();
 
@@ -277,7 +277,7 @@ void GridComicsView::setModel(ComicModel *model)
 
     //If the currentComicView was hidden before showing it sometimes the scroll view doesn't show it
     //this is a hacky solution...
-    QTimer::singleShot(0, this, SLOT(resetScroll()));
+    QTimer::singleShot(0, this, &GridComicsView::resetScroll);
 }
 
 void GridComicsView::updateBackgroundConfig()

--- a/YACReaderLibrary/import_comics_info_dialog.cpp
+++ b/YACReaderLibrary/import_comics_info_dialog.cpp
@@ -22,7 +22,7 @@ ImportComicsInfoDialog::ImportComicsInfoDialog(QWidget *parent)
     connect(accept, &QAbstractButton::clicked, this, &ImportComicsInfoDialog::import);
 
     cancel = new QPushButton(tr("Cancel"));
-    connect(cancel, SIGNAL(clicked()), this, SLOT(close()));
+    connect(cancel, &QAbstractButton::clicked, this, &ImportComicsInfoDialog::close);
     //connect(cancel,SIGNAL(clicked()),this,SIGNAL(rejected()));
 
     find = new QPushButton(QIcon(":/images/find_folder.png"), "");
@@ -85,7 +85,7 @@ void ImportComicsInfoDialog::import()
     auto importer = new Importer();
     importer->source = path->text();
     importer->dest = dest;
-    connect(importer, SIGNAL(finished()), this, SLOT(close()));
+    connect(importer, &QThread::finished, this, &ImportComicsInfoDialog::close);
     connect(importer, &QThread::finished, this, &QWidget::hide);
     importer->start();
 }

--- a/YACReaderLibrary/import_comics_info_dialog.cpp
+++ b/YACReaderLibrary/import_comics_info_dialog.cpp
@@ -19,14 +19,14 @@ ImportComicsInfoDialog::ImportComicsInfoDialog(QWidget *parent)
 
     accept = new QPushButton(tr("Import"));
     accept->setDisabled(true);
-    connect(accept, SIGNAL(clicked()), this, SLOT(import()));
+    connect(accept, &QAbstractButton::clicked, this, &ImportComicsInfoDialog::import);
 
     cancel = new QPushButton(tr("Cancel"));
     connect(cancel, SIGNAL(clicked()), this, SLOT(close()));
     //connect(cancel,SIGNAL(clicked()),this,SIGNAL(rejected()));
 
     find = new QPushButton(QIcon(":/images/find_folder.png"), "");
-    connect(find, SIGNAL(clicked()), this, SLOT(findPath()));
+    connect(find, &QAbstractButton::clicked, this, &ImportComicsInfoDialog::findPath);
 
     auto libraryLayout = new QHBoxLayout;
 
@@ -40,7 +40,7 @@ ImportComicsInfoDialog::ImportComicsInfoDialog(QWidget *parent)
     progressBar->setMaximum(0);
     progressBar->setTextVisible(false);
     progressBar->hide();
-    connect(accept, SIGNAL(clicked()), progressBar, SLOT(show()));
+    connect(accept, &QAbstractButton::clicked, progressBar, &QWidget::show);
 
     auto bottomLayout = new QHBoxLayout;
     bottomLayout->addStretch();
@@ -86,7 +86,7 @@ void ImportComicsInfoDialog::import()
     importer->source = path->text();
     importer->dest = dest;
     connect(importer, SIGNAL(finished()), this, SLOT(close()));
-    connect(importer, SIGNAL(finished()), this, SLOT(hide()));
+    connect(importer, &QThread::finished, this, &QWidget::hide);
     importer->start();
 }
 

--- a/YACReaderLibrary/import_library_dialog.cpp
+++ b/YACReaderLibrary/import_library_dialog.cpp
@@ -32,7 +32,7 @@ void ImportLibraryDialog::setupUI()
     connect(accept, &QAbstractButton::clicked, this, &ImportLibraryDialog::add);
 
     cancel = new QPushButton(tr("Cancel"));
-    connect(cancel, SIGNAL(clicked()), this, SLOT(close()));
+    connect(cancel, &QAbstractButton::clicked, this, &ImportLibraryDialog::close);
     //connect(cancel,SIGNAL(clicked()),this,SIGNAL(rejected()));
 
     find = new QPushButton(QIcon(":/images/find_folder.png"), "");

--- a/YACReaderLibrary/import_library_dialog.cpp
+++ b/YACReaderLibrary/import_library_dialog.cpp
@@ -17,7 +17,7 @@ void ImportLibraryDialog::setupUI()
     nameLabel = new QLabel(tr("Library Name : "));
     nameEdit = new QLineEdit;
     nameLabel->setBuddy(nameEdit);
-    connect(nameEdit, SIGNAL(textChanged(QString)), this, SLOT(nameEntered()));
+    connect(nameEdit, &QLineEdit::textChanged, this, &ImportLibraryDialog::nameEntered);
 
     textLabel = new QLabel(tr("Package location : "));
     path = new QLineEdit;
@@ -29,17 +29,17 @@ void ImportLibraryDialog::setupUI()
 
     accept = new QPushButton(tr("Unpack"));
     accept->setDisabled(true);
-    connect(accept, SIGNAL(clicked()), this, SLOT(add()));
+    connect(accept, &QAbstractButton::clicked, this, &ImportLibraryDialog::add);
 
     cancel = new QPushButton(tr("Cancel"));
     connect(cancel, SIGNAL(clicked()), this, SLOT(close()));
     //connect(cancel,SIGNAL(clicked()),this,SIGNAL(rejected()));
 
     find = new QPushButton(QIcon(":/images/find_folder.png"), "");
-    connect(find, SIGNAL(clicked()), this, SLOT(findPath()));
+    connect(find, &QAbstractButton::clicked, this, &ImportLibraryDialog::findPath);
 
     findDest = new QPushButton(QIcon(":/images/find_folder.png"), "");
-    connect(findDest, SIGNAL(clicked()), this, SLOT(findDestination()));
+    connect(findDest, &QAbstractButton::clicked, this, &ImportLibraryDialog::findDestination);
 
     auto content = new QGridLayout;
 

--- a/YACReaderLibrary/import_widget.cpp
+++ b/YACReaderLibrary/import_widget.cpp
@@ -195,7 +195,7 @@ ImportWidget::ImportWidget(QWidget *parent)
                               "  QToolButton:checked {background:url(\":/images/hiddenCovers.png\"); border:none;}");
     hideButton->setCheckable(true);
 
-    connect(hideButton, SIGNAL(toggled(bool)), this, SLOT(showCovers(bool)));
+    connect(hideButton, &QAbstractButton::toggled, this, &ImportWidget::showCovers);
 
     layout->addWidget(coversLabel, 0, Qt::AlignHCenter);
     layout->addWidget(coversViewContainer);
@@ -203,7 +203,7 @@ ImportWidget::ImportWidget(QWidget *parent)
     layout->addWidget(currentComicLabel, 0, Qt::AlignHCenter);
     layout->setContentsMargins(0, layout->contentsMargins().top(), 0, layout->contentsMargins().bottom());
 
-    connect(stop, SIGNAL(clicked()), this, SIGNAL(stop()));
+    connect(stop, &QAbstractButton::clicked, this, &ImportWidget::stop);
     //connect(stop,SIGNAL(clicked()),this,SLOT(addCoverTest()));
 
     previousWidth = 0;

--- a/YACReaderLibrary/import_widget.cpp
+++ b/YACReaderLibrary/import_widget.cpp
@@ -59,14 +59,14 @@ YACReaderActivityIndicatorWidget::YACReaderActivityIndicatorWidget(QWidget *pare
     auto effect = new QGraphicsOpacityEffect();
     //effect->setOpacity(1.0);
 
-    QPropertyAnimation *animation = new QPropertyAnimation(effect, "opacity");
+    auto *animation = new QPropertyAnimation(effect, "opacity", this);
 
     animation->setDuration(1000);
     animation->setStartValue(1);
     animation->setEndValue(0);
     //animation->setEasingCurve(QEasingCurve::InQuint);
 
-    QPropertyAnimation *animation2 = new QPropertyAnimation(effect, "opacity");
+    auto *animation2 = new QPropertyAnimation(effect, "opacity", this);
 
     animation2->setDuration(1000);
     animation2->setStartValue(0);
@@ -75,8 +75,8 @@ YACReaderActivityIndicatorWidget::YACReaderActivityIndicatorWidget(QWidget *pare
 
     glow->setGraphicsEffect(effect);
 
-    connect(animation, SIGNAL(finished()), animation2, SLOT(start()));
-    connect(animation2, SIGNAL(finished()), animation, SLOT(start()));
+    connect(animation, &QPropertyAnimation::finished, animation2, [=] { animation2->start(); });
+    connect(animation2, &QPropertyAnimation::finished, animation, [=] { animation->start(); });
 
     animation->start();
 }

--- a/YACReaderLibrary/info_comics_view.cpp
+++ b/YACReaderLibrary/info_comics_view.cpp
@@ -82,8 +82,9 @@ InfoComicsView::InfoComicsView(QWidget *parent)
     flow = rootObject->findChild<QObject *>("flow");
     list = rootObject->findChild<QObject *>("list");
 
-    connect(flow, SIGNAL(currentCoverChanged(int)), this, SLOT(updateInfoForIndex(int)));
-    connect(flow, SIGNAL(currentCoverChanged(int)), this, SLOT(setCurrentIndex(int)));
+    // QML signals only work with old style signal slot syntax
+    connect(flow, SIGNAL(currentCoverChanged(int)), this, SLOT(updateInfoForIndex(int))); // clazy:exclude=old-style-connect
+    connect(flow, SIGNAL(currentCoverChanged(int)), this, SLOT(setCurrentIndex(int))); // clazy:exclude=old-style-connect
 
     selectionHelper = new YACReaderComicsSelectionHelper(this);
     comicInfoHelper = new YACReaderComicInfoHelper(this);

--- a/YACReaderLibrary/library_window.cpp
+++ b/YACReaderLibrary/library_window.cpp
@@ -309,8 +309,8 @@ void LibraryWindow::doLayout()
     importWidget = new ImportWidget();
     mainWidget->addWidget(importWidget);
 
-    connect(noLibrariesWidget, SIGNAL(createNewLibrary()), this, SLOT(createLibrary()));
-    connect(noLibrariesWidget, SIGNAL(addExistingLibrary()), this, SLOT(showAddLibrary()));
+    connect(noLibrariesWidget, &NoLibrariesWidget::createNewLibrary, this, &LibraryWindow::createLibrary);
+    connect(noLibrariesWidget, &NoLibrariesWidget::addExistingLibrary, this, &LibraryWindow::showAddLibrary);
 
     //collapsible disabled in macosx (only temporaly)
 #ifdef Q_OS_MAC
@@ -1059,55 +1059,55 @@ void LibraryWindow::createMenus()
 void LibraryWindow::createConnections()
 {
     //history navigation
-    connect(backAction, SIGNAL(triggered()), historyController, SLOT(backward()));
-    connect(forwardAction, SIGNAL(triggered()), historyController, SLOT(forward()));
+    connect(backAction, &QAction::triggered, historyController, &YACReaderHistoryController::backward);
+    connect(forwardAction, &QAction::triggered, historyController, &YACReaderHistoryController::forward);
     //--
-    connect(historyController, SIGNAL(enabledBackward(bool)), backAction, SLOT(setEnabled(bool)));
-    connect(historyController, SIGNAL(enabledForward(bool)), forwardAction, SLOT(setEnabled(bool)));
+    connect(historyController, &YACReaderHistoryController::enabledBackward, backAction, &QAction::setEnabled);
+    connect(historyController, &YACReaderHistoryController::enabledForward, forwardAction, &QAction::setEnabled);
     //connect(foldersView, SIGNAL(clicked(QModelIndex)), historyController, SLOT(updateHistory(QModelIndex)));
 
     //libraryCreator connections
     connect(createLibraryDialog, SIGNAL(createLibrary(QString, QString, QString)), this, SLOT(create(QString, QString, QString)));
-    connect(createLibraryDialog, SIGNAL(libraryExists(QString)), this, SLOT(libraryAlreadyExists(QString)));
-    connect(importComicsInfoDialog, SIGNAL(finished(int)), this, SLOT(reloadCurrentLibrary()));
+    connect(createLibraryDialog, &CreateLibraryDialog::libraryExists, this, &LibraryWindow::libraryAlreadyExists);
+    connect(importComicsInfoDialog, &QDialog::finished, this, &LibraryWindow::reloadCurrentLibrary);
 
     //connect(libraryCreator,SIGNAL(coverExtracted(QString)),createLibraryDialog,SLOT(showCurrentFile(QString)));
     //connect(libraryCreator,SIGNAL(coverExtracted(QString)),updateLibraryDialog,SLOT(showCurrentFile(QString)));
     connect(libraryCreator, SIGNAL(finished()), this, SLOT(showRootWidget()));
-    connect(libraryCreator, SIGNAL(updated()), this, SLOT(reloadCurrentLibrary()));
-    connect(libraryCreator, SIGNAL(created()), this, SLOT(openLastCreated()));
+    connect(libraryCreator, &LibraryCreator::updated, this, &LibraryWindow::reloadCurrentLibrary);
+    connect(libraryCreator, &LibraryCreator::created, this, &LibraryWindow::openLastCreated);
     //connect(libraryCreator,SIGNAL(updatedCurrentFolder()), this, SLOT(showRootWidget()));
-    connect(libraryCreator, SIGNAL(updatedCurrentFolder(QModelIndex)), this, SLOT(reloadAfterCopyMove(QModelIndex)));
-    connect(libraryCreator, SIGNAL(comicAdded(QString, QString)), importWidget, SLOT(newComic(QString, QString)));
+    connect(libraryCreator, &LibraryCreator::updatedCurrentFolder, this, &LibraryWindow::reloadAfterCopyMove);
+    connect(libraryCreator, &LibraryCreator::comicAdded, importWidget, &ImportWidget::newComic);
     //libraryCreator errors
-    connect(libraryCreator, SIGNAL(failedCreatingDB(QString)), this, SLOT(manageCreatingError(QString)));
+    connect(libraryCreator, &LibraryCreator::failedCreatingDB, this, &LibraryWindow::manageCreatingError);
     connect(libraryCreator, SIGNAL(failedUpdatingDB(QString)), this, SLOT(manageUpdatingError(QString))); //TODO: implement failedUpdatingDB
 
     //new import widget
-    connect(importWidget, SIGNAL(stop()), this, SLOT(stopLibraryCreator()));
+    connect(importWidget, &ImportWidget::stop, this, &LibraryWindow::stopLibraryCreator);
 
     //packageManager connections
-    connect(exportLibraryDialog, SIGNAL(exportPath(QString)), this, SLOT(exportLibrary(QString)));
-    connect(exportLibraryDialog, SIGNAL(rejected()), packageManager, SLOT(cancel()));
+    connect(exportLibraryDialog, &ExportLibraryDialog::exportPath, this, &LibraryWindow::exportLibrary);
+    connect(exportLibraryDialog, &QDialog::rejected, packageManager, &PackageManager::cancel);
     connect(packageManager, SIGNAL(exported()), exportLibraryDialog, SLOT(close()));
-    connect(importLibraryDialog, SIGNAL(unpackCLC(QString, QString, QString)), this, SLOT(importLibrary(QString, QString, QString)));
-    connect(importLibraryDialog, SIGNAL(rejected()), packageManager, SLOT(cancel()));
-    connect(importLibraryDialog, SIGNAL(rejected()), this, SLOT(deleteCurrentLibrary()));
-    connect(importLibraryDialog, SIGNAL(libraryExists(QString)), this, SLOT(libraryAlreadyExists(QString)));
-    connect(packageManager, SIGNAL(imported()), importLibraryDialog, SLOT(hide()));
-    connect(packageManager, SIGNAL(imported()), this, SLOT(openLastCreated()));
+    connect(importLibraryDialog, &ImportLibraryDialog::unpackCLC, this, &LibraryWindow::importLibrary);
+    connect(importLibraryDialog, &QDialog::rejected, packageManager, &PackageManager::cancel);
+    connect(importLibraryDialog, &QDialog::rejected, this, &LibraryWindow::deleteCurrentLibrary);
+    connect(importLibraryDialog, &ImportLibraryDialog::libraryExists, this, &LibraryWindow::libraryAlreadyExists);
+    connect(packageManager, &PackageManager::imported, importLibraryDialog, &QWidget::hide);
+    connect(packageManager, &PackageManager::imported, this, &LibraryWindow::openLastCreated);
 
     //create and update dialogs
-    connect(createLibraryDialog, SIGNAL(cancelCreate()), this, SLOT(cancelCreating()));
+    connect(createLibraryDialog, &CreateLibraryDialog::cancelCreate, this, &LibraryWindow::cancelCreating);
 
     //open existing library from dialog.
-    connect(addLibraryDialog, SIGNAL(addLibrary(QString, QString)), this, SLOT(openLibrary(QString, QString)));
+    connect(addLibraryDialog, &AddLibraryDialog::addLibrary, this, &LibraryWindow::openLibrary);
 
     //load library when selected library changes
-    connect(selectedLibrary, SIGNAL(currentIndexChanged(QString)), this, SLOT(loadLibrary(QString)));
+    connect(selectedLibrary, &YACReaderLibraryListWidget::currentIndexChanged, this, &LibraryWindow::loadLibrary);
 
     //rename library dialog
-    connect(renameLibraryDialog, SIGNAL(renameLibrary(QString)), this, SLOT(rename(QString)));
+    connect(renameLibraryDialog, &RenameLibraryDialog::renameLibrary, this, &LibraryWindow::rename);
 
     //navigations between view modes (tree,list and flow)
     //TODO connect(foldersView, SIGNAL(pressed(QModelIndex)), this, SLOT(updateFoldersViewConextMenu(QModelIndex)));
@@ -1116,79 +1116,83 @@ void LibraryWindow::createConnections()
     //drops in folders view
     connect(foldersView, SIGNAL(copyComicsToFolder(QList<QPair<QString, QString>>, QModelIndex)), this, SLOT(copyAndImportComicsToFolder(QList<QPair<QString, QString>>, QModelIndex)));
     connect(foldersView, SIGNAL(moveComicsToFolder(QList<QPair<QString, QString>>, QModelIndex)), this, SLOT(moveAndImportComicsToFolder(QList<QPair<QString, QString>>, QModelIndex)));
-    connect(foldersView, SIGNAL(customContextMenuRequested(QPoint)), this, SLOT(showFoldersContextMenu(QPoint)));
+    connect(foldersView, &QWidget::customContextMenuRequested, this, &LibraryWindow::showFoldersContextMenu);
 
     //actions
-    connect(createLibraryAction, SIGNAL(triggered()), this, SLOT(createLibrary()));
-    connect(exportLibraryAction, SIGNAL(triggered()), exportLibraryDialog, SLOT(open()));
-    connect(importLibraryAction, SIGNAL(triggered()), this, SLOT(importLibraryPackage()));
+    connect(createLibraryAction, &QAction::triggered, this, &LibraryWindow::createLibrary);
+    connect(exportLibraryAction, &QAction::triggered, exportLibraryDialog, &QDialog::open);
+    connect(importLibraryAction, &QAction::triggered, this, &LibraryWindow::importLibraryPackage);
 
-    connect(openLibraryAction, SIGNAL(triggered()), this, SLOT(showAddLibrary()));
-    connect(setAsReadAction, SIGNAL(triggered()), this, SLOT(setCurrentComicReaded()));
-    connect(setAsNonReadAction, SIGNAL(triggered()), this, SLOT(setCurrentComicUnreaded()));
+    connect(openLibraryAction, &QAction::triggered, this, &LibraryWindow::showAddLibrary);
+    connect(setAsReadAction, &QAction::triggered, this, &LibraryWindow::setCurrentComicReaded);
+    connect(setAsNonReadAction, &QAction::triggered, this, &LibraryWindow::setCurrentComicUnreaded);
     connect(setNormalAction, &QAction::triggered, this, &LibraryWindow::setSelectedComicsAsNormal);
     connect(setMangaAction, &QAction::triggered, this, &LibraryWindow::setSelectedComicsAsManga);
     //connect(setAllAsReadAction,SIGNAL(triggered()),this,SLOT(setComicsReaded()));
     //connect(setAllAsNonReadAction,SIGNAL(triggered()),this,SLOT(setComicsUnreaded()));
 
     //comicsInfoManagement
-    connect(exportComicsInfoAction, SIGNAL(triggered()), this, SLOT(showExportComicsInfo()));
-    connect(importComicsInfoAction, SIGNAL(triggered()), this, SLOT(showImportComicsInfo()));
+    connect(exportComicsInfoAction, &QAction::triggered, this, &LibraryWindow::showExportComicsInfo);
+    connect(importComicsInfoAction, &QAction::triggered, this, &LibraryWindow::showImportComicsInfo);
 
     //properties & config
-    connect(propertiesDialog, SIGNAL(accepted()), navigationController, SLOT(reselectCurrentSource()));
+    connect(propertiesDialog, &QDialog::accepted, navigationController, &YACReaderNavigationController::reselectCurrentSource);
 
     //comic vine
-    connect(comicVineDialog, SIGNAL(accepted()), navigationController, SLOT(reselectCurrentSource()), Qt::QueuedConnection);
+    connect(comicVineDialog, &QDialog::accepted, navigationController, &YACReaderNavigationController::reselectCurrentSource, Qt::QueuedConnection);
 
-    connect(updateLibraryAction, SIGNAL(triggered()), this, SLOT(updateLibrary()));
-    connect(renameLibraryAction, SIGNAL(triggered()), this, SLOT(renameLibrary()));
+    connect(updateLibraryAction, &QAction::triggered, this, &LibraryWindow::updateLibrary);
+    connect(renameLibraryAction, &QAction::triggered, this, &LibraryWindow::renameLibrary);
     //connect(deleteLibraryAction,SIGNAL(triggered()),this,SLOT(deleteLibrary()));
-    connect(removeLibraryAction, SIGNAL(triggered()), this, SLOT(removeLibrary()));
-    connect(openComicAction, SIGNAL(triggered()), this, SLOT(openComic()));
-    connect(helpAboutAction, SIGNAL(triggered()), had, SLOT(show()));
-    connect(addFolderAction, SIGNAL(triggered()), this, SLOT(addFolderToCurrentIndex()));
-    connect(deleteFolderAction, SIGNAL(triggered()), this, SLOT(deleteSelectedFolder()));
-    connect(setRootIndexAction, SIGNAL(triggered()), this, SLOT(setRootIndex()));
-    connect(expandAllNodesAction, SIGNAL(triggered()), foldersView, SLOT(expandAll()));
-    connect(colapseAllNodesAction, SIGNAL(triggered()), foldersView, SLOT(collapseAll()));
+    connect(removeLibraryAction, &QAction::triggered, this, &LibraryWindow::removeLibrary);
+    connect(openComicAction, &QAction::triggered, this, QOverload<>::of(&LibraryWindow::openComic));
+    connect(helpAboutAction, &QAction::triggered, had, &QWidget::show);
+    connect(addFolderAction, &QAction::triggered, this, &LibraryWindow::addFolderToCurrentIndex);
+    connect(deleteFolderAction, &QAction::triggered, this, &LibraryWindow::deleteSelectedFolder);
+    connect(setRootIndexAction, &QAction::triggered, this, &LibraryWindow::setRootIndex);
+    connect(expandAllNodesAction, &QAction::triggered, foldersView, &QTreeView::expandAll);
+    connect(colapseAllNodesAction, &QAction::triggered, foldersView, &QTreeView::collapseAll);
 #ifndef Q_OS_MAC
-    connect(toggleFullScreenAction, SIGNAL(triggered()), this, SLOT(toggleFullScreen()));
+    connect(toggleFullScreenAction, &QAction::triggered, this, &LibraryWindow::toggleFullScreen);
 #endif
-    connect(toggleComicsViewAction, SIGNAL(triggered()), comicsViewsManager, SLOT(toggleComicsView()));
-    connect(optionsAction, SIGNAL(triggered()), optionsDialog, SLOT(show()));
+    connect(toggleComicsViewAction, &QAction::triggered, comicsViewsManager, &YACReaderComicsViewsManager::toggleComicsView);
+    connect(optionsAction, &QAction::triggered, optionsDialog, &QWidget::show);
 #ifdef SERVER_RELEASE
-    connect(serverConfigAction, SIGNAL(triggered()), serverConfigDialog, SLOT(show()));
+    connect(serverConfigAction, &QAction::triggered, serverConfigDialog, &QWidget::show);
 #endif
-    connect(optionsDialog, SIGNAL(optionsChanged()), this, SLOT(reloadOptions()));
-    connect(optionsDialog, SIGNAL(editShortcuts()), editShortcutsDialog, SLOT(show()));
+    connect(optionsDialog, &YACReaderOptionsDialog::optionsChanged, this, &LibraryWindow::reloadOptions);
+    connect(optionsDialog, &YACReaderOptionsDialog::editShortcuts, editShortcutsDialog, &QWidget::show);
 
-    //Search filter
-    connect(searchEdit, SIGNAL(filterChanged(YACReader::SearchModifiers, QString)), this, SLOT(setSearchFilter(YACReader::SearchModifiers, QString)));
+//Search filter
+#ifdef Q_OS_MAC
+    connect(searchEdit, &YACReaderMacOSXSearchLineEdit::filterChanged, this, &LibraryWindow::setSearchFilter);
+#else
+    connect(searchEdit, &YACReaderSearchLineEdit::filterChanged, this, &LibraryWindow::setSearchFilter);
+#endif
     connect(&comicQueryResultProcessor, &ComicQueryResultProcessor::newData, this, &LibraryWindow::setComicSearchFilterData);
     connect(folderQueryResultProcessor.get(), &FolderQueryResultProcessor::newData, this, &LibraryWindow::setFolderSearchFilterData);
 
     //ContextMenus
-    connect(openContainingFolderComicAction, SIGNAL(triggered()), this, SLOT(openContainingFolderComic()));
-    connect(setFolderAsNotCompletedAction, SIGNAL(triggered()), this, SLOT(setFolderAsNotCompleted()));
-    connect(setFolderAsCompletedAction, SIGNAL(triggered()), this, SLOT(setFolderAsCompleted()));
-    connect(setFolderAsReadAction, SIGNAL(triggered()), this, SLOT(setFolderAsRead()));
-    connect(setFolderAsUnreadAction, SIGNAL(triggered()), this, SLOT(setFolderAsUnread()));
-    connect(openContainingFolderAction, SIGNAL(triggered()), this, SLOT(openContainingFolder()));
+    connect(openContainingFolderComicAction, &QAction::triggered, this, &LibraryWindow::openContainingFolderComic);
+    connect(setFolderAsNotCompletedAction, &QAction::triggered, this, &LibraryWindow::setFolderAsNotCompleted);
+    connect(setFolderAsCompletedAction, &QAction::triggered, this, &LibraryWindow::setFolderAsCompleted);
+    connect(setFolderAsReadAction, &QAction::triggered, this, &LibraryWindow::setFolderAsRead);
+    connect(setFolderAsUnreadAction, &QAction::triggered, this, &LibraryWindow::setFolderAsUnread);
+    connect(openContainingFolderAction, &QAction::triggered, this, &LibraryWindow::openContainingFolder);
     connect(setFolderAsMangaAction, &QAction::triggered, this, &LibraryWindow::setFolderAsManga);
     connect(setFolderAsNormalAction, &QAction::triggered, this, &LibraryWindow::setFolderAsNormal);
 
-    connect(resetComicRatingAction, SIGNAL(triggered()), this, SLOT(resetComicRating()));
+    connect(resetComicRatingAction, &QAction::triggered, this, &LibraryWindow::resetComicRating);
 
     //connect(dm,SIGNAL(directoryLoaded(QString)),foldersView,SLOT(expandAll()));
     //connect(dm,SIGNAL(directoryLoaded(QString)),this,SLOT(updateFoldersView(QString)));
     //Comicts edition
-    connect(editSelectedComicsAction, SIGNAL(triggered()), this, SLOT(showProperties()));
-    connect(asignOrderAction, SIGNAL(triggered()), this, SLOT(asignNumbers()));
+    connect(editSelectedComicsAction, &QAction::triggered, this, &LibraryWindow::showProperties);
+    connect(asignOrderAction, &QAction::triggered, this, &LibraryWindow::asignNumbers);
 
-    connect(deleteComicsAction, SIGNAL(triggered()), this, SLOT(deleteComics()));
+    connect(deleteComicsAction, &QAction::triggered, this, &LibraryWindow::deleteComics);
 
-    connect(getInfoAction, SIGNAL(triggered()), this, SLOT(showComicVineScraper()));
+    connect(getInfoAction, &QAction::triggered, this, &LibraryWindow::showComicVineScraper);
 
     //connect(socialAction,SIGNAL(triggered()),this,SLOT(showSocial()));
 
@@ -1199,33 +1203,33 @@ void LibraryWindow::createConnections()
     connect(focusSearchLineAction, &QAction::triggered, searchEdit, [this] { searchEdit->setFocus(Qt::ShortcutFocusReason); });
     connect(focusComicsViewAction, &QAction::triggered, comicsViewsManager, &YACReaderComicsViewsManager::focusComicsViewViaShortcut);
 
-    connect(showEditShortcutsAction, SIGNAL(triggered()), editShortcutsDialog, SLOT(show()));
+    connect(showEditShortcutsAction, &QAction::triggered, editShortcutsDialog, &QWidget::show);
 
     connect(quitAction, &QAction::triggered, this, &LibraryWindow::closeApp);
 
     //update folders (partial updates)
-    connect(updateCurrentFolderAction, SIGNAL(triggered()), this, SLOT(updateCurrentFolder()));
-    connect(updateFolderAction, SIGNAL(triggered()), this, SLOT(updateCurrentFolder()));
+    connect(updateCurrentFolderAction, &QAction::triggered, this, &LibraryWindow::updateCurrentFolder);
+    connect(updateFolderAction, &QAction::triggered, this, &LibraryWindow::updateCurrentFolder);
 
     //lists
-    connect(addReadingListAction, SIGNAL(triggered()), this, SLOT(addNewReadingList()));
-    connect(deleteReadingListAction, SIGNAL(triggered()), this, SLOT(deleteSelectedReadingList()));
-    connect(addLabelAction, SIGNAL(triggered()), this, SLOT(showAddNewLabelDialog()));
-    connect(renameListAction, SIGNAL(triggered()), this, SLOT(showRenameCurrentList()));
+    connect(addReadingListAction, &QAction::triggered, this, &LibraryWindow::addNewReadingList);
+    connect(deleteReadingListAction, &QAction::triggered, this, &LibraryWindow::deleteSelectedReadingList);
+    connect(addLabelAction, &QAction::triggered, this, &LibraryWindow::showAddNewLabelDialog);
+    connect(renameListAction, &QAction::triggered, this, &LibraryWindow::showRenameCurrentList);
 
     connect(listsModel, SIGNAL(addComicsToFavorites(QList<qulonglong>)), comicsModel, SLOT(addComicsToFavorites(QList<qulonglong>)));
     connect(listsModel, SIGNAL(addComicsToLabel(QList<qulonglong>, qulonglong)), comicsModel, SLOT(addComicsToLabel(QList<qulonglong>, qulonglong)));
     connect(listsModel, SIGNAL(addComicsToReadingList(QList<qulonglong>, qulonglong)), comicsModel, SLOT(addComicsToReadingList(QList<qulonglong>, qulonglong)));
     //--
 
-    connect(addToFavoritesAction, SIGNAL(triggered()), this, SLOT(addSelectedComicsToFavorites()));
+    connect(addToFavoritesAction, &QAction::triggered, this, &LibraryWindow::addSelectedComicsToFavorites);
 
     //save covers
-    connect(saveCoversToAction, SIGNAL(triggered()), this, SLOT(saveSelectedCoversTo()));
+    connect(saveCoversToAction, &QAction::triggered, this, &LibraryWindow::saveSelectedCoversTo);
 
     //upgrade library
-    connect(this, SIGNAL(libraryUpgraded(QString)), this, SLOT(loadLibrary(QString)), Qt::QueuedConnection);
-    connect(this, SIGNAL(errorUpgradingLibrary(QString)), this, SLOT(showErrorUpgradingLibrary(QString)), Qt::QueuedConnection);
+    connect(this, &LibraryWindow::libraryUpgraded, this, &LibraryWindow::loadLibrary, Qt::QueuedConnection);
+    connect(this, &LibraryWindow::errorUpgradingLibrary, this, &LibraryWindow::showErrorUpgradingLibrary, Qt::QueuedConnection);
 }
 
 void LibraryWindow::showErrorUpgradingLibrary(const QString &path)
@@ -1453,7 +1457,7 @@ void LibraryWindow::moveAndImportComicsToFolder(const QList<QPair<QString, QStri
 
 void LibraryWindow::processComicFiles(ComicFilesManager *comicFilesManager, QProgressDialog *progressDialog)
 {
-    connect(comicFilesManager, SIGNAL(progress(int)), progressDialog, SLOT(setValue(int)));
+    connect(comicFilesManager, &ComicFilesManager::progress, progressDialog, &QProgressDialog::setValue);
 
     QThread *thread = NULL;
 
@@ -1461,15 +1465,15 @@ void LibraryWindow::processComicFiles(ComicFilesManager *comicFilesManager, QPro
 
     comicFilesManager->moveToThread(thread);
 
-    connect(progressDialog, SIGNAL(canceled()), comicFilesManager, SLOT(cancel()), Qt::DirectConnection);
+    connect(progressDialog, &QProgressDialog::canceled, comicFilesManager, &ComicFilesManager::cancel, Qt::DirectConnection);
 
-    connect(thread, SIGNAL(started()), comicFilesManager, SLOT(process()));
-    connect(comicFilesManager, SIGNAL(success(QModelIndex)), this, SLOT(updateCopyMoveFolderDestination(QModelIndex)));
-    connect(comicFilesManager, SIGNAL(finished()), thread, SLOT(quit()));
-    connect(comicFilesManager, SIGNAL(finished()), comicFilesManager, SLOT(deleteLater()));
-    connect(comicFilesManager, SIGNAL(finished()), progressDialog, SLOT(close()));
-    connect(comicFilesManager, SIGNAL(finished()), progressDialog, SLOT(deleteLater()));
-    connect(thread, SIGNAL(finished()), thread, SLOT(deleteLater()));
+    connect(thread, &QThread::started, comicFilesManager, &ComicFilesManager::process);
+    connect(comicFilesManager, &ComicFilesManager::success, this, &LibraryWindow::updateCopyMoveFolderDestination);
+    connect(comicFilesManager, &ComicFilesManager::finished, thread, &QThread::quit);
+    connect(comicFilesManager, &ComicFilesManager::finished, comicFilesManager, &QObject::deleteLater);
+    connect(comicFilesManager, &ComicFilesManager::finished, progressDialog, &QWidget::close);
+    connect(comicFilesManager, &ComicFilesManager::finished, progressDialog, &QObject::deleteLater);
+    connect(thread, &QThread::finished, thread, &QObject::deleteLater);
 
     if (thread != NULL)
         thread->start();
@@ -1593,9 +1597,9 @@ void LibraryWindow::deleteSelectedFolder()
                 const auto thread = new QThread(this);
                 moveAndConnectRemoverToThread(remover, thread);
 
-                connect(remover, SIGNAL(remove(QModelIndex)), foldersModel, SLOT(deleteFolder(QModelIndex)));
-                connect(remover, SIGNAL(removeError()), this, SLOT(errorDeletingFolder()));
-                connect(remover, SIGNAL(finished()), navigationController, SLOT(reselectCurrentFolder()));
+                connect(remover, &FoldersRemover::remove, foldersModel, &FolderModel::deleteFolder);
+                connect(remover, &FoldersRemover::removeError, this, &LibraryWindow::errorDeletingFolder);
+                connect(remover, &FoldersRemover::finished, navigationController, &YACReaderNavigationController::reselectCurrentFolder);
 
                 thread->start();
             }
@@ -1768,7 +1772,7 @@ void LibraryWindow::setupAddToSubmenu(QMenu &menu)
 
         menu.addAction(action);
 
-        connect(action, SIGNAL(triggered()), this, SLOT(onAddComicsToLabel()));
+        connect(action, &QAction::triggered, this, &LibraryWindow::onAddComicsToLabel);
     }
 }
 
@@ -1940,7 +1944,7 @@ void LibraryWindow::openLastCreated()
     selectedLibrary->setCurrentIndex(selectedLibrary->findText(_lastAdded));
     libraries.save();
 
-    connect(selectedLibrary, SIGNAL(currentIndexChanged(QString)), this, SLOT(loadLibrary(QString)));
+    connect(selectedLibrary, &YACReaderLibraryListWidget::currentIndexChanged, this, &LibraryWindow::loadLibrary);
 
     loadLibrary(_lastAdded);
 }
@@ -2573,13 +2577,13 @@ void LibraryWindow::deleteComicsFromDisk()
 
         comicsModel->startTransaction();
 
-        connect(remover, SIGNAL(remove(int)), comicsModel, SLOT(remove(int)));
-        connect(remover, SIGNAL(removeError()), this, SLOT(setRemoveError()));
-        connect(remover, SIGNAL(finished()), comicsModel, SLOT(finishTransaction()));
-        connect(remover, SIGNAL(removedItemsFromFolder(qulonglong)), foldersModel, SLOT(updateFolderChildrenInfo(qulonglong)));
+        connect(remover, &ComicsRemover::remove, comicsModel, &ComicModel::remove);
+        connect(remover, &ComicsRemover::removeError, this, &LibraryWindow::setRemoveError);
+        connect(remover, &ComicsRemover::finished, comicsModel, &ComicModel::finishTransaction);
+        connect(remover, &ComicsRemover::removedItemsFromFolder, foldersModel, &FolderModel::updateFolderChildrenInfo);
 
-        connect(remover, SIGNAL(finished()), this, SLOT(checkEmptyFolder()));
-        connect(remover, SIGNAL(finished()), this, SLOT(checkRemoveError()));
+        connect(remover, &ComicsRemover::finished, this, &LibraryWindow::checkEmptyFolder);
+        connect(remover, &ComicsRemover::finished, this, &LibraryWindow::checkRemoveError);
 
         thread->start();
     }

--- a/YACReaderLibrary/library_window.cpp
+++ b/YACReaderLibrary/library_window.cpp
@@ -1067,13 +1067,13 @@ void LibraryWindow::createConnections()
     //connect(foldersView, SIGNAL(clicked(QModelIndex)), historyController, SLOT(updateHistory(QModelIndex)));
 
     //libraryCreator connections
-    connect(createLibraryDialog, SIGNAL(createLibrary(QString, QString, QString)), this, SLOT(create(QString, QString, QString)));
+    connect(createLibraryDialog, &CreateLibraryDialog::createLibrary, this, QOverload<QString, QString, QString>::of(&LibraryWindow::create));
     connect(createLibraryDialog, &CreateLibraryDialog::libraryExists, this, &LibraryWindow::libraryAlreadyExists);
     connect(importComicsInfoDialog, &QDialog::finished, this, &LibraryWindow::reloadCurrentLibrary);
 
     //connect(libraryCreator,SIGNAL(coverExtracted(QString)),createLibraryDialog,SLOT(showCurrentFile(QString)));
     //connect(libraryCreator,SIGNAL(coverExtracted(QString)),updateLibraryDialog,SLOT(showCurrentFile(QString)));
-    connect(libraryCreator, SIGNAL(finished()), this, SLOT(showRootWidget()));
+    connect(libraryCreator, &LibraryCreator::finished, this, &LibraryWindow::showRootWidget);
     connect(libraryCreator, &LibraryCreator::updated, this, &LibraryWindow::reloadCurrentLibrary);
     connect(libraryCreator, &LibraryCreator::created, this, &LibraryWindow::openLastCreated);
     //connect(libraryCreator,SIGNAL(updatedCurrentFolder()), this, SLOT(showRootWidget()));
@@ -1089,7 +1089,7 @@ void LibraryWindow::createConnections()
     //packageManager connections
     connect(exportLibraryDialog, &ExportLibraryDialog::exportPath, this, &LibraryWindow::exportLibrary);
     connect(exportLibraryDialog, &QDialog::rejected, packageManager, &PackageManager::cancel);
-    connect(packageManager, SIGNAL(exported()), exportLibraryDialog, SLOT(close()));
+    connect(packageManager, &PackageManager::exported, exportLibraryDialog, &ExportLibraryDialog::close);
     connect(importLibraryDialog, &ImportLibraryDialog::unpackCLC, this, &LibraryWindow::importLibrary);
     connect(importLibraryDialog, &QDialog::rejected, packageManager, &PackageManager::cancel);
     connect(importLibraryDialog, &QDialog::rejected, this, &LibraryWindow::deleteCurrentLibrary);
@@ -1114,13 +1114,15 @@ void LibraryWindow::createConnections()
     //connect(foldersView, SIGNAL(clicked(QModelIndex)), this, SLOT(loadCovers(QModelIndex)));
 
     //drops in folders view
-    connect(foldersView, SIGNAL(copyComicsToFolder(QList<QPair<QString, QString>>, QModelIndex)), this, SLOT(copyAndImportComicsToFolder(QList<QPair<QString, QString>>, QModelIndex)));
-    connect(foldersView, SIGNAL(moveComicsToFolder(QList<QPair<QString, QString>>, QModelIndex)), this, SLOT(moveAndImportComicsToFolder(QList<QPair<QString, QString>>, QModelIndex)));
+    connect(foldersView, QOverload<QList<QPair<QString, QString>>, QModelIndex>::of(&YACReaderFoldersView::copyComicsToFolder),
+            this, &LibraryWindow::copyAndImportComicsToFolder);
+    connect(foldersView, QOverload<QList<QPair<QString, QString>>, QModelIndex>::of(&YACReaderFoldersView::moveComicsToFolder),
+            this, &LibraryWindow::moveAndImportComicsToFolder);
     connect(foldersView, &QWidget::customContextMenuRequested, this, &LibraryWindow::showFoldersContextMenu);
 
     //actions
     connect(createLibraryAction, &QAction::triggered, this, &LibraryWindow::createLibrary);
-    connect(exportLibraryAction, &QAction::triggered, exportLibraryDialog, &QDialog::open);
+    connect(exportLibraryAction, &QAction::triggered, exportLibraryDialog, &ExportLibraryDialog::open);
     connect(importLibraryAction, &QAction::triggered, this, &LibraryWindow::importLibraryPackage);
 
     connect(openLibraryAction, &QAction::triggered, this, &LibraryWindow::showAddLibrary);
@@ -1217,9 +1219,9 @@ void LibraryWindow::createConnections()
     connect(addLabelAction, &QAction::triggered, this, &LibraryWindow::showAddNewLabelDialog);
     connect(renameListAction, &QAction::triggered, this, &LibraryWindow::showRenameCurrentList);
 
-    connect(listsModel, SIGNAL(addComicsToFavorites(QList<qulonglong>)), comicsModel, SLOT(addComicsToFavorites(QList<qulonglong>)));
-    connect(listsModel, SIGNAL(addComicsToLabel(QList<qulonglong>, qulonglong)), comicsModel, SLOT(addComicsToLabel(QList<qulonglong>, qulonglong)));
-    connect(listsModel, SIGNAL(addComicsToReadingList(QList<qulonglong>, qulonglong)), comicsModel, SLOT(addComicsToReadingList(QList<qulonglong>, qulonglong)));
+    connect(listsModel, &ReadingListModel::addComicsToFavorites, comicsModel, QOverload<const QList<qulonglong> &>::of(&ComicModel::addComicsToFavorites));
+    connect(listsModel, &ReadingListModel::addComicsToLabel, comicsModel, QOverload<const QList<qulonglong> &, qulonglong>::of(&ComicModel::addComicsToLabel));
+    connect(listsModel, &ReadingListModel::addComicsToReadingList, comicsModel, QOverload<const QList<qulonglong> &, qulonglong>::of(&ComicModel::addComicsToReadingList));
     //--
 
     connect(addToFavoritesAction, &QAction::triggered, this, &LibraryWindow::addSelectedComicsToFavorites);

--- a/YACReaderLibrary/library_window.cpp
+++ b/YACReaderLibrary/library_window.cpp
@@ -2176,8 +2176,8 @@ void LibraryWindow::toNormal()
     auto timer = new QTimer();
     timer->setSingleShot(true);
     timer->start();
-    connect(timer, SIGNAL(timeout()), libraryToolBar, SLOT(show()));
-    connect(timer, SIGNAL(timeout()), timer, SLOT(deleteLater()));
+    connect(timer, &QTimer::timeout, libraryToolBar, &YACReaderMacOSXToolbar::show);
+    connect(timer, &QTimer::timeout, timer, &QTimer::deleteLater);
 #else
     libraryToolBar->show();
 #endif

--- a/YACReaderLibrary/main.cpp
+++ b/YACReaderLibrary/main.cpp
@@ -245,7 +245,7 @@ int main(int argc, char **argv)
 
     auto mw = new LibraryWindow();
 
-    mw->connect(localServer, SIGNAL(comicUpdated(quint64, const ComicDB &)), mw, SLOT(updateComicsView(quint64, const ComicDB &)), Qt::QueuedConnection);
+    mw->connect(localServer, &YACReaderLocalServer::comicUpdated, mw, &LibraryWindow::updateComicsView, Qt::QueuedConnection);
 
     //connections to localServer
 

--- a/YACReaderLibrary/no_libraries_widget.cpp
+++ b/YACReaderLibrary/no_libraries_widget.cpp
@@ -73,6 +73,6 @@ NoLibrariesWidget::NoLibrariesWidget(QWidget *parent)
     layout->addSpacing(150);
     layout->addStretch();
 
-    connect(createButton, SIGNAL(clicked()), this, SIGNAL(createNewLibrary()));
-    connect(addButton, SIGNAL(clicked()), this, SIGNAL(addExistingLibrary()));
+    connect(createButton, &QAbstractButton::clicked, this, &NoLibrariesWidget::createNewLibrary);
+    connect(addButton, &QAbstractButton::clicked, this, &NoLibrariesWidget::addExistingLibrary);
 }

--- a/YACReaderLibrary/options_dialog.cpp
+++ b/YACReaderLibrary/options_dialog.cpp
@@ -72,7 +72,7 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     auto apiKeyBox = new QGroupBox(tr("Comic Vine API key"));
     apiKeyBox->setLayout(apiKeyLayout);
 
-    connect(apiKeyButton, SIGNAL(clicked()), this, SLOT(editApiKey()));
+    connect(apiKeyButton, &QAbstractButton::clicked, this, &OptionsDialog::editApiKey);
 
     //grid view background config
     useBackgroundImageCheck = new QCheckBox(tr("Enable background image"));
@@ -115,9 +115,9 @@ OptionsDialog::OptionsDialog(QWidget *parent)
     gridViewLayout->addWidget(continueReadingGroup);
     gridViewLayout->addStretch();
 
-    connect(useBackgroundImageCheck, SIGNAL(clicked(bool)), this, SLOT(useBackgroundImageCheckClicked(bool)));
-    connect(backgroundImageOpacitySlider, SIGNAL(valueChanged(int)), this, SLOT(backgroundImageOpacitySliderChanged(int)));
-    connect(backgroundImageBlurRadiusSlider, SIGNAL(valueChanged(int)), this, SLOT(backgroundImageBlurRadiusSliderChanged(int)));
+    connect(useBackgroundImageCheck, &QAbstractButton::clicked, this, &OptionsDialog::useBackgroundImageCheckClicked);
+    connect(backgroundImageOpacitySlider, &QAbstractSlider::valueChanged, this, &OptionsDialog::backgroundImageOpacitySliderChanged);
+    connect(backgroundImageBlurRadiusSlider, &QAbstractSlider::valueChanged, this, &OptionsDialog::backgroundImageBlurRadiusSliderChanged);
     connect(useCurrentComicCoverCheck, &QCheckBox::clicked, this, &OptionsDialog::useCurrentComicCoverCheckClicked);
     connect(resetButton, &QPushButton::clicked, this, &OptionsDialog::resetToDefaults);
     //end grid view background config

--- a/YACReaderLibrary/package_manager.cpp
+++ b/YACReaderLibrary/package_manager.cpp
@@ -13,8 +13,9 @@ void PackageManager::createPackage(const QString &libraryPath, const QString &de
                << "-y"
                << "-ttar" << dest + ".clc" << libraryPath;
     _7z = new QProcess();
+    //TODO: Missing slot for openingError!!!
     connect(_7z, SIGNAL(error(QProcess::ProcessError)), this, SLOT(openingError(QProcess::ProcessError)));
-    connect(_7z, SIGNAL(finished(int, QProcess::ExitStatus)), this, SIGNAL(exported()));
+    connect(_7z, QOverload<int, QProcess::ExitStatus>::of(&QProcess::finished), this, &PackageManager::exported);
 #if defined Q_OS_UNIX && !defined Q_OS_MAC
     _7z->start("7z", attributes); //TODO: use 7z.so
 #else

--- a/YACReaderLibrary/properties_dialog.cpp
+++ b/YACReaderLibrary/properties_dialog.cpp
@@ -120,8 +120,8 @@ void PropertiesDialog::createCoverBox()
     //busyIndicator->move((280-busyIndicator->width())/2,(444-busyIndicator->height()-28)/2);
     //busyIndicator->hide();
 
-    connect(showPreviousCoverPageButton, SIGNAL(clicked()), this, SLOT(loadPreviousCover()));
-    connect(showNextCoverPageButton, SIGNAL(clicked()), this, SLOT(loadNextCover()));
+    connect(showPreviousCoverPageButton, &QAbstractButton::clicked, this, &PropertiesDialog::loadPreviousCover);
+    connect(showNextCoverPageButton, &QAbstractButton::clicked, this, &PropertiesDialog::loadNextCover);
 }
 
 QFrame *createLine()
@@ -299,8 +299,8 @@ void PropertiesDialog::createButtonBox()
     //rotateWidgetsButton = buttonBox->addButton(tr("Rotate &Widgets"),QDialogButtonBox::ActionRole);
 
     //connect(rotateWidgetsButton, SIGNAL(clicked()), this, SLOT(rotateWidgets()));
-    connect(closeButton, SIGNAL(clicked()), this, SLOT(close()));
-    connect(saveButton, SIGNAL(clicked()), this, SLOT(save()));
+    connect(closeButton, &QAbstractButton::clicked, this, &QWidget::close);
+    connect(saveButton, &QAbstractButton::clicked, this, &PropertiesDialog::save);
 }
 
 QImage blurred(const QImage &image, const QRect &rect, int radius, bool alphaOnly = false)

--- a/YACReaderLibrary/rename_library_dialog.cpp
+++ b/YACReaderLibrary/rename_library_dialog.cpp
@@ -15,11 +15,11 @@ void RenameLibraryDialog::setupUI()
     newNameLabel = new QLabel(tr("New Library Name : "));
     newNameEdit = new QLineEdit;
     newNameLabel->setBuddy(newNameEdit);
-    connect(newNameEdit, SIGNAL(textChanged(QString)), this, SLOT(nameSetted(QString)));
+    connect(newNameEdit, &QLineEdit::textChanged, this, &RenameLibraryDialog::nameSetted);
 
     accept = new QPushButton(tr("Rename"));
     accept->setDisabled(true);
-    connect(accept, SIGNAL(clicked()), this, SLOT(rename()));
+    connect(accept, &QAbstractButton::clicked, this, &RenameLibraryDialog::rename);
 
     cancel = new QPushButton(tr("Cancel"));
     connect(cancel, SIGNAL(clicked()), this, SLOT(close()));

--- a/YACReaderLibrary/rename_library_dialog.cpp
+++ b/YACReaderLibrary/rename_library_dialog.cpp
@@ -22,10 +22,9 @@ void RenameLibraryDialog::setupUI()
     connect(accept, &QAbstractButton::clicked, this, &RenameLibraryDialog::rename);
 
     cancel = new QPushButton(tr("Cancel"));
-    connect(cancel, SIGNAL(clicked()), this, SLOT(close()));
+    connect(cancel, &QAbstractButton::clicked, this, &RenameLibraryDialog::close);
 
     auto nameLayout = new QHBoxLayout;
-
     nameLayout->addWidget(newNameLabel);
     nameLayout->addWidget(newNameEdit);
 

--- a/YACReaderLibrary/server/controllers/v1/comiccontroller.cpp
+++ b/YACReaderLibrary/server/controllers/v1/comiccontroller.cpp
@@ -64,7 +64,7 @@ void ComicController::service(HttpRequest &request, HttpResponse &response)
         connect(comicFile, SIGNAL(errorOpening()), thread, SLOT(quit()));
         connect(comicFile, SIGNAL(errorOpening(QString)), thread, SLOT(quit()));
         connect(comicFile, &Comic::imagesLoaded, thread, &QThread::quit);
-        connect(thread, SIGNAL(started()), comicFile, SLOT(process()));
+        connect(thread, &QThread::started, comicFile, &Comic::process);
         connect(thread, &QThread::finished, thread, &QObject::deleteLater);
 
         comicFile->load(libraries.getPath(libraryId) + comic.path);

--- a/YACReaderLibrary/server/controllers/v1/comiccontroller.cpp
+++ b/YACReaderLibrary/server/controllers/v1/comiccontroller.cpp
@@ -61,8 +61,8 @@ void ComicController::service(HttpRequest &request, HttpResponse &response)
 
         comicFile->moveToThread(thread);
 
-        connect(comicFile, SIGNAL(errorOpening()), thread, SLOT(quit()));
-        connect(comicFile, SIGNAL(errorOpening(QString)), thread, SLOT(quit()));
+        connect(comicFile, QOverload<>::of(&Comic::errorOpening), thread, &QThread::quit);
+        connect(comicFile, QOverload<QString>::of(&Comic::errorOpening), thread, &QThread::quit);
         connect(comicFile, &Comic::imagesLoaded, thread, &QThread::quit);
         connect(thread, &QThread::started, comicFile, &Comic::process);
         connect(thread, &QThread::finished, thread, &QObject::deleteLater);

--- a/YACReaderLibrary/server/controllers/v1/comiccontroller.cpp
+++ b/YACReaderLibrary/server/controllers/v1/comiccontroller.cpp
@@ -63,9 +63,9 @@ void ComicController::service(HttpRequest &request, HttpResponse &response)
 
         connect(comicFile, SIGNAL(errorOpening()), thread, SLOT(quit()));
         connect(comicFile, SIGNAL(errorOpening(QString)), thread, SLOT(quit()));
-        connect(comicFile, SIGNAL(imagesLoaded()), thread, SLOT(quit()));
+        connect(comicFile, &Comic::imagesLoaded, thread, &QThread::quit);
         connect(thread, SIGNAL(started()), comicFile, SLOT(process()));
-        connect(thread, SIGNAL(finished()), thread, SLOT(deleteLater()));
+        connect(thread, &QThread::finished, thread, &QObject::deleteLater);
 
         comicFile->load(libraries.getPath(libraryId) + comic.path);
 

--- a/YACReaderLibrary/server/controllers/v2/comiccontroller_v2.cpp
+++ b/YACReaderLibrary/server/controllers/v2/comiccontroller_v2.cpp
@@ -66,8 +66,8 @@ void ComicControllerV2::service(HttpRequest &request, HttpResponse &response)
 
         comicFile->moveToThread(thread);
 
-        connect(comicFile, SIGNAL(errorOpening()), thread, SLOT(quit()));
-        connect(comicFile, SIGNAL(errorOpening(QString)), thread, SLOT(quit()));
+        connect(comicFile, QOverload<>::of(&Comic::errorOpening), thread, &QThread::quit);
+        connect(comicFile, QOverload<QString>::of(&Comic::errorOpening), thread, &QThread::quit);
         connect(comicFile, &Comic::imagesLoaded, thread, &QThread::quit);
         connect(thread, &QThread::started, comicFile, &Comic::process);
         connect(thread, &QThread::finished, thread, &QObject::deleteLater);

--- a/YACReaderLibrary/server/controllers/v2/comiccontroller_v2.cpp
+++ b/YACReaderLibrary/server/controllers/v2/comiccontroller_v2.cpp
@@ -69,7 +69,7 @@ void ComicControllerV2::service(HttpRequest &request, HttpResponse &response)
         connect(comicFile, SIGNAL(errorOpening()), thread, SLOT(quit()));
         connect(comicFile, SIGNAL(errorOpening(QString)), thread, SLOT(quit()));
         connect(comicFile, &Comic::imagesLoaded, thread, &QThread::quit);
-        connect(thread, SIGNAL(started()), comicFile, SLOT(process()));
+        connect(thread, &QThread::started, comicFile, &Comic::process);
         connect(thread, &QThread::finished, thread, &QObject::deleteLater);
 
         comicFile->load(libraries.getPath(libraryId) + comic.path);

--- a/YACReaderLibrary/server/controllers/v2/comiccontroller_v2.cpp
+++ b/YACReaderLibrary/server/controllers/v2/comiccontroller_v2.cpp
@@ -68,9 +68,9 @@ void ComicControllerV2::service(HttpRequest &request, HttpResponse &response)
 
         connect(comicFile, SIGNAL(errorOpening()), thread, SLOT(quit()));
         connect(comicFile, SIGNAL(errorOpening(QString)), thread, SLOT(quit()));
-        connect(comicFile, SIGNAL(imagesLoaded()), thread, SLOT(quit()));
+        connect(comicFile, &Comic::imagesLoaded, thread, &QThread::quit);
         connect(thread, SIGNAL(started()), comicFile, SLOT(process()));
-        connect(thread, SIGNAL(finished()), thread, SLOT(deleteLater()));
+        connect(thread, &QThread::finished, thread, &QObject::deleteLater);
 
         comicFile->load(libraries.getPath(libraryId) + comic.path);
 

--- a/YACReaderLibrary/server/controllers/v2/comiccontrollerinreadinglist_v2.cpp
+++ b/YACReaderLibrary/server/controllers/v2/comiccontrollerinreadinglist_v2.cpp
@@ -55,9 +55,9 @@ void ComicControllerInReadingListV2::service(HttpRequest &request, HttpResponse 
 
         connect(comicFile, SIGNAL(errorOpening()), thread, SLOT(quit()));
         connect(comicFile, SIGNAL(errorOpening(QString)), thread, SLOT(quit()));
-        connect(comicFile, SIGNAL(imagesLoaded()), thread, SLOT(quit()));
+        connect(comicFile, &Comic::imagesLoaded, thread, &QThread::quit);
         connect(thread, SIGNAL(started()), comicFile, SLOT(process()));
-        connect(thread, SIGNAL(finished()), thread, SLOT(deleteLater()));
+        connect(thread, &QThread::finished, thread, &QObject::deleteLater);
 
         comicFile->load(libraries.getPath(libraryId) + comic.path);
 

--- a/YACReaderLibrary/server/controllers/v2/comiccontrollerinreadinglist_v2.cpp
+++ b/YACReaderLibrary/server/controllers/v2/comiccontrollerinreadinglist_v2.cpp
@@ -53,8 +53,8 @@ void ComicControllerInReadingListV2::service(HttpRequest &request, HttpResponse 
 
         comicFile->moveToThread(thread);
 
-        connect(comicFile, SIGNAL(errorOpening()), thread, SLOT(quit()));
-        connect(comicFile, SIGNAL(errorOpening(QString)), thread, SLOT(quit()));
+        connect(comicFile, QOverload<>::of(&Comic::errorOpening), thread, &QThread::quit);
+        connect(comicFile, QOverload<QString>::of(&Comic::errorOpening), thread, &QThread::quit);
         connect(comicFile, &Comic::imagesLoaded, thread, &QThread::quit);
         connect(thread, &QThread::started, comicFile, &Comic::process);
         connect(thread, &QThread::finished, thread, &QObject::deleteLater);

--- a/YACReaderLibrary/server/controllers/v2/comiccontrollerinreadinglist_v2.cpp
+++ b/YACReaderLibrary/server/controllers/v2/comiccontrollerinreadinglist_v2.cpp
@@ -56,7 +56,7 @@ void ComicControllerInReadingListV2::service(HttpRequest &request, HttpResponse 
         connect(comicFile, SIGNAL(errorOpening()), thread, SLOT(quit()));
         connect(comicFile, SIGNAL(errorOpening(QString)), thread, SLOT(quit()));
         connect(comicFile, &Comic::imagesLoaded, thread, &QThread::quit);
-        connect(thread, SIGNAL(started()), comicFile, SLOT(process()));
+        connect(thread, &QThread::started, comicFile, &Comic::process);
         connect(thread, &QThread::finished, thread, &QObject::deleteLater);
 
         comicFile->load(libraries.getPath(libraryId) + comic.path);

--- a/YACReaderLibrary/server_config_dialog.cpp
+++ b/YACReaderLibrary/server_config_dialog.cpp
@@ -139,7 +139,7 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent)
     portWidget->setLayout(portWidgetLayout);
     portWidget->move(332, 244);
     //accept->move(514,149);
-    connect(accept, SIGNAL(pressed()), this, SLOT(updatePort()));
+    connect(accept, &QAbstractButton::pressed, this, &ServerConfigDialog::updatePort);
     //END FORM-----------------------------------------------------------------
 
     check = new QCheckBox(this);
@@ -174,8 +174,8 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent)
 
     settings->endGroup();
 
-    connect(check, SIGNAL(stateChanged(int)), this, SLOT(enableServer(int)));
-    connect(performanceWorkaroundCheck, SIGNAL(stateChanged(int)), this, SLOT(enableperformanceWorkaround(int)));
+    connect(check, &QCheckBox::stateChanged, this, &ServerConfigDialog::enableServer);
+    connect(performanceWorkaroundCheck, &QCheckBox::stateChanged, this, &ServerConfigDialog::enableperformanceWorkaround);
 }
 
 void ServerConfigDialog::enableServer(int status)

--- a/YACReaderLibrary/server_config_dialog.cpp
+++ b/YACReaderLibrary/server_config_dialog.cpp
@@ -117,7 +117,7 @@ ServerConfigDialog::ServerConfigDialog(QWidget *parent)
     portLabel->setStyleSheet("QLabel {color:#575757; font-size:18px; font-family: Arial;}");
 
     ip = new QComboBox(this);
-    connect(ip, SIGNAL(activated(const QString &)), this, SLOT(regenerateQR(const QString &)));
+    connect(ip, QOverload<const QString &>::of(&QComboBox::activated), this, &ServerConfigDialog::regenerateQR);
 
     ip->setFixedWidth(200);
     ip->move(332, 153);

--- a/YACReaderLibrary/yacreader_comics_views_manager.cpp
+++ b/YACReaderLibrary/yacreader_comics_views_manager.cpp
@@ -31,7 +31,7 @@ YACReaderComicsViewsManager::YACReaderComicsViewsManager(QSettings *settings, Li
 
     case Grid:
         comicsView = gridComicsView = new GridComicsView();
-        connect(libraryWindow->optionsDialog, SIGNAL(optionsChanged()), gridComicsView, SLOT(updateBackgroundConfig()));
+        connect(libraryWindow->optionsDialog, &YACReaderOptionsDialog::optionsChanged, gridComicsView, &GridComicsView::updateBackgroundConfig);
         comicsViewStatus = Grid;
         break;
 
@@ -114,8 +114,8 @@ void YACReaderComicsViewsManager::showNoSearchResultsView()
 void YACReaderComicsViewsManager::toggleComicsView()
 {
     if (comicsViewStack->currentWidget() == comicsView) {
-        QTimer::singleShot(0, this, SLOT(showComicsViewTransition()));
-        QTimer::singleShot(100, this, SLOT(_toggleComicsView()));
+        QTimer::singleShot(0, this, &YACReaderComicsViewsManager::showComicsViewTransition);
+        QTimer::singleShot(100, this, &YACReaderComicsViewsManager::_toggleComicsView);
     } else {
         _toggleComicsView();
     }
@@ -130,28 +130,28 @@ void YACReaderComicsViewsManager::focusComicsViewViaShortcut()
 
 void YACReaderComicsViewsManager::disconnectComicsViewConnections(ComicsView *widget)
 {
-    disconnect(widget, SIGNAL(comicRated(int, QModelIndex)), libraryWindow->comicsModel, SLOT(updateRating(int, QModelIndex)));
-    disconnect(libraryWindow->showHideMarksAction, SIGNAL(toggled(bool)), widget, SLOT(setShowMarks(bool)));
-    disconnect(widget, SIGNAL(selected(unsigned int)), libraryWindow, SLOT(openComic()));
-    disconnect(widget, SIGNAL(openComic(ComicDB)), libraryWindow, SLOT(openComic(ComicDB)));
-    disconnect(libraryWindow->selectAllComicsAction, SIGNAL(triggered()), widget, SLOT(selectAll()));
+    disconnect(widget, &ComicsView::comicRated, libraryWindow->comicsModel, &ComicModel::updateRating);
+    disconnect(libraryWindow->showHideMarksAction, &QAction::toggled, widget, &ComicsView::setShowMarks);
+    disconnect(widget, &ComicsView::selected, libraryWindow, QOverload<>::of(&LibraryWindow::openComic));
+    disconnect(widget, &ComicsView::openComic, libraryWindow, QOverload<const ComicDB &, const ComicModel::Mode>::of(&LibraryWindow::openComic));
+    disconnect(libraryWindow->selectAllComicsAction, &QAction::triggered, widget, &ComicsView::selectAll);
     disconnect(comicsView, SIGNAL(copyComicsToCurrentFolder(QList<QPair<QString, QString>>)), libraryWindow, SLOT(copyAndImportComicsToCurrentFolder(QList<QPair<QString, QString>>)));
     disconnect(comicsView, SIGNAL(moveComicsToCurrentFolder(QList<QPair<QString, QString>>)), libraryWindow, SLOT(moveAndImportComicsToCurrentFolder(QList<QPair<QString, QString>>)));
-    disconnect(comicsView, SIGNAL(customContextMenuViewRequested(QPoint)), libraryWindow, SLOT(showComicsViewContextMenu(QPoint)));
-    disconnect(comicsView, SIGNAL(customContextMenuItemRequested(QPoint)), libraryWindow, SLOT(showComicsItemContextMenu(QPoint)));
+    disconnect(comicsView, &ComicsView::customContextMenuViewRequested, libraryWindow, &LibraryWindow::showComicsViewContextMenu);
+    disconnect(comicsView, &ComicsView::customContextMenuItemRequested, libraryWindow, &LibraryWindow::showComicsItemContextMenu);
 }
 
 void YACReaderComicsViewsManager::doComicsViewConnections()
 {
-    connect(comicsView, SIGNAL(comicRated(int, QModelIndex)), libraryWindow->comicsModel, SLOT(updateRating(int, QModelIndex)));
-    connect(libraryWindow->showHideMarksAction, SIGNAL(toggled(bool)), comicsView, SLOT(setShowMarks(bool)));
-    connect(comicsView, SIGNAL(selected(unsigned int)), libraryWindow, SLOT(openComic()));
-    connect(comicsView, SIGNAL(openComic(const ComicDB &, const ComicModel::Mode)), libraryWindow, SLOT(openComic(const ComicDB &, const ComicModel::Mode)));
+    connect(comicsView, &ComicsView::comicRated, libraryWindow->comicsModel, &ComicModel::updateRating);
+    connect(libraryWindow->showHideMarksAction, &QAction::toggled, comicsView, &ComicsView::setShowMarks);
+    connect(comicsView, &ComicsView::selected, libraryWindow, QOverload<>::of(&LibraryWindow::openComic));
+    connect(comicsView, &ComicsView::openComic, libraryWindow, QOverload<const ComicDB &, const ComicModel::Mode>::of(&LibraryWindow::openComic));
 
-    connect(libraryWindow->selectAllComicsAction, SIGNAL(triggered()), comicsView, SLOT(selectAll()));
+    connect(libraryWindow->selectAllComicsAction, &QAction::triggered, comicsView, &ComicsView::selectAll);
 
-    connect(comicsView, SIGNAL(customContextMenuViewRequested(QPoint)), libraryWindow, SLOT(showComicsViewContextMenu(QPoint)));
-    connect(comicsView, SIGNAL(customContextMenuItemRequested(QPoint)), libraryWindow, SLOT(showComicsItemContextMenu(QPoint)));
+    connect(comicsView, &ComicsView::customContextMenuViewRequested, libraryWindow, &LibraryWindow::showComicsViewContextMenu);
+    connect(comicsView, &ComicsView::customContextMenuItemRequested, libraryWindow, &LibraryWindow::showComicsItemContextMenu);
     //Drops
     connect(comicsView, SIGNAL(copyComicsToCurrentFolder(QList<QPair<QString, QString>>)), libraryWindow, SLOT(copyAndImportComicsToCurrentFolder(QList<QPair<QString, QString>>)));
     connect(comicsView, SIGNAL(moveComicsToCurrentFolder(QList<QPair<QString, QString>>)), libraryWindow, SLOT(moveAndImportComicsToCurrentFolder(QList<QPair<QString, QString>>)));
@@ -200,7 +200,7 @@ void YACReaderComicsViewsManager::_toggleComicsView()
             gridComicsView = new GridComicsView();
 
         switchToComicsView(classicComicsView, gridComicsView);
-        connect(libraryWindow->optionsDialog, SIGNAL(optionsChanged()), gridComicsView, SLOT(updateBackgroundConfig()));
+        connect(libraryWindow->optionsDialog, &YACReaderOptionsDialog::optionsChanged, gridComicsView, &GridComicsView::updateBackgroundConfig);
         comicsViewStatus = Grid;
 
         break;

--- a/YACReaderLibrary/yacreader_comics_views_manager.cpp
+++ b/YACReaderLibrary/yacreader_comics_views_manager.cpp
@@ -59,9 +59,8 @@ YACReaderComicsViewsManager::YACReaderComicsViewsManager(QSettings *settings, Li
     comicsViewStack->setCurrentWidget(comicsView);
 
     //connections
-
-    connect(emptyFolderWidget, SIGNAL(copyComicsToCurrentFolder(QList<QPair<QString, QString>>)), libraryWindow, SLOT(copyAndImportComicsToCurrentFolder(QList<QPair<QString, QString>>)));
-    connect(emptyFolderWidget, SIGNAL(moveComicsToCurrentFolder(QList<QPair<QString, QString>>)), libraryWindow, SLOT(moveAndImportComicsToCurrentFolder(QList<QPair<QString, QString>>)));
+    connect(emptyFolderWidget, &EmptyFolderWidget::copyComicsToCurrentFolder, libraryWindow, &LibraryWindow::copyAndImportComicsToCurrentFolder);
+    connect(emptyFolderWidget, &EmptyFolderWidget::moveComicsToCurrentFolder, libraryWindow, &LibraryWindow::moveAndImportComicsToCurrentFolder);
 }
 
 QWidget *YACReaderComicsViewsManager::containerWidget()
@@ -135,8 +134,8 @@ void YACReaderComicsViewsManager::disconnectComicsViewConnections(ComicsView *wi
     disconnect(widget, &ComicsView::selected, libraryWindow, QOverload<>::of(&LibraryWindow::openComic));
     disconnect(widget, &ComicsView::openComic, libraryWindow, QOverload<const ComicDB &, const ComicModel::Mode>::of(&LibraryWindow::openComic));
     disconnect(libraryWindow->selectAllComicsAction, &QAction::triggered, widget, &ComicsView::selectAll);
-    disconnect(comicsView, SIGNAL(copyComicsToCurrentFolder(QList<QPair<QString, QString>>)), libraryWindow, SLOT(copyAndImportComicsToCurrentFolder(QList<QPair<QString, QString>>)));
-    disconnect(comicsView, SIGNAL(moveComicsToCurrentFolder(QList<QPair<QString, QString>>)), libraryWindow, SLOT(moveAndImportComicsToCurrentFolder(QList<QPair<QString, QString>>)));
+    disconnect(comicsView, &ComicsView::copyComicsToCurrentFolder, libraryWindow, &LibraryWindow::copyAndImportComicsToCurrentFolder);
+    disconnect(comicsView, &ComicsView::moveComicsToCurrentFolder, libraryWindow, &LibraryWindow::moveAndImportComicsToCurrentFolder);
     disconnect(comicsView, &ComicsView::customContextMenuViewRequested, libraryWindow, &LibraryWindow::showComicsViewContextMenu);
     disconnect(comicsView, &ComicsView::customContextMenuItemRequested, libraryWindow, &LibraryWindow::showComicsItemContextMenu);
 }
@@ -153,8 +152,8 @@ void YACReaderComicsViewsManager::doComicsViewConnections()
     connect(comicsView, &ComicsView::customContextMenuViewRequested, libraryWindow, &LibraryWindow::showComicsViewContextMenu);
     connect(comicsView, &ComicsView::customContextMenuItemRequested, libraryWindow, &LibraryWindow::showComicsItemContextMenu);
     //Drops
-    connect(comicsView, SIGNAL(copyComicsToCurrentFolder(QList<QPair<QString, QString>>)), libraryWindow, SLOT(copyAndImportComicsToCurrentFolder(QList<QPair<QString, QString>>)));
-    connect(comicsView, SIGNAL(moveComicsToCurrentFolder(QList<QPair<QString, QString>>)), libraryWindow, SLOT(moveAndImportComicsToCurrentFolder(QList<QPair<QString, QString>>)));
+    connect(comicsView, &ComicsView::copyComicsToCurrentFolder, libraryWindow, &LibraryWindow::copyAndImportComicsToCurrentFolder);
+    connect(comicsView, &ComicsView::moveComicsToCurrentFolder, libraryWindow, &LibraryWindow::moveAndImportComicsToCurrentFolder);
 }
 
 void YACReaderComicsViewsManager::switchToComicsView(ComicsView *from, ComicsView *to)

--- a/YACReaderLibrary/yacreader_local_server.cpp
+++ b/YACReaderLibrary/yacreader_local_server.cpp
@@ -24,7 +24,7 @@ YACReaderLocalServer::YACReaderLocalServer(QObject *parent)
         QLOG_ERROR() << "Unable to create local server";
     }
 
-    connect(localServer, SIGNAL(newConnection()), this, SLOT(sendResponse()));
+    connect(localServer, &QLocalServer::newConnection, this, &YACReaderLocalServer::sendResponse);
 }
 
 bool YACReaderLocalServer::isListening()
@@ -47,8 +47,8 @@ void YACReaderLocalServer::sendResponse()
     auto worker = new YACReaderClientConnectionWorker(clientConnection);
     if (worker != 0) {
         clientConnection->moveToThread(worker);
-        connect(worker, SIGNAL(comicUpdated(quint64, ComicDB)), this, SIGNAL(comicUpdated(quint64, ComicDB)));
-        connect(worker, SIGNAL(finished()), worker, SLOT(deleteLater()));
+        connect(worker, &YACReaderClientConnectionWorker::comicUpdated, this, &YACReaderLocalServer::comicUpdated);
+        connect(worker, &QThread::finished, worker, &QObject::deleteLater);
         worker->start();
     }
 

--- a/YACReaderLibrary/yacreader_navigation_controller.cpp
+++ b/YACReaderLibrary/yacreader_navigation_controller.cpp
@@ -269,11 +269,11 @@ void YACReaderNavigationController::loadPreviousStatus()
 
 void YACReaderNavigationController::setupConnections()
 {
-    connect(libraryWindow->foldersView, SIGNAL(clicked(QModelIndex)), this, SLOT(selectedFolder(QModelIndex)));
-    connect(libraryWindow->listsView, SIGNAL(clicked(QModelIndex)), this, SLOT(selectedList(QModelIndex)));
-    connect(libraryWindow->historyController, SIGNAL(modelIndexSelected(YACReaderLibrarySourceContainer)), this, SLOT(selectedIndexFromHistory(YACReaderLibrarySourceContainer)));
-    connect(comicsViewsManager->emptyFolderWidget, SIGNAL(subfolderSelected(QModelIndex, int)), this, SLOT(selectSubfolder(QModelIndex, int)));
-    connect(libraryWindow->comicsModel, SIGNAL(isEmpty()), this, SLOT(reselectCurrentSource()));
+    connect(libraryWindow->foldersView, &QAbstractItemView::clicked, this, &YACReaderNavigationController::selectedFolder);
+    connect(libraryWindow->listsView, &QAbstractItemView::clicked, this, &YACReaderNavigationController::selectedList);
+    connect(libraryWindow->historyController, &YACReaderHistoryController::modelIndexSelected, this, &YACReaderNavigationController::selectedIndexFromHistory);
+    connect(comicsViewsManager->emptyFolderWidget, &EmptyFolderWidget::subfolderSelected, this, &YACReaderNavigationController::selectSubfolder);
+    connect(libraryWindow->comicsModel, &ComicModel::isEmpty, this, &YACReaderNavigationController::reselectCurrentSource);
 }
 
 qulonglong YACReaderNavigationController::folderModelIndexToID(const QModelIndex &mi)

--- a/common/check_new_version.cpp
+++ b/common/check_new_version.cpp
@@ -15,7 +15,7 @@
 HttpVersionChecker::HttpVersionChecker()
     : HttpWorker("https://raw.githubusercontent.com/YACReader/yacreader/master/common/yacreader_global.h")
 {
-    connect(this, SIGNAL(dataReady(const QByteArray &)), this, SLOT(checkNewVersion(const QByteArray &)));
+    connect(this, &HttpVersionChecker::dataReady, this, QOverload<const QByteArray &>::of(&HttpVersionChecker::checkNewVersion));
 }
 
 void HttpVersionChecker::checkNewVersion(const QByteArray &data)

--- a/common/comic.cpp
+++ b/common/comic.cpp
@@ -126,7 +126,7 @@ Comic::~Comic()
 //-----------------------------------------------------------------------------
 void Comic::setup()
 {
-    connect(this, SIGNAL(pageChanged(int)), this, SLOT(checkIsBookmark(int)));
+    connect(this, &Comic::pageChanged, this, &Comic::checkIsBookmark);
     connect(this, SIGNAL(imageLoaded(int)), this, SLOT(updateBookmarkImage(int)));
     connect(this, SIGNAL(imageLoaded(int)), this, SLOT(setPageLoaded(int)));
 

--- a/common/comic.cpp
+++ b/common/comic.cpp
@@ -127,8 +127,8 @@ Comic::~Comic()
 void Comic::setup()
 {
     connect(this, &Comic::pageChanged, this, &Comic::checkIsBookmark);
-    connect(this, SIGNAL(imageLoaded(int)), this, SLOT(updateBookmarkImage(int)));
-    connect(this, SIGNAL(imageLoaded(int)), this, SLOT(setPageLoaded(int)));
+    connect(this, QOverload<int>::of(&Comic::imageLoaded), this, &Comic::updateBookmarkImage);
+    connect(this, QOverload<int>::of(&Comic::imageLoaded), this, &Comic::setPageLoaded);
 
     auto l = [&]() { _errorOpening = true; };
 

--- a/common/comic.h
+++ b/common/comic.h
@@ -92,6 +92,7 @@ public slots:
     void updateBookmarkImage(int);
     void setPageLoaded(int page);
     void invalidate();
+    virtual void process() {};
 
 signals:
     void invalidated();

--- a/common/http_worker.cpp
+++ b/common/http_worker.cpp
@@ -44,8 +44,8 @@ void HttpWorker::run()
     QTimer tT;
 
     tT.setSingleShot(true);
-    connect(&tT, SIGNAL(timeout()), &q, SLOT(quit()));
-    connect(&manager, SIGNAL(finished(QNetworkReply *)), &q, SLOT(quit()));
+    connect(&tT, &QTimer::timeout, &q, &QEventLoop::quit);
+    connect(&manager, &QNetworkAccessManager::finished, &q, &QEventLoop::quit);
     QNetworkReply *reply = manager.get(QNetworkRequest(url));
 
     tT.start(5000); // 5s timeout

--- a/common/onstart_flow_selection_dialog.cpp
+++ b/common/onstart_flow_selection_dialog.cpp
@@ -9,9 +9,9 @@ OnStartFlowSelectionDialog::OnStartFlowSelectionDialog(QWidget *parent)
 {
     setModal(true);
     QPushButton *acceptHW = new QPushButton(this);
-    connect(acceptHW, SIGNAL(clicked()), this, SLOT(accept()));
+    connect(acceptHW, &QAbstractButton::clicked, this, &QDialog::accept);
     QPushButton *rejectHW = new QPushButton(this); //and use SW flow
-    connect(rejectHW, SIGNAL(clicked()), this, SLOT(reject()));
+    connect(rejectHW, &QAbstractButton::clicked, this, &QDialog::reject);
 
     acceptHW->setGeometry(90, 165, 110, 118);
     acceptHW->setFlat(true);

--- a/common/pictureflow.cpp
+++ b/common/pictureflow.cpp
@@ -778,7 +778,7 @@ QImage *PictureFlowSoftwareRenderer::surface(int slideIndex)
 		  {
 			  for(int i = iInit-(j-jInit); i < iInit; i ++)
 			  {
-				  
+
 				  painter.drawPoint(i,j);
 			  }
 		  }*/
@@ -986,7 +986,7 @@ PictureFlow::PictureFlow(QWidget *parent, FlowType flowType)
     d->animator->state = d->state;
     QObject::connect(&d->animator->animateTimer, &QTimer::timeout, this, &PictureFlow::updateAnimation);
 
-    QObject::connect(&d->triggerTimer, SIGNAL(timeout()), this, SLOT(render()));
+    QObject::connect(&d->triggerTimer, &QTimer::timeout, this, QOverload<>::of(&PictureFlow::render));
 
 #ifdef PICTUREFLOW_QT4
     setAttribute(Qt::WA_StaticContents, true);

--- a/common/pictureflow.cpp
+++ b/common/pictureflow.cpp
@@ -984,7 +984,7 @@ PictureFlow::PictureFlow(QWidget *parent, FlowType flowType)
 
     d->animator = new PictureFlowAnimator;
     d->animator->state = d->state;
-    QObject::connect(&d->animator->animateTimer, SIGNAL(timeout()), this, SLOT(updateAnimation()));
+    QObject::connect(&d->animator->animateTimer, &QTimer::timeout, this, &PictureFlow::updateAnimation);
 
     QObject::connect(&d->triggerTimer, SIGNAL(timeout()), this, SLOT(render()));
 
@@ -1299,9 +1299,9 @@ void PictureFlow::updateAnimation() //bucle principal
     if (d->animator->animating == true) {
         int difference = 10 - now.elapsed();
         if (difference >= 0 && !frameSkiped)
-            QTimer::singleShot(difference, this, SLOT(updateAnimation()));
+            QTimer::singleShot(difference, this, &PictureFlow::updateAnimation);
         else {
-            QTimer::singleShot(0, this, SLOT(updateAnimation()));
+            QTimer::singleShot(0, this, &PictureFlow::updateAnimation);
             if (!frameSkiped)
                 framesSkip = -((difference - 10) / 10);
         }

--- a/custom_widgets/yacreader_busy_widget.cpp
+++ b/custom_widgets/yacreader_busy_widget.cpp
@@ -35,7 +35,7 @@ BusyIndicator::BusyIndicator(QWidget *parent)
     fillColor = palette().color(QPalette::WindowText);
 
     timer.setInterval(16);
-    connect(&timer, SIGNAL(timeout()), this, SLOT(rotate()));
+    connect(&timer, &QTimer::timeout, this, &BusyIndicator::rotate);
     timer.start();
 }
 

--- a/custom_widgets/yacreader_gl_flow_config_widget.cpp
+++ b/custom_widgets/yacreader_gl_flow_config_widget.cpp
@@ -75,7 +75,7 @@ YACReaderGLFlowConfigWidget::YACReaderGLFlowConfigWidget(QWidget *parent /* = 0 
 
     showAdvancedOptions = new QPushButton(tr("Show advanced settings"));
     showAdvancedOptions->setCheckable(true);
-    connect(showAdvancedOptions, SIGNAL(toggled(bool)), this, SLOT(avancedOptionToogled(bool)));
+    connect(showAdvancedOptions, &QAbstractButton::toggled, this, &YACReaderGLFlowConfigWidget::avancedOptionToogled);
 
     vbox->addWidget(showAdvancedOptions, 0, Qt::AlignRight);
 

--- a/custom_widgets/yacreader_library_item_widget.cpp
+++ b/custom_widgets/yacreader_library_item_widget.cpp
@@ -42,7 +42,7 @@ YACReaderLibraryItemWidget::YACReaderLibraryItemWidget(QString n /*ame*/, QStrin
     options->setFixedWidth(18);
     options->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Minimum);
     options->setStyleSheet("QToolButton {border:none;}");
-    connect(options, SIGNAL(clicked()), this, SIGNAL(showOptions()));
+    connect(options, &QAbstractButton::clicked, this, &YACReaderLibraryItemWidget::showOptions);
     /*up = new QToolButton(this);
 	up->setIcon(QIcon(":/images/libraryUp.png"));
 	up->setHidden(true);

--- a/custom_widgets/yacreader_library_list_widget.cpp
+++ b/custom_widgets/yacreader_library_list_widget.cpp
@@ -21,7 +21,7 @@ void YACReaderLibraryListWidget::addItem(QString name, QString path)
     QVBoxLayout *mainLayout = dynamic_cast<QVBoxLayout *>(layout());
 
     YACReaderLibraryItemWidget *library = new YACReaderLibraryItemWidget(name, path, this);
-    connect(library, SIGNAL(showOptions()), this, SLOT(showContextMenu()));
+    connect(library, &YACReaderLibraryItemWidget::showOptions, this, &YACReaderLibraryListWidget::showContextMenu);
     QList<YACReaderLibraryItemWidget *>::iterator itr;
     int i = 0;
     for (itr = librariesList.begin(); itr != librariesList.end() && !naturalSortLessThanCI(name, (*itr)->name); itr++)

--- a/custom_widgets/yacreader_macosx_toolbar.mm
+++ b/custom_widgets/yacreader_macosx_toolbar.mm
@@ -188,7 +188,7 @@ void YACReaderMacOSXToolbar::addAction(QAction *action)
     QMacToolBarItem *toolBarItem = addItem(action->icon(), action->text());
     if (action->data().toString() == TOGGLE_COMICS_VIEW_ACTION_YL)
         viewSelector = toolBarItem;
-    connect(toolBarItem, SIGNAL(activated()), action, SIGNAL(triggered()));
+    connect(toolBarItem, &QMacToolBarItem::activated, action, [=] { emit action->triggered(); });
 
     NSToolbarItem *nativeItem = toolBarItem->nativeToolBarItem();
     actions.insert(QString::fromNSString(nativeItem.itemIdentifier), action);
@@ -287,7 +287,7 @@ QAction *YACReaderMacOSXToolbar::addFitToWidthSlider(QAction *attachToAction)
 
     QAction *action = new QAction("", attachToAction->parent());
 
-    connect(toolBarItem, SIGNAL(activated()), action, SIGNAL(triggered()));
+    connect(toolBarItem, &QMacToolBarItem::activated, action, [=] { emit action->triggered(); });
 
     return action;
 }
@@ -359,8 +359,8 @@ MacToolBarItemWrapper::MacToolBarItemWrapper(QAction *action, QMacToolBarItem *t
     : action(action), toolbaritem(toolbaritem)
 {
     if (action->isCheckable()) {
-        connect(action, SIGNAL(toggled(bool)), this, SLOT(actionToggled(bool)));
-        connect(toolbaritem, SIGNAL(activated()), action, SLOT(toggle()));
+        connect(action, &QAction::toggled, this, &MacToolBarItemWrapper::actionToggled);
+        connect(toolbaritem, &QMacToolBarItem::activated, action, &QAction::toggle);
         updateIcon(action->isChecked());
     }
 }

--- a/custom_widgets/yacreader_options_dialog.cpp
+++ b/custom_widgets/yacreader_options_dialog.cpp
@@ -37,73 +37,73 @@ YACReaderOptionsDialog::YACReaderOptionsDialog(QWidget *parent)
     shortcutsBox = new QGroupBox(tr("Shortcuts"));
     shortcutsBox->setLayout(shortcutsLayout);
 
-    connect(shortcutsButton, SIGNAL(clicked()), this, SIGNAL(editShortcuts()));
+    connect(shortcutsButton, &QAbstractButton::clicked, this, &YACReaderOptionsDialog::editShortcuts);
 
-    connect(accept, SIGNAL(clicked()), this, SLOT(saveOptions()));
+    connect(accept, &QAbstractButton::clicked, this, &YACReaderOptionsDialog::saveOptions);
     connect(cancel, SIGNAL(clicked()), this, SLOT(restoreOptions())); //TODO fix this
-    connect(cancel, SIGNAL(clicked()), this, SLOT(close()));
+    connect(cancel, &QAbstractButton::clicked, this, &QWidget::close);
 #ifndef NO_OPENGL
     useGL = new QCheckBox(tr("Use hardware acceleration (restart needed)"));
-    connect(useGL, SIGNAL(stateChanged(int)), this, SLOT(saveUseGL(int)));
+    connect(useGL, &QCheckBox::stateChanged, this, &YACReaderOptionsDialog::saveUseGL);
 #endif
 #ifdef FORCE_ANGLE
     useGL->setHidden(true);
 #endif
     //sw CONNECTIONS
-    connect(sw->radio1, SIGNAL(toggled(bool)), this, SLOT(setClassicConfigSW()));
-    connect(sw->radio2, SIGNAL(toggled(bool)), this, SLOT(setStripeConfigSW()));
-    connect(sw->radio3, SIGNAL(toggled(bool)), this, SLOT(setOverlappedStripeConfigSW()));
+    connect(sw->radio1, &QAbstractButton::toggled, this, &YACReaderOptionsDialog::setClassicConfigSW);
+    connect(sw->radio2, &QAbstractButton::toggled, this, &YACReaderOptionsDialog::setStripeConfigSW);
+    connect(sw->radio3, &QAbstractButton::toggled, this, &YACReaderOptionsDialog::setOverlappedStripeConfigSW);
 #ifndef NO_OPENGL
     //gl CONNECTIONS
-    connect(gl->radioClassic, SIGNAL(toggled(bool)), this, SLOT(setClassicConfig()));
-    connect(gl->radioStripe, SIGNAL(toggled(bool)), this, SLOT(setStripeConfig()));
-    connect(gl->radioOver, SIGNAL(toggled(bool)), this, SLOT(setOverlappedStripeConfig()));
-    connect(gl->radionModern, SIGNAL(toggled(bool)), this, SLOT(setModernConfig()));
-    connect(gl->radioDown, SIGNAL(toggled(bool)), this, SLOT(setRouletteConfig()));
+    connect(gl->radioClassic, &QAbstractButton::toggled, this, &YACReaderOptionsDialog::setClassicConfig);
+    connect(gl->radioStripe, &QAbstractButton::toggled, this, &YACReaderOptionsDialog::setStripeConfig);
+    connect(gl->radioOver, &QAbstractButton::toggled, this, &YACReaderOptionsDialog::setOverlappedStripeConfig);
+    connect(gl->radionModern, &QAbstractButton::toggled, this, &YACReaderOptionsDialog::setModernConfig);
+    connect(gl->radioDown, &QAbstractButton::toggled, this, &YACReaderOptionsDialog::setRouletteConfig);
 
-    connect(gl->radioClassic, SIGNAL(toggled(bool)), this, SIGNAL(optionsChanged()));
-    connect(gl->radioStripe, SIGNAL(toggled(bool)), this, SIGNAL(optionsChanged()));
-    connect(gl->radioOver, SIGNAL(toggled(bool)), this, SIGNAL(optionsChanged()));
-    connect(gl->radionModern, SIGNAL(toggled(bool)), this, SIGNAL(optionsChanged()));
-    connect(gl->radioDown, SIGNAL(toggled(bool)), this, SIGNAL(optionsChanged()));
+    connect(gl->radioClassic, &QAbstractButton::toggled, this, &YACReaderOptionsDialog::optionsChanged);
+    connect(gl->radioStripe, &QAbstractButton::toggled, this, &YACReaderOptionsDialog::optionsChanged);
+    connect(gl->radioOver, &QAbstractButton::toggled, this, &YACReaderOptionsDialog::optionsChanged);
+    connect(gl->radionModern, &QAbstractButton::toggled, this, &YACReaderOptionsDialog::optionsChanged);
+    connect(gl->radioDown, &QAbstractButton::toggled, this, &YACReaderOptionsDialog::optionsChanged);
 
-    connect(gl->xRotation, SIGNAL(valueChanged(int)), this, SLOT(saveXRotation(int)));
-    connect(gl->xRotation, SIGNAL(valueChanged(int)), this, SIGNAL(optionsChanged()));
+    connect(gl->xRotation, &YACReaderSpinSliderWidget::valueChanged, this, &YACReaderOptionsDialog::saveXRotation);
+    connect(gl->xRotation, &YACReaderSpinSliderWidget::valueChanged, this, &YACReaderOptionsDialog::optionsChanged);
 
-    connect(gl->yPosition, SIGNAL(valueChanged(int)), this, SLOT(saveYPosition(int)));
-    connect(gl->yPosition, SIGNAL(valueChanged(int)), this, SIGNAL(optionsChanged()));
+    connect(gl->yPosition, &YACReaderSpinSliderWidget::valueChanged, this, &YACReaderOptionsDialog::saveYPosition);
+    connect(gl->yPosition, &YACReaderSpinSliderWidget::valueChanged, this, &YACReaderOptionsDialog::optionsChanged);
 
-    connect(gl->coverDistance, SIGNAL(valueChanged(int)), this, SLOT(saveCoverDistance(int)));
-    connect(gl->coverDistance, SIGNAL(valueChanged(int)), this, SIGNAL(optionsChanged()));
+    connect(gl->coverDistance, &YACReaderSpinSliderWidget::valueChanged, this, &YACReaderOptionsDialog::saveCoverDistance);
+    connect(gl->coverDistance, &YACReaderSpinSliderWidget::valueChanged, this, &YACReaderOptionsDialog::optionsChanged);
 
-    connect(gl->centralDistance, SIGNAL(valueChanged(int)), this, SLOT(saveCentralDistance(int)));
-    connect(gl->centralDistance, SIGNAL(valueChanged(int)), this, SIGNAL(optionsChanged()));
+    connect(gl->centralDistance, &YACReaderSpinSliderWidget::valueChanged, this, &YACReaderOptionsDialog::saveCentralDistance);
+    connect(gl->centralDistance, &YACReaderSpinSliderWidget::valueChanged, this, &YACReaderOptionsDialog::optionsChanged);
 
-    connect(gl->zoomLevel, SIGNAL(valueChanged(int)), this, SLOT(saveZoomLevel(int)));
-    connect(gl->zoomLevel, SIGNAL(valueChanged(int)), this, SIGNAL(optionsChanged()));
+    connect(gl->zoomLevel, &YACReaderSpinSliderWidget::valueChanged, this, &YACReaderOptionsDialog::saveZoomLevel);
+    connect(gl->zoomLevel, &YACReaderSpinSliderWidget::valueChanged, this, &YACReaderOptionsDialog::optionsChanged);
 
-    connect(gl->yCoverOffset, SIGNAL(valueChanged(int)), this, SLOT(saveYCoverOffset(int)));
-    connect(gl->yCoverOffset, SIGNAL(valueChanged(int)), this, SIGNAL(optionsChanged()));
+    connect(gl->yCoverOffset, &YACReaderSpinSliderWidget::valueChanged, this, &YACReaderOptionsDialog::saveYCoverOffset);
+    connect(gl->yCoverOffset, &YACReaderSpinSliderWidget::valueChanged, this, &YACReaderOptionsDialog::optionsChanged);
 
-    connect(gl->zCoverOffset, SIGNAL(valueChanged(int)), this, SLOT(saveZCoverOffset(int)));
-    connect(gl->zCoverOffset, SIGNAL(valueChanged(int)), this, SIGNAL(optionsChanged()));
+    connect(gl->zCoverOffset, &YACReaderSpinSliderWidget::valueChanged, this, &YACReaderOptionsDialog::saveZCoverOffset);
+    connect(gl->zCoverOffset, &YACReaderSpinSliderWidget::valueChanged, this, &YACReaderOptionsDialog::optionsChanged);
 
-    connect(gl->coverRotation, SIGNAL(valueChanged(int)), this, SLOT(saveCoverRotation(int)));
-    connect(gl->coverRotation, SIGNAL(valueChanged(int)), this, SIGNAL(optionsChanged()));
+    connect(gl->coverRotation, &YACReaderSpinSliderWidget::valueChanged, this, &YACReaderOptionsDialog::saveCoverRotation);
+    connect(gl->coverRotation, &YACReaderSpinSliderWidget::valueChanged, this, &YACReaderOptionsDialog::optionsChanged);
 
-    connect(gl->fadeOutDist, SIGNAL(valueChanged(int)), this, SLOT(saveFadeOutDist(int)));
-    connect(gl->fadeOutDist, SIGNAL(valueChanged(int)), this, SIGNAL(optionsChanged()));
+    connect(gl->fadeOutDist, &YACReaderSpinSliderWidget::valueChanged, this, &YACReaderOptionsDialog::saveFadeOutDist);
+    connect(gl->fadeOutDist, &YACReaderSpinSliderWidget::valueChanged, this, &YACReaderOptionsDialog::optionsChanged);
 
-    connect(gl->lightStrength, SIGNAL(valueChanged(int)), this, SLOT(saveLightStrength(int)));
-    connect(gl->lightStrength, SIGNAL(valueChanged(int)), this, SIGNAL(optionsChanged()));
+    connect(gl->lightStrength, &YACReaderSpinSliderWidget::valueChanged, this, &YACReaderOptionsDialog::saveLightStrength);
+    connect(gl->lightStrength, &YACReaderSpinSliderWidget::valueChanged, this, &YACReaderOptionsDialog::optionsChanged);
 
-    connect(gl->maxAngle, SIGNAL(valueChanged(int)), this, SLOT(saveMaxAngle(int)));
-    connect(gl->maxAngle, SIGNAL(valueChanged(int)), this, SIGNAL(optionsChanged()));
+    connect(gl->maxAngle, &YACReaderSpinSliderWidget::valueChanged, this, &YACReaderOptionsDialog::saveMaxAngle);
+    connect(gl->maxAngle, &YACReaderSpinSliderWidget::valueChanged, this, &YACReaderOptionsDialog::optionsChanged);
 
-    connect(gl->performanceSlider, SIGNAL(valueChanged(int)), this, SLOT(savePerformance(int)));
-    connect(gl->performanceSlider, SIGNAL(valueChanged(int)), this, SIGNAL(optionsChanged()));
+    connect(gl->performanceSlider, &QAbstractSlider::valueChanged, this, &YACReaderOptionsDialog::savePerformance);
+    connect(gl->performanceSlider, &QAbstractSlider::valueChanged, this, &YACReaderOptionsDialog::optionsChanged);
 
-    connect(gl->vSyncCheck, SIGNAL(stateChanged(int)), this, SLOT(saveUseVSync(int)));
+    connect(gl->vSyncCheck, &QCheckBox::stateChanged, this, &YACReaderOptionsDialog::saveUseVSync);
 #endif
 }
 

--- a/custom_widgets/yacreader_options_dialog.cpp
+++ b/custom_widgets/yacreader_options_dialog.cpp
@@ -40,7 +40,7 @@ YACReaderOptionsDialog::YACReaderOptionsDialog(QWidget *parent)
     connect(shortcutsButton, &QAbstractButton::clicked, this, &YACReaderOptionsDialog::editShortcuts);
 
     connect(accept, &QAbstractButton::clicked, this, &YACReaderOptionsDialog::saveOptions);
-    connect(cancel, SIGNAL(clicked()), this, SLOT(restoreOptions())); //TODO fix this
+    connect(cancel, &QAbstractButton::clicked, this, QOverload<>::of(&YACReaderOptionsDialog::restoreOptions));
     connect(cancel, &QAbstractButton::clicked, this, &QWidget::close);
 #ifndef NO_OPENGL
     useGL = new QCheckBox(tr("Use hardware acceleration (restart needed)"));

--- a/custom_widgets/yacreader_search_line_edit.cpp
+++ b/custom_widgets/yacreader_search_line_edit.cpp
@@ -25,8 +25,8 @@ YACReaderSearchLineEdit::YACReaderSearchLineEdit(QWidget *parent)
     clearButton->setCursor(Qt::ArrowCursor);
     clearButton->setStyleSheet("QToolButton { border: none; padding: 0px; }");
     clearButton->hide();
-    connect(clearButton, SIGNAL(clicked()), this, SLOT(clear()));
-    connect(this, SIGNAL(textChanged(const QString &)), this, SLOT(updateCloseButton(const QString &)));
+    connect(clearButton, &QAbstractButton::clicked, this, &QLineEdit::clear);
+    connect(this, &QLineEdit::textChanged, this, &YACReaderSearchLineEdit::updateCloseButton);
     int frameWidth = style()->pixelMetric(QStyle::PM_DefaultFrameWidth);
 #ifdef Q_OS_MAC
     setStyleSheet(QString("QLineEdit {border-top:1px solid #9F9F9F; border-bottom:1px solid #ACACAC; border-right:1px solid #ACACAC; border-left:1px solid #ACACAC; border-radius: 10px; background-color:qlineargradient(x1: 0, y1: 0, x2: 0, y2: 1, stop: 0 #CACACA, stop: 0.15 #FFFFFF); padding-left: %1px; padding-right: %2px; padding-bottom: 1px; margin-bottom: 1px;} ").arg(searchLabel->sizeHint().width() + frameWidth + 6).arg(clearButton->sizeHint().width() + frameWidth + 2));
@@ -67,14 +67,14 @@ YACReaderSearchLineEdit::YACReaderSearchLineEdit(QWidget *parent)
     setValidator(validator);
     setCompleter(modifiersCompleter);
 
-    connect(this, SIGNAL(textChanged(QString)), this, SLOT(processText(QString)));
+    connect(this, &QLineEdit::textChanged, this, &YACReaderSearchLineEdit::processText);
 }
 
 void YACReaderSearchLineEdit::clearText()
 {
-    disconnect(this, SIGNAL(textChanged(QString)), this, SLOT(processText(QString)));
+    disconnect(this, &QLineEdit::textChanged, this, &YACReaderSearchLineEdit::processText);
     clear();
-    connect(this, SIGNAL(textChanged(QString)), this, SLOT(processText(QString)));
+    connect(this, &QLineEdit::textChanged, this, &YACReaderSearchLineEdit::processText);
 }
 
 //modifiers are not returned

--- a/custom_widgets/yacreader_spin_slider_widget.cpp
+++ b/custom_widgets/yacreader_spin_slider_widget.cpp
@@ -22,11 +22,11 @@ YACReaderSpinSliderWidget::YACReaderSpinSliderWidget(QWidget *parent, bool strec
         layout->setStretchFactor(label, 0.15);
     }
 
-    connect(spinBox, SIGNAL(valueChanged(int)), slider, SLOT(setValue(int)));
+    connect(spinBox, QOverload<int>::of(&QSpinBox::valueChanged), slider, &QAbstractSlider::setValue);
     connect(slider, &QAbstractSlider::valueChanged, spinBox, &QSpinBox::setValue);
 
     connect(slider, &QAbstractSlider::valueChanged, this, &YACReaderSpinSliderWidget::valueWillChange);
-    connect(spinBox, SIGNAL(valueChanged(int)), this, SLOT(valueWillChangeFromSpinBox(int)));
+    connect(spinBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &YACReaderSpinSliderWidget::valueWillChangeFromSpinBox);
 
     connect(slider, &QAbstractSlider::sliderReleased, this, &YACReaderSpinSliderWidget::sliderRelease);
 
@@ -65,9 +65,9 @@ void YACReaderSpinSliderWidget::setRange(int lowValue, int topValue, int step)
 
 void YACReaderSpinSliderWidget::setValue(int value)
 {
-    disconnect(spinBox, SIGNAL(valueChanged(int)), this, SLOT(valueWillChange(int)));
+    disconnect(spinBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &YACReaderSpinSliderWidget::setValue);
     spinBox->setValue(value);
-    connect(spinBox, SIGNAL(valueChanged(int)), this, SLOT(valueWillChange(int)));
+    connect(spinBox, QOverload<int>::of(&QSpinBox::valueChanged), this, &YACReaderSpinSliderWidget::valueWillChange);
 }
 
 void YACReaderSpinSliderWidget::setText(const QString &text)

--- a/custom_widgets/yacreader_spin_slider_widget.cpp
+++ b/custom_widgets/yacreader_spin_slider_widget.cpp
@@ -23,12 +23,12 @@ YACReaderSpinSliderWidget::YACReaderSpinSliderWidget(QWidget *parent, bool strec
     }
 
     connect(spinBox, SIGNAL(valueChanged(int)), slider, SLOT(setValue(int)));
-    connect(slider, SIGNAL(valueChanged(int)), spinBox, SLOT(setValue(int)));
+    connect(slider, &QAbstractSlider::valueChanged, spinBox, &QSpinBox::setValue);
 
-    connect(slider, SIGNAL(valueChanged(int)), this, SLOT(valueWillChange(int)));
+    connect(slider, &QAbstractSlider::valueChanged, this, &YACReaderSpinSliderWidget::valueWillChange);
     connect(spinBox, SIGNAL(valueChanged(int)), this, SLOT(valueWillChangeFromSpinBox(int)));
 
-    connect(slider, SIGNAL(sliderReleased()), this, SLOT(sliderRelease()));
+    connect(slider, &QAbstractSlider::sliderReleased, this, &YACReaderSpinSliderWidget::sliderRelease);
 
     setLayout(layout);
 }

--- a/custom_widgets/yacreader_table_view.cpp
+++ b/custom_widgets/yacreader_table_view.cpp
@@ -271,10 +271,10 @@ QWidget *YACReaderRatingDelegate::createEditor(QWidget *parent,
     Q_UNUSED(option)
     Q_UNUSED(index)
     StarEditor *editor = new StarEditor(parent);
-    connect(editor, SIGNAL(editingFinished()),
-            this, SLOT(sendCloseEditor()));
-    connect(editor, SIGNAL(commitData()),
-            this, SLOT(sendCommitData()));
+    connect(editor, &StarEditor::editingFinished,
+            this, &YACReaderRatingDelegate::sendCloseEditor);
+    connect(editor, &StarEditor::commitData,
+            this, &YACReaderRatingDelegate::sendCommitData);
     return editor;
 }
 

--- a/custom_widgets/yacreader_titled_toolbar.cpp
+++ b/custom_widgets/yacreader_titled_toolbar.cpp
@@ -100,7 +100,7 @@ void YACReaderTitledToolBar::addAction(QAction *action)
     pb->setIcon(action->icon());
     pb->addAction(action);
 
-    connect(pb, SIGNAL(clicked(bool)), action, SIGNAL(triggered(bool)));
+    connect(pb, &QPushButton::clicked, action, &QAction::triggered);
 
     mainLayout->addWidget(pb);
 #else

--- a/custom_widgets/yacreader_treeview.cpp
+++ b/custom_widgets/yacreader_treeview.cpp
@@ -88,7 +88,7 @@ void YACReaderTreeView::dragMoveEvent(QDragMoveEvent *event)
     QModelIndex underMouse = indexAt(event->pos());
     if (underMouse.isValid()) {
         expandPos = event->pos();
-        connect(&expandTimer, SIGNAL(timeout()), this, SLOT(expandCurrent()));
+        connect(&expandTimer, &QTimer::timeout, this, &YACReaderTreeView::expandCurrent);
         expandTimer.setSingleShot(true);
         expandTimer.start(500);
     }

--- a/shortcuts_management/edit_shortcut_item_delegate.cpp
+++ b/shortcuts_management/edit_shortcut_item_delegate.cpp
@@ -13,7 +13,7 @@ QWidget *EditShortcutItemDelegate::createEditor(QWidget *parent, const QStyleOpt
     Q_UNUSED(index);
 
     KeySequenceLineEdit *editor = new KeySequenceLineEdit(parent);
-    connect(editor, SIGNAL(editingFinished()), this, SLOT(closeShortcutEditor()));
+    connect(editor, &QLineEdit::editingFinished, this, &EditShortcutItemDelegate::closeShortcutEditor);
     return editor;
 }
 
@@ -76,8 +76,8 @@ KeySequenceLineEdit::KeySequenceLineEdit(QWidget *parent)
     acceptButton->setCursor(Qt::ArrowCursor);
     acceptButton->setStyleSheet(buttonsStyle);
 
-    connect(clearButton, SIGNAL(clicked()), this, SLOT(clear()));
-    connect(acceptButton, SIGNAL(clicked()), this, SIGNAL(editingFinished()));
+    connect(clearButton, &QAbstractButton::clicked, this, &QLineEdit::clear);
+    connect(acceptButton, &QAbstractButton::clicked, this, &QLineEdit::editingFinished);
 }
 
 void KeySequenceLineEdit::resizeEvent(QResizeEvent *e)

--- a/shortcuts_management/edit_shortcuts_dialog.cpp
+++ b/shortcuts_management/edit_shortcuts_dialog.cpp
@@ -57,9 +57,9 @@ EditShortcutsDialog::EditShortcutsDialog(QWidget *parent)
                                       "QTableView::item:selected {outline: 0px; border: 0px;}"
                                       "");*/
 
-    connect(resetButton, SIGNAL(clicked()), this, SLOT(resetToDefaults()));
-    connect(actionsGroupsListView->selectionModel(), SIGNAL(currentChanged(QModelIndex, QModelIndex)), this, SLOT(loadShortcuts(QModelIndex, QModelIndex))); //clicked(QModelIndex) doesn't work :S
-    connect(actionsModel, SIGNAL(conflict(QString)), this, SLOT(processConflict(QString)));
+    connect(resetButton, &QAbstractButton::clicked, this, &EditShortcutsDialog::resetToDefaults);
+    connect(actionsGroupsListView->selectionModel(), &QItemSelectionModel::currentChanged, this, &EditShortcutsDialog::loadShortcuts); //clicked(QModelIndex) doesn't work :S
+    connect(actionsModel, &ActionsShortcutsModel::conflict, this, &EditShortcutsDialog::processConflict);
 
 #ifdef Q_OS_MAC
     setFixedSize(760, 500);

--- a/third_party/QtWebApp/httpserver/httpconnectionhandler.cpp
+++ b/third_party/QtWebApp/httpserver/httpconnectionhandler.cpp
@@ -32,10 +32,10 @@ HttpConnectionHandler::HttpConnectionHandler(const QSettings *settings, HttpRequ
     socket->moveToThread(thread);
 
     // Connect signals
-    connect(socket, SIGNAL(readyRead()), SLOT(read()));
-    connect(socket, SIGNAL(disconnected()), SLOT(disconnected()));
-    connect(&readTimer, SIGNAL(timeout()), SLOT(readTimeout()));
-    connect(thread, SIGNAL(finished()), this, SLOT(thread_done()));
+    connect(socket, &QIODevice::readyRead, this, &HttpConnectionHandler::read);
+    connect(socket, &QAbstractSocket::disconnected, this, &HttpConnectionHandler::disconnected);
+    connect(&readTimer, &QTimer::timeout, this, &HttpConnectionHandler::readTimeout);
+    connect(thread, &QThread::finished, this, &HttpConnectionHandler::thread_done);
 
     qDebug("HttpConnectionHandler (%p): constructed", static_cast<void*>(this));    
 }

--- a/third_party/QtWebApp/httpserver/httpconnectionhandlerpool.cpp
+++ b/third_party/QtWebApp/httpserver/httpconnectionhandlerpool.cpp
@@ -18,7 +18,7 @@ HttpConnectionHandlerPool::HttpConnectionHandlerPool(const QSettings *settings, 
     this->sslConfiguration=NULL;
     loadSslConfig();
     cleanupTimer.start(settings->value("cleanupInterval",1000).toInt());
-    connect(&cleanupTimer, SIGNAL(timeout()), SLOT(cleanup()));
+    connect(&cleanupTimer, &QTimer::timeout, this, &HttpConnectionHandlerPool::cleanup);
 }
 
 

--- a/third_party/QtWebApp/httpserver/httplistener.cpp
+++ b/third_party/QtWebApp/httpserver/httplistener.cpp
@@ -83,7 +83,7 @@ void HttpListener::incomingConnection(tSocketDescriptor socketDescriptor) {
         qDebug("HttpListener: Too many incoming connections");
         QTcpSocket* socket=new QTcpSocket(this);
         socket->setSocketDescriptor(socketDescriptor);
-        connect(socket, SIGNAL(disconnected()), socket, SLOT(deleteLater()));
+        connect(socket, &QAbstractSocket::disconnected, socket, &QObject::deleteLater);
         socket->write("HTTP/1.1 503 too many connections\r\nConnection: close\r\n\r\nToo many connections\r\n");
         socket->disconnectFromHost();
     }

--- a/third_party/QtWebApp/httpserver/httpsessionstore.cpp
+++ b/third_party/QtWebApp/httpserver/httpsessionstore.cpp
@@ -13,7 +13,7 @@ HttpSessionStore::HttpSessionStore(const QSettings *settings, QObject* parent)
     :QObject(parent)
 {
     this->settings=settings;
-    connect(&cleanupTimer,SIGNAL(timeout()),this,SLOT(sessionTimerEvent()));
+    connect(&cleanupTimer,&QTimer::timeout,this,&HttpSessionStore::sessionTimerEvent);
     cleanupTimer.start(60000);
     cookieName=settings->value("cookieName","sessionid").toByteArray();
     expirationTime=settings->value("expirationTime",3600000).toInt();


### PR DESCRIPTION
This is the first batch of a rather huge PR with the intention of getting rid of the old Qt SIGNAL/SLOT syntax. Most of the heavy lifting was done using the Clazy static code checker for Qt code, with some minor manual corrections to the code.

The suggested way to introduce these changes is to cherry-pick the **first three commits** which are mostly automated, safe replacements for the old connections and to introduce them ASAP to reduce the risk of this work getting outdated and to avoid risky labor intensive rebase work.

As the conversions after the first batch of automated fixes are mostly manual, they have a higher risk to introduce bugs and thus should be independently verified and tested before being introduced into the code base.

**This PR is not intended to be merged as a whole, but to serve as a testing and staging area for this work.**

I will introduce additional commits to this PR as I continue the conversion to the new syntax.