### PR TITLE
Add flatpak manifest

### DIFF
--- a/com.yacreader.YACReader.appdata.xml
+++ b/com.yacreader.YACReader.appdata.xml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<component type="desktop-application">
+    <id>com.yacreader.YACReader</id>
+    <metadata_license>FSFAP</metadata_license>
+    <project_license>GPL-3.0-only</project_license>
+    <name>YACReader</name>
+    <developer_name>Luis Ángel San Martín Rodríguez</developer_name>
+    <summary>Yet another comic reader</summary>
+    <description>
+        <p>
+            Read, browse and manage your comics collection.
+            All you need to enjoy your digital comics.
+        </p>
+        <p>
+            Browse your comics collections using beautiful, customizable and smooth "comic flow" transitions.
+        </p>
+        <p>Features:</p>
+        <ul>
+            <li>File support: YACReader supports a wide variety of comic files and image types. rar, zip, cbr, cbz, tar, pdf, 7z and cb7, jpeg, gif, png, tiff and bmp.</li>
+            <li>Configure your reading: Image rotation, double page mode, full size view, fullscreen mode, customizable background color, custom page fitting mode, bookmarks, resume reading, eye candy 'go to' and more.</li>
+            <li>Image improvements: Bring to life your old comics with the image adjustments available in the reading mode. Use the brightness, contrast and gamma sliders and enjoy the new vibrant colors.</li>
+            <li>Track your readings: YACReaderLibrary organizes your comics and keeps track of your reading progress and your collections' status.</li>
+            <li>Tags (comic vine): Download your comics' information from Comic Vine. Title, number, volumen, authors and more.</li>
+            <li>Search: Find your comics quickly using the built-in search engine. No matter how big is your collection, YACReaderLibrary will find anything instantly.</li>
+        </ul>
+    </description>
+    <categories>
+        <category>Graphics</category>
+        <category>Office</category>
+        <category>Viewer</category>
+    </categories>
+    <launchable type="desktop-id">com.yacreader.YACReader.desktop</launchable>
+    <launchable type="desktop-id">com.yacreader.YACReader.YACReaderLibrary.desktop</launchable>
+    <screenshots>
+        <screenshot type="default">
+            <caption>YACReader &amp; YACReaderLibrary</caption>
+            <image>https://www.yacreader.com/images/features/phoca_thumb_l_ss3b.jpg</image>
+        </screenshot>
+        <screenshot>
+            <caption>Properties</caption>
+            <image>https://www.yacreader.com/images/features/phoca_thumb_l_properties.jpg</image>
+        </screenshot>
+    </screenshots>
+    <url type="homepage">https://www.yacreader.com/</url>
+    <url type="bugtracker">https://github.com/YACReader/yacreader/issues</url>
+    <url type="faq">https://www.yacreader.com/support</url>
+    <url type="help">https://www.yacreader.com/support</url>
+    <url type="donation">https://www.yacreader.com/donation-why</url>
+    <url type="contact">https://www.yacreader.com/contact</url>
+    <provides>
+        <mediatype>application/x-cbz</mediatype>
+        <mediatype>application/x-cbr</mediatype>
+        <mediatype>application/x-cbt</mediatype>
+        <mediatype>application/x-cb7</mediatype>
+        <mediatype>application/x-pdf</mediatype>
+        <mediatype>application/x-zip</mediatype>
+        <mediatype>application/x-rar</mediatype>
+        <mediatype>application/x-7z</mediatype>
+        <mediatype>inode/directory</mediatype>
+        <mediatype>application/vnd.comicbook-rar</mediatype>
+        <mediatype>application/vnd.comicbook+zip</mediatype>
+        <mediatype>application/pdf</mediatype>
+        <mediatype>application/vnd.rar</mediatype>
+        <mediatype>application/x-7z-compressed</mediatype>
+        <mediatype>application/zip</mediatype>
+        <binary>YACReader</binary>
+        <binary>YACReaderLibrary</binary>
+        <binary>YACReaderLibraryServer</binary>
+    </provides>
+    <releases>
+        <release version="9.8.2.2106204" date="2021-06-20">
+            <description>
+                <p>YACReaderLibrary</p>
+                <ul>
+                    <li>Fix opening comics from the continue reading banner.</li>
+                    <li>Make available next/prev comic covers in the iOS app while reading. (ios app 3.16.1 needed)</li>
+                </ul>
+                <p>Server</p>
+                <ul>
+                    <li>Make available next/prev comic covers in the iOS app while reading. (ios app 3.16.1 needed)</li>
+                </ul>
+            </description>
+        </release>
+    </releases>
+</component>

