### PR TITLE
Enable using integrated GPU in Dual GPU Macs

### DIFF
--- a/YACReader/Info.plist
+++ b/YACReader/Info.plist
@@ -139,5 +139,7 @@
 	</array>
 	<key>NSRequiresAquaSystemAppearance</key>
 	<true/>
+	<key>NSSupportsAutomaticGraphicsSwitching</key>
+	<true/>
 </dict>
 </plist>


### PR DESCRIPTION
Currently YACReader will default to higher-end discrete GPU for OpenGL calls. This increases the battery usage while having no need for a high performance device. This flag tells MacOS that switching to integrated GPU is acceptable in this app. As a result, YACReader will use integrated GPU in Macs that support automatic graphics switching.

References:
https://developer.apple.com/library/archive/qa/qa1734/_index.html
https://developer.apple.com/documentation/bundleresources/information_property_list/nssupportsautomaticgraphicsswitching?language=objc