### PR TITLE
Add updated mime-types to YACReader.desktop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Version counting is based on semantic versioning (Major.Feature.Patch)
 * Remove obsolete double page mode debug messages
 * Support HDPI screens.
 * Use one wheel mouse step per page in full page mode.
+* Add updated MIME types to .desktop file for .cbz and .cbr
 
 ### YACReaderLibrary
 * Support HDPI screens.

--- a/YACReader.desktop
+++ b/YACReader.desktop
@@ -8,6 +8,6 @@ Terminal=false
 Type=Application
 StartupNotify=true
 Categories=Graphics;Viewer;
-MimeType=application/x-cbz;application/x-cbr;application/x-cbt;application/x-cb7;application/x-pdf;application/x-zip;application/x-rar;application/x-7z;inode/directory;
+MimeType=application/vnd.comicbook+zip;application/vnd.comicbook-rar;application/x-cbz;application/x-cbr;application/x-cbt;application/x-cb7;application/x-pdf;application/x-zip;application/x-rar;application/x-7z;inode/directory;
 Keywords=comic;viewer;pdf;reader;
 X-Desktop-File-Install-Version=0.22


### PR DESCRIPTION
according to the IANA, [`application/vnd.comicbook+zip`](https://www.iana.org/assignments/media-types/application/vnd.comicbook+zip) and [`application/vnd.comicbook-rar`](https://www.iana.org/assignments/media-types/application/vnd.comicbook-rar) are the correct mimetypes for cbz and cbr. i was having issues getting `xdg-open` to open my cbz and this fixed the issue