--- a/com.yacreader.YACReader.yml
+++ b/com.yacreader.YACReader.yml
@@ -1,0 +1,128 @@
+app-id: com.yacreader.YACReader
+runtime: org.kde.Platform
+runtime-version: "5.15-21.08"
+sdk: org.kde.Sdk
+command: YACReader
+finish-args:
+  - --share=ipc
+  - --socket=fallback-x11
+  - --socket=wayland
+  - --share=network
+  - --device=dri
+  - --filesystem=xdg-documents
+  - --filesystem=xdg-pictures
+cleanup:
+  - /bin/gn
+  - /include
+  - /lib/cmake
+  - /lib/pkgconfig
+  - /lib/systemd
+  - /share/doc
+  - /share/man
+  - "*.a"
+  - "*.la"
+modules:
+  - name: yacreader
+    # https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=yacreader
+    buildsystem: qmake
+    config-opts:
+      - CONFIG+=unarr pdfium server_bundled
+    install-rule: null
+    make-install-args:
+      - sub-YACReader-install_subtargets
+      - sub-YACReaderLibrary-install_subtargets
+    post-install:
+      - mv "$FLATPAK_DEST"/share/applications/{YACReader,com.yacreader.YACReader}.desktop
+      - mv "$FLATPAK_DEST"/share/applications/{YACReaderLibrary,com.yacreader.YACReader.YACReaderLibrary}.desktop
+      - mv "$FLATPAK_DEST"/share/icons/hicolor/scalable/apps/{YACReader,com.yacreader.YACReader}.svg
+      - mv "$FLATPAK_DEST"/share/icons/hicolor/scalable/apps/{YACReaderLibrary,com.yacreader.YACReader.YACReaderLibrary}.svg
+      - sed -i -e 's/^Categories=\(.*\)$/Categories=Office;\1/' -e 's/^Icon=.*$/Icon=com.yacreader.YACReader/' "$FLATPAK_DEST"/share/applications/com.yacreader.YACReader.desktop
+      - sed -i -e 's/^Categories=\(.*\)$/Categories=Office;\1/' -e 's/^Icon=.*$/Icon=com.yacreader.YACReader.YACReaderLibrary/' "$FLATPAK_DEST"/share/applications/com.yacreader.YACReader.YACReaderLibrary.desktop
+      - install -D -m644 com.yacreader.YACReader.appdata.xml "$FLATPAK_DEST"/share/metainfo/com.yacreader.YACReader.appdata.xml
+    sources:
+      - type: git
+        url: https://github.com/YACReader/yacreader.git
+        tag: 9.8.2.2106204
+        commit: 7394944dccd1ee1f9dd8247e878f6ff8a055b7b8
+      - type: file
+        path: com.yacreader.YACReader.appdata.xml
+    modules:
+      - name: unarr
+        buildsystem: cmake
+        config-opts:
+          - -DENABLE_7Z=ON
+        sources:
+          - type: git
+            url: https://github.com/selmf/unarr.git
+            commit: e6fb85e8cdd1b1f9086e6e42be8d385f44136faa
+      - name: pdfium
+        buildsystem: simple
+        build-commands:
+          # https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=libpdfium-nojs
+          # Fix visibilty for system Freetype
+          - git -C pdfium/build cherry-pick -n bfd6ff0
+          # Patch abseil build to be static
+          - cd "$FLATPAK_BUILDER_BUILDDIR/pdfium/third_party/abseil-cpp"
+          - sed -i -e 's/component(/static_library(/' -e 's/is_component_build(/false/' pdfium/third_party/abseil-cpp/BUILD.gn
+          # Use system provided icu library (unbundling)
+          - mkdir -p pdfium/third_party/icu
+          - ln -sf ../../build/linux/unbundle/icu.gn pdfium/third_party/icu/BUILD.gn
+          # Download and decode shim header script needed to unbundle icu (gittiles is weird)
+          - mkdir -p pdfium/tools/generate_shim_headers
+          - base64 --decode generate_shim_headers.py > pdfium/tools/generate_shim_headers/generate_shim_headers.py
+          # Create fake gclient_args.gni file to satisfy include list for build/config/compiler/compiler.gni
+          - touch pdfium/build/config/gclient_args.gni
+          # Exclude test fonts from build
+          - sed -i '/"\/\/third_party\/test_fonts",/s/^/#/g' pdfium/testing/BUILD.gn
+          # Build
+          - gn --root=pdfium gen pdfium/out/Release --args="is_clang=false use_sysroot=false is_debug=false symbol_level=0 pdf_enable_v8=false pdf_enable_xfa=false treat_warnings_as_errors=false use_system_libjpeg=true use_system_zlib=true pdf_bundle_freetype=false use_system_freetype=true use_system_lcms2=true use_system_libpng=true use_custom_libcxx=false pdf_is_standalone=true use_system_libopenjpeg2=true is_component_build=true use_gold=false"
+          - ninja -C pdfium/out/Release pdfium
+          - sed -e 's/@VERSION@/4896/g' -e 's#^\s*prefix\s*=.*$#prefix='"$FLATPAK_DEST"'#' -i libpdfium.pc
+          # Install
+          - install -D -m644 pdfium/LICENSE "$FLATPAK_DEST/share/licenses/pdfium/LICENSE"
+          - install -D pdfium/public/*.h --target-directory="$FLATPAK_DEST/include/pdfium"
+          - install -D pdfium/public/cpp/* --target-directory="$FLATPAK_DEST/include/pdfium/cpp"
+          - install -D pdfium/docs/* --target-directory="$FLATPAK_DEST/share/doc/pdfium"
+          - install -Dm755 pdfium/out/Release/libpdfium.so --target-directory="$FLATPAK_DEST/lib"
+          - install -Dm644 libpdfium.pc --target-directory="$FLATPAK_DEST/lib/pkgconfig"
+        sources:
+          - type: git
+            url: https://pdfium.googlesource.com/pdfium
+            # curl 'https://omahaproxy.appspot.com/linux?channel=stable' | cut -d'.' -f 3
+            branch: chromium/4896
+            commit: 2fcb5025f65abf3f9446b3935ac3186a59a7dc90
+            dest: pdfium
+          - type: git
+            url: https://chromium.googlesource.com/chromium/src/build.git
+            # awk '/build_revision/ {print substr($2,2,40)}' pdfium/DEPS
+            commit: 893ac785aa454dcf84dcc26af1a410095c1d4fa2
+            dest: pdfium/build
+          - type: git
+            url: https://chromium.googlesource.com/chromium/src/third_party/abseil-cpp
+            # awk '/abseil_revision/ {print substr($2,2,40)}' pdfium/DEPS
+            branch: 9ffdb583473a319b3920c752badde40f91ffd609
+            dest: pdfium/third_party/abseil-cpp
+          - type: file
+            url: https://chromium.googlesource.com/chromium/src/+/master/tools/generate_shim_headers/generate_shim_headers.py?format=TEXT
+            dest-filename: generate_shim_headers.py
+            sha256: f95f0d29e3e12b22a7b86455265c87bc0219a25c09a7fa160d34b608992ea6da
+          - type: file
+            url: https://aur.archlinux.org/cgit/aur.git/plain/libpdfium.pc?h=libpdfium-nojs
+            dest-filename: libpdfium.pc
+            sha256: 4e8cf32c09568ae4c59244f0a221eee8f87ea4a31ddb31f796a1d818c967d477
+        modules:
+          - name: gn
+            buildsystem: simple
+            build-options:
+              env:
+                CC: gcc
+                CXX: g++
+            build-commands:
+              - ./build/gen.py
+              - ninja -C out
+              - install -D out/gn "$FLATPAK_DEST/bin/gn"
+            sources:
+              - type: git
+                url: https://gn.googlesource.com/gn
+                commit: 80a40b07305373617eba2d5878d353532af77da3
+                disable-shallow-clone: true


### PR DESCRIPTION
I put this flatpak manifest and appstream metadata together.

It can be tested locally with:
```
flatpak-builder --user --install --force-clean build-dir com.yacreader.YACReader.yml
```

A portable flatpak bundle can be generated with:
```
flatpak-builder --repo=custom --force-clean build-dir com.yacreader.YACReader.yml
flatpak build-bundle custom com.yacreader.YACReader.flatpak com.yacreader.YACReader
```

An official app submission to flathub could be considered now: https://github.com/flathub/flathub/wiki/App-Submission