### PR TITLE
Translations: Don't use QLocale::system::name

### DIFF
--- a/YACReader/YACReader.pro
+++ b/YACReader/YACReader.pro
@@ -196,8 +196,8 @@ TRANSLATIONS =    yacreader_es.ts \
                   yacreader_zh_CN.ts \
                   yacreader_zh_TW.ts \
                   yacreader_zh_HK.ts \
-                  yacreader_it.ts
-#                  yacreader_source.ts
+                  yacreader_it.ts \
+                  yacreader_en.ts
 
 CONFIG += lrelease
 

--- a/YACReader/YACReader.pro
+++ b/YACReader/YACReader.pro
@@ -202,6 +202,23 @@ TRANSLATIONS =    yacreader_es.ts \
 LRELEASE_DIR = ../release/languages/
 CONFIG += lrelease
 
+win32 {
+    CONFIG(release, debug|release) {
+        SOURCE_QM_DIR = $$OUT_PWD/release/*.qm
+    }
+    CONFIG(debug, debug|release) {
+        SOURCE_QM_DIR = $$OUT_PWD/debug/*.qm
+    }
+
+    DEPLOYMENT_OUT_QM_DIR = ../release/languages/
+    OUT_QM_DIR = $${DESTDIR}/languages/
+
+    QMAKE_POST_LINK += $(MKDIR) $$shell_path($${OUT_QM_DIR}) 2> NULL & \
+                       $(COPY) $$shell_path($${SOURCE_QM_DIR}) $$shell_path($${OUT_QM_DIR}) & \
+                       $(MKDIR) $$shell_path($${DEPLOYMENT_OUT_QM_DIR}) 2> NULL & \
+                       $(COPY) $$shell_path($${SOURCE_QM_DIR}) $$shell_path($${DEPLOYMENT_OUT_QM_DIR})
+}
+
 unix:!macx {
 # set install prefix if it's empty
 isEmpty(PREFIX) {

--- a/YACReader/YACReader.pro
+++ b/YACReader/YACReader.pro
@@ -199,7 +199,6 @@ TRANSLATIONS =    yacreader_es.ts \
                   yacreader_it.ts
 #                  yacreader_source.ts
 
-LRELEASE_DIR = ../release/languages/
 CONFIG += lrelease
 
 win32 {
@@ -217,6 +216,8 @@ win32 {
                        $(COPY) $$shell_path($${SOURCE_QM_DIR}) $$shell_path($${OUT_QM_DIR}) & \
                        $(MKDIR) $$shell_path($${DEPLOYMENT_OUT_QM_DIR}) 2> NULL & \
                        $(COPY) $$shell_path($${SOURCE_QM_DIR}) $$shell_path($${DEPLOYMENT_OUT_QM_DIR})
+} else {
+    LRELEASE_DIR = ../release/languages/
 }
 
 unix:!macx {

--- a/YACReader/main.cpp
+++ b/YACReader/main.cpp
@@ -173,11 +173,10 @@ int main(int argc, char *argv[])
     logger.addDestination(std::move(fileDestination));
 
     QTranslator translator;
-    QString sufix = QLocale::system().name();
 #if defined Q_OS_UNIX && !defined Q_OS_MAC
-    translator.load(QString(DATADIR) + "/yacreader/languages/yacreader_" + sufix);
+    translator.load(QLocale(), "yacreader", "_", QString(DATADIR) + "/yacreader/languages");
 #else
-    translator.load(QCoreApplication::applicationDirPath() + "/languages/yacreader_" + sufix);
+    translator.load(QLocale(), "yacreader", "_", "languages");
 #endif
     app.installTranslator(&translator);
     auto mwv = new MainWindowViewer();

--- a/YACReader/yacreader_de.ts
+++ b/YACReader/yacreader_de.ts
@@ -4,6 +4,7 @@
 <context>
     <name>ActionsShortcutsModel</name>
     <message>
+        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="73"/>
         <source>None</source>
         <translation>Keine</translation>
     </message>
@@ -11,18 +12,23 @@
 <context>
     <name>BookmarksDialog</name>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="75"/>
         <source>Close</source>
         <translation>Schliessen</translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="107"/>
+        <location filename="bookmarks_dialog.cpp" line="124"/>
         <source>Loading...</source>
         <translation>Laden...</translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="85"/>
         <source>Click on any image to go to the bookmark</source>
         <translation>Klicke auf ein beliebiges Bild, um zum Lesezeichen zu gehen</translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="25"/>
         <source>Lastest Page</source>
         <translation>Neueste Seite</translation>
     </message>
@@ -30,22 +36,27 @@
 <context>
     <name>EditShortcutsDialog</name>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="21"/>
         <source>Restore defaults</source>
         <translation>Standardwerte wiederherstellen</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="22"/>
         <source>To change a shortcut, double click in the key combination and type the new keys.</source>
         <translation>Um ein Kürzel zu ändern, klicke doppelt auf die Tastenkombination und füge die neuen Tasten ein.</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="69"/>
         <source>Shortcuts settings</source>
         <translation>Kürzel-Einstellungen</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>Shortcut in use</source>
         <translation>Genutzte Kürzel</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>The shortcut &quot;%1&quot; is already assigned to other function</source>
         <translation>Das Kürzel &quot;%1&quot; ist bereits für eine andere Funktion in Verwendung</translation>
     </message>
@@ -53,18 +64,22 @@
 <context>
     <name>FileComic</name>
     <message>
+        <location filename="../common/comic.cpp" line="568"/>
         <source>Format not supported</source>
         <translation>Format wird nicht unterstützt</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="562"/>
         <source>7z not found</source>
         <translation>7z nicht gefunden</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="461"/>
         <source>Unknown error opening the file</source>
         <translation>Unbekannter Fehler beim Öffnen des Files</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="454"/>
         <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
         <translation>CRC Error auf Seite (%1): Einige Seiten werden nicht korrekt dargestellt</translation>
     </message>
@@ -72,22 +87,28 @@
 <context>
     <name>GoToDialog</name>
     <message>
+        <location filename="goto_dialog.cpp" line="23"/>
         <source>Go To</source>
         <translation>Gehe zu</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="53"/>
         <source>Go to...</source>
         <translation>Gehe zu...</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="39"/>
+        <location filename="goto_dialog.cpp" line="71"/>
         <source>Total pages : </source>
         <translation>Seiten gesamt :</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="25"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="15"/>
         <source>Page : </source>
         <translation>Seite :</translation>
     </message>
@@ -95,6 +116,7 @@
 <context>
     <name>GoToFlowToolBar</name>
     <message>
+        <location filename="goto_flow_toolbar.cpp" line="38"/>
         <source>Page : </source>
         <translation>Seite :</translation>
     </message>
@@ -102,10 +124,17 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
+        <source>System info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation>Über</translation>
     </message>
@@ -113,30 +142,37 @@
 <context>
     <name>LogWindow</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="14"/>
         <source>Log window</source>
         <translation>Änderungsprotokoll-Fenster</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="22"/>
         <source>&amp;Pause</source>
         <translation>Pause</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="39"/>
         <source>&amp;Save</source>
         <translation>Speichern</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="56"/>
         <source>C&amp;lear</source>
         <translation>L&amp;öschen</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="73"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopieren</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="90"/>
         <source>Level:</source>
         <translation>Level</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="136"/>
         <source>&amp;Auto scroll</source>
         <translation>&amp;Automatisches Scrollen</translation>
     </message>
@@ -145,464 +181,500 @@
     <name>MainWindowViewer</name>
     <message>
         <source>File</source>
-        <translation>Datei</translation>
+        <translation type="vanished">Datei</translation>
     </message>
     <message>
         <source>Help</source>
-        <translation>Hilfe</translation>
+        <translation type="vanished">Hilfe</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation>Speichern</translation>
+        <translation type="vanished">Speichern</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation>&amp;Datei</translation>
+        <translation type="vanished">&amp;Datei</translation>
     </message>
     <message>
         <source>&amp;Next</source>
-        <translation>&amp;Nächstes</translation>
+        <translation type="vanished">&amp;Nächstes</translation>
     </message>
     <message>
         <source>&amp;Open</source>
-        <translation>&amp;Öffnen</translation>
+        <translation type="vanished">&amp;Öffnen</translation>
     </message>
     <message>
         <source>Close</source>
-        <translation>Schliessen</translation>
+        <translation type="vanished">Schliessen</translation>
     </message>
     <message>
         <source>Open Comic</source>
-        <translation>Comic öffnen</translation>
+        <translation type="vanished">Comic öffnen</translation>
     </message>
     <message>
         <source>Go To</source>
-        <translation>Gehe zu</translation>
+        <translation type="vanished">Gehe zu</translation>
     </message>
     <message>
         <source>Open image folder</source>
-        <translation>Bilder-Ordner öffnen</translation>
+        <translation type="vanished">Bilder-Ordner öffnen</translation>
     </message>
     <message>
         <source>Set bookmark</source>
-        <translation>Lesezeichen setzen</translation>
+        <translation type="vanished">Lesezeichen setzen</translation>
     </message>
     <message>
         <source>page_%1.jpg</source>
-        <translation>Seite_%1.jpg</translation>
+        <translation type="vanished">Seite_%1.jpg</translation>
     </message>
     <message>
         <source>Switch to double page mode</source>
-        <translation>Zum Doppelseiten-Modus wechseln</translation>
+        <translation type="vanished">Zum Doppelseiten-Modus wechseln</translation>
     </message>
     <message>
         <source>Save current page</source>
-        <translation>Aktuelle Seite speichern</translation>
+        <translation type="vanished">Aktuelle Seite speichern</translation>
     </message>
     <message>
         <source>Double page mode</source>
-        <translation>Doppelseiten-Modus</translation>
+        <translation type="vanished">Doppelseiten-Modus</translation>
     </message>
     <message>
         <source>Switch Magnifying glass</source>
-        <translation>Vergrößerungsglas wechseln</translation>
+        <translation type="vanished">Vergrößerungsglas wechseln</translation>
     </message>
     <message>
         <source>Open Folder</source>
-        <translation>Ordner öffnen</translation>
+        <translation type="vanished">Ordner öffnen</translation>
     </message>
     <message>
         <source>Fit Height</source>
-        <translation>Höhe anpassen</translation>
+        <translation type="vanished">Höhe anpassen</translation>
     </message>
     <message>
         <source>Comic files</source>
-        <translation>Comic-Dateien</translation>
+        <translation type="vanished">Comic-Dateien</translation>
     </message>
     <message>
         <source>Not now</source>
-        <translation>Nicht jetzt</translation>
+        <translation type="vanished">Nicht jetzt</translation>
     </message>
     <message>
         <source>Go to previous page</source>
-        <translation>Zur vorherigen Seite gehen</translation>
+        <translation type="vanished">Zur vorherigen Seite gehen</translation>
     </message>
     <message>
         <source>Open a comic</source>
-        <translation>Comic öffnen</translation>
+        <translation type="vanished">Comic öffnen</translation>
     </message>
     <message>
         <source>Image files (*.jpg)</source>
-        <translation>Bildateien (*.jpg)</translation>
+        <translation type="vanished">Bildateien (*.jpg)</translation>
     </message>
     <message>
         <source>Next Comic</source>
-        <translation>Nächster Comic</translation>
+        <translation type="vanished">Nächster Comic</translation>
     </message>
     <message>
         <source>Fit Width</source>
-        <translation>Breite anpassen</translation>
+        <translation type="vanished">Breite anpassen</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation>Optionen</translation>
+        <translation type="vanished">Optionen</translation>
     </message>
     <message>
         <source>Show Info</source>
-        <translation>Info anzeigen</translation>
+        <translation type="vanished">Info anzeigen</translation>
     </message>
     <message>
         <source>Open folder</source>
-        <translation>Ordner öffnen</translation>
+        <translation type="vanished">Ordner öffnen</translation>
     </message>
     <message>
         <source>Go to page ...</source>
-        <translation>Gehe zu Seite ...</translation>
+        <translation type="vanished">Gehe zu Seite ...</translation>
     </message>
     <message>
         <source>Fit image to width</source>
-        <translation>Bildbreite anpassen</translation>
+        <translation type="vanished">Bildbreite anpassen</translation>
     </message>
     <message>
         <source>&amp;Previous</source>
-        <translation>&amp;Vorherige</translation>
+        <translation type="vanished">&amp;Vorherige</translation>
     </message>
     <message>
         <source>Go to next page</source>
-        <translation>Zur nächsten Seite gehen</translation>
+        <translation type="vanished">Zur nächsten Seite gehen</translation>
     </message>
     <message>
         <source>Show keyboard shortcuts</source>
-        <translation>Tastenkürzel anzeigen</translation>
+        <translation type="vanished">Tastenkürzel anzeigen</translation>
     </message>
     <message>
         <source>There is a new version available</source>
-        <translation>Neue Version verfügbar</translation>
+        <translation type="vanished">Neue Version verfügbar</translation>
     </message>
     <message>
         <source>Open next comic</source>
-        <translation>Nächsten Comic öffnen</translation>
+        <translation type="vanished">Nächsten Comic öffnen</translation>
     </message>
     <message>
         <source>Remind me in 14 days</source>
-        <translation>In 14 Tagen erneut erinnern</translation>
+        <translation type="vanished">In 14 Tagen erneut erinnern</translation>
     </message>
     <message>
         <source>Show bookmarks</source>
-        <translation>Lesezeichen anzeigen</translation>
+        <translation type="vanished">Lesezeichen anzeigen</translation>
     </message>
     <message>
         <source>Open previous comic</source>
-        <translation>Vorherigen Comic öffnen</translation>
+        <translation type="vanished">Vorherigen Comic öffnen</translation>
     </message>
     <message>
         <source>Rotate image to the left</source>
-        <translation>Bild nach links drehen</translation>
+        <translation type="vanished">Bild nach links drehen</translation>
     </message>
     <message>
         <source>Fit image to height</source>
-        <translation>Bild an Höhe anpassen</translation>
+        <translation type="vanished">Bild an Höhe anpassen</translation>
     </message>
     <message>
         <source>Show the bookmarks of the current comic</source>
-        <translation>Lesezeichen für diesen Comic anzeigen</translation>
+        <translation type="vanished">Lesezeichen für diesen Comic anzeigen</translation>
     </message>
     <message>
         <source>Show Dictionary</source>
-        <translation>Wörterbuch anzeigen</translation>
+        <translation type="vanished">Wörterbuch anzeigen</translation>
     </message>
     <message>
         <source>YACReader options</source>
-        <translation>YACReader Optionen</translation>
+        <translation type="vanished">YACReader Optionen</translation>
     </message>
     <message>
         <source>Help, About YACReader</source>
-        <translation>Hilfe, über YACReader</translation>
+        <translation type="vanished">Hilfe, über YACReader</translation>
     </message>
     <message>
         <source>Show go to flow</source>
-        <translation>&quot;Go to Flow&quot; anzeigen</translation>
+        <translation type="vanished">&quot;Go to Flow&quot; anzeigen</translation>
     </message>
     <message>
         <source>Previous Comic</source>
-        <translation>Voheriger Comic</translation>
+        <translation type="vanished">Voheriger Comic</translation>
     </message>
     <message>
         <source>Show full size</source>
-        <translation>Vollansicht anzeigen</translation>
+        <translation type="vanished">Vollansicht anzeigen</translation>
     </message>
     <message>
         <source>Magnifying glass</source>
-        <translation>Vergößerungsglas</translation>
+        <translation type="vanished">Vergößerungsglas</translation>
     </message>
     <message>
         <source>General</source>
-        <translation>Allgemein</translation>
+        <translation type="vanished">Allgemein</translation>
     </message>
     <message>
         <source>Set a bookmark on the current page</source>
-        <translation>Lesezeichen auf dieser Seite setzen</translation>
+        <translation type="vanished">Lesezeichen auf dieser Seite setzen</translation>
     </message>
     <message>
         <source>Do you want to download the new version?</source>
-        <translation>Möchten Sie die neue Version herunterladen?</translation>
+        <translation type="vanished">Möchten Sie die neue Version herunterladen?</translation>
     </message>
     <message>
         <source>Rotate image to the right</source>
-        <translation>Bild nach rechts drehen</translation>
+        <translation type="vanished">Bild nach rechts drehen</translation>
     </message>
     <message>
         <source>Always on top</source>
-        <translation>Immer Oberste Ansicht</translation>
+        <translation type="vanished">Immer Oberste Ansicht</translation>
     </message>
     <message>
         <source>New instance</source>
-        <translation>Neuer Fall</translation>
+        <translation type="vanished">Neuer Fall</translation>
     </message>
     <message>
         <source>Open latest comic</source>
-        <translation>Neuesten Comic öffnen</translation>
+        <translation type="vanished">Neuesten Comic öffnen</translation>
     </message>
     <message>
         <source>Open the latest comic opened in the previous reading session</source>
-        <translation>Öffne den neuesten Comic deiner letzten Sitzung</translation>
+        <translation type="vanished">Öffne den neuesten Comic deiner letzten Sitzung</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation>Löschen</translation>
+        <translation type="vanished">Löschen</translation>
     </message>
     <message>
         <source>Clear open recent list</source>
-        <translation>Lösche Liste zuletzt geöffneter Elemente</translation>
+        <translation type="vanished">Lösche Liste zuletzt geöffneter Elemente</translation>
     </message>
     <message>
         <source>Fit to page</source>
-        <translation>An Seite anpassen</translation>
+        <translation type="vanished">An Seite anpassen</translation>
     </message>
     <message>
         <source>Reset zoom</source>
-        <translation>Zoom zurücksetzen</translation>
+        <translation type="vanished">Zoom zurücksetzen</translation>
     </message>
     <message>
         <source>Show zoom slider</source>
-        <translation>Zoomleiste anzeigen</translation>
+        <translation type="vanished">Zoomleiste anzeigen</translation>
     </message>
     <message>
         <source>Zoom+</source>
-        <translation>Zoom+</translation>
+        <translation type="vanished">Zoom+</translation>
     </message>
     <message>
         <source>Zoom-</source>
-        <translation>Zoom-</translation>
+        <translation type="vanished">Zoom-</translation>
     </message>
     <message>
         <source>Double page manga mode</source>
-        <translation>Doppelseiten-Manga-Modus</translation>
+        <translation type="vanished">Doppelseiten-Manga-Modus</translation>
     </message>
     <message>
         <source>Reverse reading order in double page mode</source>
-        <translation>Umgekehrte Lesereihenfolge im Doppelseiten-Modus</translation>
+        <translation type="vanished">Umgekehrte Lesereihenfolge im Doppelseiten-Modus</translation>
     </message>
     <message>
         <source>Edit shortcuts</source>
-        <translation>Kürzel ändern</translation>
+        <translation type="vanished">Kürzel ändern</translation>
     </message>
     <message>
         <source>Open recent</source>
-        <translation>Kürzlich geöffnet</translation>
+        <translation type="vanished">Kürzlich geöffnet</translation>
     </message>
     <message>
         <source>Edit</source>
-        <translation>Ändern</translation>
+        <translation type="vanished">Ändern</translation>
     </message>
     <message>
         <source>View</source>
-        <translation>Anzeigen</translation>
+        <translation type="vanished">Anzeigen</translation>
     </message>
     <message>
         <source>Go</source>
-        <translation>Los</translation>
+        <translation type="vanished">Los</translation>
     </message>
     <message>
         <source>Window</source>
-        <translation>Fenster</translation>
+        <translation type="vanished">Fenster</translation>
     </message>
     <message>
         <source>Comics</source>
-        <translation>Comics</translation>
+        <translation type="vanished">Comics</translation>
     </message>
     <message>
         <source>Toggle fullscreen mode</source>
-        <translation>Vollbild-Modus umschalten</translation>
+        <translation type="vanished">Vollbild-Modus umschalten</translation>
     </message>
     <message>
         <source>Hide/show toolbar</source>
-        <translation>Symbolleiste anzeigen/verstecken</translation>
+        <translation type="vanished">Symbolleiste anzeigen/verstecken</translation>
     </message>
     <message>
         <source>Size up magnifying glass</source>
-        <translation>Vergrößerungsglas vergrößern</translation>
+        <translation type="vanished">Vergrößerungsglas vergrößern</translation>
     </message>
     <message>
         <source>Size down magnifying glass</source>
-        <translation>Vergrößerungsglas verkleinern</translation>
+        <translation type="vanished">Vergrößerungsglas verkleinern</translation>
     </message>
     <message>
         <source>Zoom in magnifying glass</source>
-        <translation>Vergrößerungsglas reinzoomen</translation>
+        <translation type="vanished">Vergrößerungsglas reinzoomen</translation>
     </message>
     <message>
         <source>Zoom out magnifying glass</source>
-        <translation>Vergrößerungsglas rauszoomen</translation>
+        <translation type="vanished">Vergrößerungsglas rauszoomen</translation>
     </message>
     <message>
         <source>Magnifiying glass</source>
-        <translation>Vergrößerungsglas</translation>
+        <translation type="vanished">Vergrößerungsglas</translation>
     </message>
     <message>
         <source>Toggle between fit to width and fit to height</source>
-        <translation>Zwischen Anpassung an Seite und Höhe wechseln</translation>
+        <translation type="vanished">Zwischen Anpassung an Seite und Höhe wechseln</translation>
     </message>
     <message>
         <source>Page adjustement</source>
-        <translation>Seitenanpassung</translation>
+        <translation type="vanished">Seitenanpassung</translation>
     </message>
     <message>
         <source>Autoscroll down</source>
-        <translation>Automatisches Runterscrollen</translation>
+        <translation type="vanished">Automatisches Runterscrollen</translation>
     </message>
     <message>
         <source>Autoscroll up</source>
-        <translation>Automatisches Raufscrollen</translation>
+        <translation type="vanished">Automatisches Raufscrollen</translation>
     </message>
     <message>
         <source>Autoscroll forward, horizontal first</source>
-        <translation>Automatisches Vorwärtsscrollen, horizontal zuerst</translation>
+        <translation type="vanished">Automatisches Vorwärtsscrollen, horizontal zuerst</translation>
     </message>
     <message>
         <source>Autoscroll backward, horizontal first</source>
-        <translation>Automatisches Zurückscrollen, horizontal zuerst</translation>
+        <translation type="vanished">Automatisches Zurückscrollen, horizontal zuerst</translation>
     </message>
     <message>
         <source>Autoscroll forward, vertical first</source>
-        <translation>Automatisches Vorwärtsscrollen, vertikal zuerst</translation>
+        <translation type="vanished">Automatisches Vorwärtsscrollen, vertikal zuerst</translation>
     </message>
     <message>
         <source>Autoscroll backward, vertical first</source>
-        <translation>Automatisches Zurückscrollen, vertikal zuerst</translation>
+        <translation type="vanished">Automatisches Zurückscrollen, vertikal zuerst</translation>
     </message>
     <message>
         <source>Move down</source>
-        <translation>Nach unten</translation>
+        <translation type="vanished">Nach unten</translation>
     </message>
     <message>
         <source>Move up</source>
-        <translation>Nach oben</translation>
+        <translation type="vanished">Nach oben</translation>
     </message>
     <message>
         <source>Move left</source>
-        <translation>Nach links</translation>
+        <translation type="vanished">Nach links</translation>
     </message>
     <message>
         <source>Move right</source>
-        <translation>Nach rechts</translation>
+        <translation type="vanished">Nach rechts</translation>
     </message>
     <message>
         <source>Go to the first page</source>
-        <translation>Zur ersten Seite gehen</translation>
+        <translation type="vanished">Zur ersten Seite gehen</translation>
     </message>
     <message>
         <source>Go to the last page</source>
-        <translation>Zur letzten Seite gehen</translation>
+        <translation type="vanished">Zur letzten Seite gehen</translation>
     </message>
     <message>
         <source>Reading</source>
-        <translation>Lesend</translation>
+        <translation type="vanished">Lesend</translation>
     </message>
 </context>
 <context>
     <name>OptionsDialog</name>
     <message>
+        <location filename="options_dialog.cpp" line="143"/>
         <source>Gamma</source>
         <translation>Gamma</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="147"/>
         <source>Reset</source>
         <translation>Zurücksetzen</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="34"/>
         <source>My comics path</source>
         <translation>Meine Comics-Pfad</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="191"/>
         <source>Image adjustment</source>
         <translation>Bildanpassung</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="43"/>
         <source>&quot;Go to flow&quot; size</source>
         <translation>&quot;Go to flow&quot; Größe</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="64"/>
         <source>Choose</source>
         <translation>Auswählen</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="152"/>
         <source>Image options</source>
         <translation>Bilderoptionen</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="142"/>
         <source>Contrast</source>
         <translation>Kontrast</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="206"/>
         <source>Options</source>
         <translation>Optionen</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="213"/>
         <source>Comics directory</source>
         <translation>Comics-Verzeichnis</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="61"/>
         <source>Background color</source>
         <translation>Hintergrundfarbe</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="190"/>
         <source>Page Flow</source>
         <translation>Page Flow</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="189"/>
         <source>General</source>
         <translation>Allgemein</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="141"/>
         <source>Brightness</source>
         <translation>Helligkeit</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="197"/>
         <source>Restart is needed</source>
         <translation>Neustart erforderlich</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="97"/>
         <source>Quick Navigation Mode</source>
         <translation>Schnellnavigations-Modus</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="71"/>
+        <source>Scroll behaviour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="74"/>
+        <source>Do not turn page using scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="75"/>
+        <source>Use single scroll step to turn page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="98"/>
         <source>Disable mouse over activation</source>
         <translation>Aktivierung durch Maus deaktivieren</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="156"/>
         <source>Fit options</source>
         <translation>Anpassungsoptionen</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="158"/>
         <source>Enlarge images to fit width/height</source>
         <translation>Bilder vergrößern, um sie Breite/Höhe anzupassen</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="169"/>
         <source>Double Page options</source>
         <translation>Doppelseiten-Einstellungen</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="171"/>
         <source>Show covers as single page</source>
         <translation>Cover als eine Seite darstellen</translation>
     </message>
@@ -610,34 +682,42 @@
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>7z lib not found</source>
         <translation>7z-Verzeichnis nicht gefunden</translation>
     </message>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>unable to load 7z lib from ./utils</source>
         <translation>7z -erzeichnis kann von ./utils nicht geladen werden</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41"/>
         <source>Trace</source>
         <translation>Verfolgen</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43"/>
         <source>Debug</source>
         <translation>Fehlersuche</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45"/>
         <source>Info</source>
         <translation>Information</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47"/>
         <source>Warning</source>
         <translation>Warnung</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51"/>
         <source>Fatal</source>
         <translation>Fatal</translation>
     </message>
@@ -645,14 +725,17 @@
 <context>
     <name>QsLogging::LogWindowModel</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="141"/>
         <source>Time</source>
         <translation>Zeit</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="143"/>
         <source>Level</source>
         <translation>Level</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="145"/>
         <source>Message</source>
         <translation>NAchricht</translation>
     </message>
@@ -660,18 +743,22 @@
 <context>
     <name>QsLogging::Window</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Pause</source>
         <translation>&amp;Pause</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Resume</source>
         <translation>&amp;Weiter</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="236"/>
         <source>Save log</source>
         <translation>Protokoll speichern</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="237"/>
         <source>Log file (*.log)</source>
         <translation>Protokoll-Datei (*.log)</translation>
     </message>
@@ -679,14 +766,17 @@
 <context>
     <name>ShortcutsDialog</name>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="23"/>
         <source>Close</source>
         <translation>Schliessen</translation>
     </message>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="19"/>
         <source>YACReader keyboard shortcuts</source>
         <translation>YACReader Tastaturkürzel</translation>
     </message>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="63"/>
         <source>Keyboard Shortcuts</source>
         <translation>Tastaturkürzel</translation>
     </message>
@@ -694,45 +784,537 @@
 <context>
     <name>Viewer</name>
     <message>
+        <location filename="viewer.cpp" line="937"/>
         <source>Page not available!</source>
         <translation>Seite nicht verfügbar!</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="51"/>
+        <location filename="viewer.cpp" line="915"/>
         <source>Press &apos;O&apos; to open comic.</source>
         <translation>&apos;O&apos; drücken, um Comic zu öffnen.</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="240"/>
         <source>Error opening comic</source>
         <translation>Fehler beim Öffnen des Comics</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="1089"/>
         <source>Cover!</source>
         <translation>Titelseite!</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="246"/>
         <source>CRC Error</source>
         <translation>CRC Fehler</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="234"/>
         <source>Comic not found</source>
         <translation>Comic nicht gefunden</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="234"/>
         <source>Not found</source>
         <translation>Nicht gefunden</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="1103"/>
         <source>Last page!</source>
         <translation>Letzte Seite!</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="927"/>
         <source>Loading...please wait!</source>
         <translation>Ladevorgang... Bitte warten!</translation>
     </message>
 </context>
 <context>
+    <name>YACReader::MainWindowViewer</name>
+    <message>
+        <location filename="main_window_viewer.cpp" line="219"/>
+        <source>&amp;Open</source>
+        <translation type="unfinished">&amp;Öffnen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="221"/>
+        <source>Open a comic</source>
+        <translation type="unfinished">Comic öffnen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="227"/>
+        <source>New instance</source>
+        <translation type="unfinished">Neuer Fall</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="246"/>
+        <source>Open Folder</source>
+        <translation type="unfinished">Ordner öffnen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="248"/>
+        <source>Open image folder</source>
+        <translation type="unfinished">Bilder-Ordner öffnen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="253"/>
+        <source>Open latest comic</source>
+        <translation type="unfinished">Neuesten Comic öffnen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="254"/>
+        <source>Open the latest comic opened in the previous reading session</source>
+        <translation type="unfinished">Öffne den neuesten Comic deiner letzten Sitzung</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="266"/>
+        <source>Clear</source>
+        <translation type="unfinished">Löschen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="267"/>
+        <source>Clear open recent list</source>
+        <translation type="unfinished">Lösche Liste zuletzt geöffneter Elemente</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="270"/>
+        <source>Save</source>
+        <translation type="unfinished">Speichern</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="272"/>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>Save current page</source>
+        <translation type="unfinished">Aktuelle Seite speichern</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="277"/>
+        <source>Previous Comic</source>
+        <translation type="unfinished">Voheriger Comic</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="279"/>
+        <location filename="main_window_viewer.cpp" line="1656"/>
+        <location filename="main_window_viewer.cpp" line="1660"/>
+        <source>Open previous comic</source>
+        <translation type="unfinished">Vorherigen Comic öffnen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="284"/>
+        <source>Next Comic</source>
+        <translation type="unfinished">Nächster Comic</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="286"/>
+        <location filename="main_window_viewer.cpp" line="1655"/>
+        <location filename="main_window_viewer.cpp" line="1661"/>
+        <source>Open next comic</source>
+        <translation type="unfinished">Nächsten Comic öffnen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="291"/>
+        <source>&amp;Previous</source>
+        <translation type="unfinished">&amp;Vorherige</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="294"/>
+        <location filename="main_window_viewer.cpp" line="1658"/>
+        <location filename="main_window_viewer.cpp" line="1662"/>
+        <source>Go to previous page</source>
+        <translation type="unfinished">Zur vorherigen Seite gehen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="299"/>
+        <source>&amp;Next</source>
+        <translation type="unfinished">&amp;Nächstes</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="302"/>
+        <location filename="main_window_viewer.cpp" line="1657"/>
+        <location filename="main_window_viewer.cpp" line="1663"/>
+        <source>Go to next page</source>
+        <translation type="unfinished">Zur nächsten Seite gehen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="307"/>
+        <source>Fit Height</source>
+        <translation type="unfinished">Höhe anpassen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="310"/>
+        <source>Fit image to height</source>
+        <translation type="unfinished">Bild an Höhe anpassen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="317"/>
+        <source>Fit Width</source>
+        <translation type="unfinished">Breite anpassen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="320"/>
+        <source>Fit image to width</source>
+        <translation type="unfinished">Bildbreite anpassen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="327"/>
+        <source>Show full size</source>
+        <translation type="unfinished">Vollansicht anzeigen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="335"/>
+        <source>Fit to page</source>
+        <translation type="unfinished">An Seite anpassen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="366"/>
+        <source>Reset zoom</source>
+        <translation type="unfinished">Zoom zurücksetzen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="371"/>
+        <source>Show zoom slider</source>
+        <translation type="unfinished">Zoomleiste anzeigen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="374"/>
+        <source>Zoom+</source>
+        <translation type="unfinished">Zoom+</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="379"/>
+        <source>Zoom-</source>
+        <translation type="unfinished">Zoom-</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="384"/>
+        <source>Rotate image to the left</source>
+        <translation type="unfinished">Bild nach links drehen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="390"/>
+        <source>Rotate image to the right</source>
+        <translation type="unfinished">Bild nach rechts drehen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="396"/>
+        <source>Double page mode</source>
+        <translation type="unfinished">Doppelseiten-Modus</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="397"/>
+        <source>Switch to double page mode</source>
+        <translation type="unfinished">Zum Doppelseiten-Modus wechseln</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="406"/>
+        <source>Double page manga mode</source>
+        <translation type="unfinished">Doppelseiten-Manga-Modus</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="407"/>
+        <source>Reverse reading order in double page mode</source>
+        <translation type="unfinished">Umgekehrte Lesereihenfolge im Doppelseiten-Modus</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="416"/>
+        <source>Go To</source>
+        <translation type="unfinished">Gehe zu</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="418"/>
+        <source>Go to page ...</source>
+        <translation type="unfinished">Gehe zu Seite ...</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="423"/>
+        <source>Options</source>
+        <translation type="unfinished">Optionen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="424"/>
+        <source>YACReader options</source>
+        <translation type="unfinished">YACReader Optionen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="431"/>
+        <location filename="main_window_viewer.cpp" line="715"/>
+        <source>Help</source>
+        <translation type="unfinished">Hilfe</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="432"/>
+        <source>Help, About YACReader</source>
+        <translation type="unfinished">Hilfe, über YACReader</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="438"/>
+        <source>Magnifying glass</source>
+        <translation type="unfinished">Vergößerungsglas</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="439"/>
+        <source>Switch Magnifying glass</source>
+        <translation type="unfinished">Vergrößerungsglas wechseln</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="446"/>
+        <source>Set bookmark</source>
+        <translation type="unfinished">Lesezeichen setzen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="447"/>
+        <source>Set a bookmark on the current page</source>
+        <translation type="unfinished">Lesezeichen auf dieser Seite setzen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="456"/>
+        <source>Show bookmarks</source>
+        <translation type="unfinished">Lesezeichen anzeigen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="457"/>
+        <source>Show the bookmarks of the current comic</source>
+        <translation type="unfinished">Lesezeichen für diesen Comic anzeigen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="463"/>
+        <source>Show keyboard shortcuts</source>
+        <translation type="unfinished">Tastenkürzel anzeigen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="470"/>
+        <source>Show Info</source>
+        <translation type="unfinished">Info anzeigen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="476"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="482"/>
+        <source>Show Dictionary</source>
+        <translation type="unfinished">Wörterbuch anzeigen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="489"/>
+        <source>Show go to flow</source>
+        <translation type="unfinished">&quot;Go to Flow&quot; anzeigen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="495"/>
+        <source>Edit shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="515"/>
+        <source>&amp;File</source>
+        <translation type="unfinished">&amp;Datei</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="529"/>
+        <location filename="main_window_viewer.cpp" line="670"/>
+        <source>Open recent</source>
+        <translation type="unfinished">Kürzlich geöffnet</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="659"/>
+        <source>File</source>
+        <translation type="unfinished">Datei</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="680"/>
+        <source>Edit</source>
+        <translation type="unfinished">Ändern</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="684"/>
+        <source>View</source>
+        <translation type="unfinished">Anzeigen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="700"/>
+        <source>Go</source>
+        <translation type="unfinished">Los</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="708"/>
+        <source>Window</source>
+        <translation type="unfinished">Fenster</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="809"/>
+        <location filename="main_window_viewer.cpp" line="811"/>
+        <source>Open Comic</source>
+        <translation type="unfinished">Comic öffnen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="809"/>
+        <location filename="main_window_viewer.cpp" line="811"/>
+        <source>Comic files</source>
+        <translation type="unfinished">Comic-Dateien</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="898"/>
+        <source>Open folder</source>
+        <translation type="unfinished">Ordner öffnen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>page_%1.jpg</source>
+        <translation type="unfinished">Seite_%1.jpg</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>Image files (*.jpg)</source>
+        <translation type="unfinished">Bildateien (*.jpg)</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1159"/>
+        <source>Comics</source>
+        <translation type="unfinished">Comics</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1169"/>
+        <source>Toggle fullscreen mode</source>
+        <translation type="unfinished">Vollbild-Modus umschalten</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1172"/>
+        <source>Hide/show toolbar</source>
+        <translation type="unfinished">Symbolleiste anzeigen/verstecken</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1175"/>
+        <source>General</source>
+        <translation type="unfinished">Allgemein</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1194"/>
+        <source>Size up magnifying glass</source>
+        <translation type="unfinished">Vergrößerungsglas vergrößern</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1197"/>
+        <source>Size down magnifying glass</source>
+        <translation type="unfinished">Vergrößerungsglas verkleinern</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1200"/>
+        <source>Zoom in magnifying glass</source>
+        <translation type="unfinished">Vergrößerungsglas reinzoomen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1203"/>
+        <source>Zoom out magnifying glass</source>
+        <translation type="unfinished">Vergrößerungsglas rauszoomen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1209"/>
+        <source>Magnifiying glass</source>
+        <translation type="unfinished">Vergrößerungsglas</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1216"/>
+        <source>Toggle between fit to width and fit to height</source>
+        <translation type="unfinished">Zwischen Anpassung an Seite und Höhe wechseln</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1220"/>
+        <source>Page adjustement</source>
+        <translation type="unfinished">Seitenanpassung</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1237"/>
+        <source>Autoscroll down</source>
+        <translation type="unfinished">Automatisches Runterscrollen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1240"/>
+        <source>Autoscroll up</source>
+        <translation type="unfinished">Automatisches Raufscrollen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1243"/>
+        <source>Autoscroll forward, horizontal first</source>
+        <translation type="unfinished">Automatisches Vorwärtsscrollen, horizontal zuerst</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1247"/>
+        <source>Autoscroll backward, horizontal first</source>
+        <translation type="unfinished">Automatisches Zurückscrollen, horizontal zuerst</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1251"/>
+        <source>Autoscroll forward, vertical first</source>
+        <translation type="unfinished">Automatisches Vorwärtsscrollen, vertikal zuerst</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1255"/>
+        <source>Autoscroll backward, vertical first</source>
+        <translation type="unfinished">Automatisches Zurückscrollen, vertikal zuerst</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1259"/>
+        <source>Move down</source>
+        <translation type="unfinished">Nach unten</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1262"/>
+        <source>Move up</source>
+        <translation type="unfinished">Nach oben</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1265"/>
+        <source>Move left</source>
+        <translation type="unfinished">Nach links</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1268"/>
+        <source>Move right</source>
+        <translation type="unfinished">Nach rechts</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1271"/>
+        <source>Go to the first page</source>
+        <translation type="unfinished">Zur ersten Seite gehen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1274"/>
+        <source>Go to the last page</source>
+        <translation type="unfinished">Zur letzten Seite gehen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1290"/>
+        <source>Reading</source>
+        <translation type="unfinished">Lesend</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1335"/>
+        <source>There is a new version available</source>
+        <translation type="unfinished">Neue Version verfügbar</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1336"/>
+        <source>Do you want to download the new version?</source>
+        <translation type="unfinished">Möchten Sie die neue Version herunterladen?</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1339"/>
+        <source>Remind me in 14 days</source>
+        <translation type="unfinished">In 14 Tagen erneut erinnern</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1340"/>
+        <source>Not now</source>
+        <translation type="unfinished">Nicht jetzt</translation>
+    </message>
+</context>
+<context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
@@ -740,10 +1322,13 @@
 <context>
     <name>YACReaderFieldEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11"/>
         <source>Restore to default</source>
         <translation>Ursprungszustand wiederherstellen</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28"/>
         <source>Click to overwrite</source>
         <translation>Anklicken, um zu überschreiben</translation>
     </message>
@@ -751,10 +1336,15 @@
 <context>
     <name>YACReaderFieldPlainTextEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10"/>
         <source>Restore to default</source>
         <translation>Urpsrungszustand wiederherstellen</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50"/>
         <source>Click to overwrite</source>
         <translation>Anklicken, um zu überschreiben</translation>
     </message>
@@ -762,18 +1352,22 @@
 <context>
     <name>YACReaderFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="15"/>
         <source>CoverFlow look</source>
         <translation>Tielseiten Ansicht</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="13"/>
         <source>How to show covers:</source>
         <translation>Titelseiten Anzeigeoptionen:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="16"/>
         <source>Stripe look</source>
         <translation>Streifen-Ansicht</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="17"/>
         <source>Overlapped Stripe look</source>
         <translation>Überlappende Streifen-Ansicht</translation>
     </message>
@@ -781,94 +1375,117 @@
 <context>
     <name>YACReaderGLFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="112"/>
         <source>Zoom</source>
         <translation>Vergrößern</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="142"/>
         <source>Light</source>
         <translation>Licht</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="76"/>
         <source>Show advanced settings</source>
         <translation>Zeige erweiterte Einstellungen</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="32"/>
         <source>Roulette look</source>
         <translation>Zufalls-Ansicht</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="130"/>
         <source>Cover Angle</source>
         <translation>Titelbild Ansichtswinkel</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="23"/>
         <source>Stripe look</source>
         <translation>Streifen-Ansicht</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="94"/>
         <source>Position</source>
         <translation>Position</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="124"/>
         <source>Z offset</source>
         <translation>Z-Anpassung</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="118"/>
         <source>Y offset</source>
         <translation>Y-Anpassung</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="106"/>
         <source>Central gap</source>
         <translation>Mittiger Abstand</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="18"/>
         <source>Presets:</source>
         <translation>Voreinstellungen:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="26"/>
         <source>Overlapped Stripe look</source>
         <translation>Überlappende Streifen-Ansicht</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="29"/>
         <source>Modern look</source>
         <translation>Moderne Ansicht</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="88"/>
         <source>View angle</source>
         <translation>Anzeige-Winkel</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="148"/>
         <source>Max angle</source>
         <translation>Maximaler Winkel</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="85"/>
         <source>Custom:</source>
         <translation>Benutzerdefiniert:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="20"/>
         <source>Classic look</source>
         <translation>Klassische Ansicht</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="100"/>
         <source>Cover gap</source>
         <translation>Titelbild-Abstand</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="182"/>
         <source>High Performance</source>
         <translation>Hohe Leistung</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="201"/>
         <source>Performance:</source>
         <translation>Leistung:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="193"/>
         <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
         <translation>Benutze VSync (verbessert die Bildqualität im Vollanzeigemodus, schlechtere Leistung)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="136"/>
         <source>Visibility</source>
         <translation>Sichtbarkeit</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="180"/>
         <source>Low Performance</source>
         <translation>Niedrige Leistung</translation>
     </message>
@@ -876,22 +1493,27 @@
 <context>
     <name>YACReaderOptionsDialog</name>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="46"/>
         <source>Use hardware acceleration (restart needed)</source>
         <translation>Nutze Hardwarebeschleunigung (Neustart erforderlich)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="29"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="34"/>
         <source>Edit shortcuts</source>
         <translation>Kürzel bearbeiten</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="37"/>
         <source>Shortcuts</source>
         <translation>Kürzel</translation>
     </message>
@@ -899,6 +1521,7 @@
 <context>
     <name>YACReaderSlider</name>
     <message>
+        <location filename="width_slider.cpp" line="49"/>
         <source>Reset</source>
         <translation>Zurücksetzen</translation>
     </message>
@@ -906,18 +1529,23 @@
 <context>
     <name>YACReaderTranslator</name>
     <message>
+        <location filename="translator.cpp" line="139"/>
         <source>clear</source>
         <translation>Löschen</translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="216"/>
         <source>Service not available</source>
         <translation>Service nicht verfügbar</translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="116"/>
+        <location filename="translator.cpp" line="207"/>
         <source>Translation</source>
         <translation>Übersetzung</translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="62"/>
         <source>YACReader translator</source>
         <translation>YACReader Übersetzer</translation>
     </message>

--- a/YACReader/yacreader_en.ts
+++ b/YACReader/yacreader_en.ts
@@ -4,7 +4,7 @@
 <context>
     <name>ActionsShortcutsModel</name>
     <message>
-        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="72"/>
+        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="73"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17,18 +17,18 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="bookmarks_dialog.cpp" line="70"/>
+        <location filename="bookmarks_dialog.cpp" line="75"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="bookmarks_dialog.cpp" line="80"/>
+        <location filename="bookmarks_dialog.cpp" line="85"/>
         <source>Click on any image to go to the bookmark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="bookmarks_dialog.cpp" line="102"/>
-        <location filename="bookmarks_dialog.cpp" line="119"/>
+        <location filename="bookmarks_dialog.cpp" line="107"/>
+        <location filename="bookmarks_dialog.cpp" line="124"/>
         <source>Loading...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -103,7 +103,7 @@
     </message>
     <message>
         <location filename="goto_dialog.cpp" line="39"/>
-        <location filename="goto_dialog.cpp" line="73"/>
+        <location filename="goto_dialog.cpp" line="71"/>
         <source>Total pages : </source>
         <translation type="unfinished"></translation>
     </message>
@@ -116,7 +116,7 @@
 <context>
     <name>GoToFlowToolBar</name>
     <message>
-        <location filename="goto_flow_toolbar.cpp" line="37"/>
+        <location filename="goto_flow_toolbar.cpp" line="38"/>
         <source>Page : </source>
         <translation type="unfinished"></translation>
     </message>
@@ -124,13 +124,18 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
-        <location filename="../custom_widgets/help_about_dialog.cpp" line="21"/>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../custom_widgets/help_about_dialog.cpp" line="24"/>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
+        <source>System info</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -173,510 +178,24 @@
     </message>
 </context>
 <context>
-    <name>MainWindowViewer</name>
-    <message>
-        <location filename="main_window_viewer.cpp" line="211"/>
-        <source>&amp;Open</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="213"/>
-        <source>Open a comic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="238"/>
-        <source>Open Folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="240"/>
-        <source>Open image folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="264"/>
-        <source>Save</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="266"/>
-        <location filename="main_window_viewer.cpp" line="969"/>
-        <source>Save current page</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="272"/>
-        <source>Previous Comic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="274"/>
-        <location filename="main_window_viewer.cpp" line="1735"/>
-        <location filename="main_window_viewer.cpp" line="1739"/>
-        <source>Open previous comic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="280"/>
-        <source>Next Comic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="282"/>
-        <location filename="main_window_viewer.cpp" line="1734"/>
-        <location filename="main_window_viewer.cpp" line="1740"/>
-        <source>Open next comic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="288"/>
-        <source>&amp;Previous</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="291"/>
-        <location filename="main_window_viewer.cpp" line="1737"/>
-        <location filename="main_window_viewer.cpp" line="1741"/>
-        <source>Go to previous page</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="297"/>
-        <source>&amp;Next</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="300"/>
-        <location filename="main_window_viewer.cpp" line="1736"/>
-        <location filename="main_window_viewer.cpp" line="1742"/>
-        <source>Go to next page</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="317"/>
-        <source>Fit Width</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="310"/>
-        <source>Fit image to height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="245"/>
-        <source>Open latest comic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="246"/>
-        <source>Open the latest comic opened in the previous reading session</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="261"/>
-        <source>Clear open recent list</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="306"/>
-        <source>Fit Height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="321"/>
-        <source>Fit image to width</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="391"/>
-        <source>Rotate image to the left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="398"/>
-        <source>Rotate image to the right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="405"/>
-        <source>Double page mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="406"/>
-        <source>Switch to double page mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="427"/>
-        <source>Go To</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="430"/>
-        <source>Go to page ...</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="435"/>
-        <source>Options</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="436"/>
-        <source>YACReader options</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="443"/>
-        <location filename="main_window_viewer.cpp" line="734"/>
-        <source>Help</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="444"/>
-        <source>Help, About YACReader</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="450"/>
-        <source>Magnifying glass</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="451"/>
-        <source>Switch Magnifying glass</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="459"/>
-        <source>Set bookmark</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="460"/>
-        <source>Set a bookmark on the current page</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="470"/>
-        <source>Show bookmarks</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="471"/>
-        <source>Show the bookmarks of the current comic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="478"/>
-        <source>Show keyboard shortcuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="485"/>
-        <source>Show Info</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="492"/>
-        <source>Close</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="498"/>
-        <source>Show Dictionary</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="507"/>
-        <source>Always on top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="328"/>
-        <source>Show full size</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="219"/>
-        <source>New instance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="260"/>
-        <source>Clear</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="337"/>
-        <source>Fit to page</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="369"/>
-        <source>Reset zoom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="375"/>
-        <source>Show zoom slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="379"/>
-        <source>Zoom+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="385"/>
-        <source>Zoom-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="416"/>
-        <source>Double page manga mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="417"/>
-        <source>Reverse reading order in double page mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="516"/>
-        <source>Show go to flow</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="523"/>
-        <source>Edit shortcuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="534"/>
-        <source>&amp;File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="548"/>
-        <location filename="main_window_viewer.cpp" line="689"/>
-        <source>Open recent</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="678"/>
-        <source>File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="699"/>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="703"/>
-        <source>View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="719"/>
-        <source>Go</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="727"/>
-        <source>Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="825"/>
-        <location filename="main_window_viewer.cpp" line="827"/>
-        <source>Open Comic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="825"/>
-        <location filename="main_window_viewer.cpp" line="827"/>
-        <source>Comic files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="913"/>
-        <source>Open folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="969"/>
-        <source>Image files (*.jpg)</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="969"/>
-        <source>page_%1.jpg</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1251"/>
-        <source>Comics</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1262"/>
-        <source>Toggle fullscreen mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1266"/>
-        <source>Hide/show toolbar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1270"/>
-        <source>General</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1290"/>
-        <source>Size up magnifying glass</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1294"/>
-        <source>Size down magnifying glass</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1298"/>
-        <source>Zoom in magnifying glass</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1302"/>
-        <source>Zoom out magnifying glass</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1306"/>
-        <source>Magnifiying glass</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1317"/>
-        <source>Toggle between fit to width and fit to height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1321"/>
-        <source>Page adjustement</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1337"/>
-        <source>Autoscroll down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1341"/>
-        <source>Autoscroll up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1345"/>
-        <source>Autoscroll forward, horizontal first</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1349"/>
-        <source>Autoscroll backward, horizontal first</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1353"/>
-        <source>Autoscroll forward, vertical first</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1357"/>
-        <source>Autoscroll backward, vertical first</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1361"/>
-        <source>Move down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1365"/>
-        <source>Move up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1369"/>
-        <source>Move left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1373"/>
-        <source>Move right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1377"/>
-        <source>Go to the first page</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1381"/>
-        <source>Go to the last page</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1385"/>
-        <source>Reading</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1441"/>
-        <source>There is a new version available</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1442"/>
-        <source>Do you want to download the new version?</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1445"/>
-        <source>Remind me in 14 days</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="main_window_viewer.cpp" line="1446"/>
-        <source>Not now</source>
-        <translation type="unfinished"></translation>
-    </message>
-</context>
-<context>
     <name>OptionsDialog</name>
     <message>
-        <location filename="options_dialog.cpp" line="38"/>
+        <location filename="options_dialog.cpp" line="43"/>
         <source>&quot;Go to flow&quot; size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="49"/>
+        <location filename="options_dialog.cpp" line="34"/>
         <source>My comics path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="68"/>
+        <location filename="options_dialog.cpp" line="61"/>
         <source>Background color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="71"/>
+        <location filename="options_dialog.cpp" line="64"/>
         <source>Choose</source>
         <translation type="unfinished"></translation>
     </message>
@@ -691,77 +210,92 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="102"/>
+        <location filename="options_dialog.cpp" line="197"/>
         <source>Restart is needed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="122"/>
+        <location filename="options_dialog.cpp" line="141"/>
         <source>Brightness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="123"/>
+        <location filename="options_dialog.cpp" line="71"/>
+        <source>Scroll behaviour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="74"/>
+        <source>Do not turn page using scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="75"/>
+        <source>Use single scroll step to turn page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="142"/>
         <source>Contrast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="124"/>
+        <location filename="options_dialog.cpp" line="143"/>
         <source>Gamma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="128"/>
+        <location filename="options_dialog.cpp" line="147"/>
         <source>Reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="133"/>
+        <location filename="options_dialog.cpp" line="152"/>
         <source>Image options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="137"/>
+        <location filename="options_dialog.cpp" line="156"/>
         <source>Fit options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="139"/>
+        <location filename="options_dialog.cpp" line="158"/>
         <source>Enlarge images to fit width/height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="150"/>
+        <location filename="options_dialog.cpp" line="169"/>
         <source>Double Page options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="152"/>
+        <location filename="options_dialog.cpp" line="171"/>
         <source>Show covers as single page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="168"/>
+        <location filename="options_dialog.cpp" line="189"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="169"/>
+        <location filename="options_dialog.cpp" line="190"/>
         <source>Page Flow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="170"/>
+        <location filename="options_dialog.cpp" line="191"/>
         <source>Image adjustment</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="184"/>
+        <location filename="options_dialog.cpp" line="206"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="191"/>
+        <location filename="options_dialog.cpp" line="213"/>
         <source>Comics directory</source>
         <translation type="unfinished"></translation>
     </message>
@@ -853,17 +387,17 @@
 <context>
     <name>ShortcutsDialog</name>
     <message>
-        <location filename="shortcuts_dialog.cpp" line="16"/>
+        <location filename="shortcuts_dialog.cpp" line="19"/>
         <source>YACReader keyboard shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="shortcuts_dialog.cpp" line="20"/>
+        <location filename="shortcuts_dialog.cpp" line="23"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="shortcuts_dialog.cpp" line="54"/>
+        <location filename="shortcuts_dialog.cpp" line="63"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -871,56 +405,537 @@
 <context>
     <name>Viewer</name>
     <message>
-        <location filename="viewer.cpp" line="50"/>
-        <location filename="viewer.cpp" line="949"/>
+        <location filename="viewer.cpp" line="51"/>
+        <location filename="viewer.cpp" line="915"/>
         <source>Press &apos;O&apos; to open comic.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="viewer.cpp" line="229"/>
+        <location filename="viewer.cpp" line="234"/>
         <source>Not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="viewer.cpp" line="229"/>
+        <location filename="viewer.cpp" line="234"/>
         <source>Comic not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="viewer.cpp" line="235"/>
+        <location filename="viewer.cpp" line="240"/>
         <source>Error opening comic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="viewer.cpp" line="241"/>
+        <location filename="viewer.cpp" line="246"/>
         <source>CRC Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="viewer.cpp" line="961"/>
+        <location filename="viewer.cpp" line="927"/>
         <source>Loading...please wait!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="viewer.cpp" line="971"/>
+        <location filename="viewer.cpp" line="937"/>
         <source>Page not available!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="viewer.cpp" line="1107"/>
+        <location filename="viewer.cpp" line="1089"/>
         <source>Cover!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="viewer.cpp" line="1121"/>
+        <location filename="viewer.cpp" line="1103"/>
         <source>Last page!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReader::MainWindowViewer</name>
+    <message>
+        <location filename="main_window_viewer.cpp" line="219"/>
+        <source>&amp;Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="221"/>
+        <source>Open a comic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="227"/>
+        <source>New instance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="246"/>
+        <source>Open Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="248"/>
+        <source>Open image folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="253"/>
+        <source>Open latest comic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="254"/>
+        <source>Open the latest comic opened in the previous reading session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="266"/>
+        <source>Clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="267"/>
+        <source>Clear open recent list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="270"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="272"/>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>Save current page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="277"/>
+        <source>Previous Comic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="279"/>
+        <location filename="main_window_viewer.cpp" line="1656"/>
+        <location filename="main_window_viewer.cpp" line="1660"/>
+        <source>Open previous comic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="284"/>
+        <source>Next Comic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="286"/>
+        <location filename="main_window_viewer.cpp" line="1655"/>
+        <location filename="main_window_viewer.cpp" line="1661"/>
+        <source>Open next comic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="291"/>
+        <source>&amp;Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="294"/>
+        <location filename="main_window_viewer.cpp" line="1658"/>
+        <location filename="main_window_viewer.cpp" line="1662"/>
+        <source>Go to previous page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="299"/>
+        <source>&amp;Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="302"/>
+        <location filename="main_window_viewer.cpp" line="1657"/>
+        <location filename="main_window_viewer.cpp" line="1663"/>
+        <source>Go to next page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="307"/>
+        <source>Fit Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="310"/>
+        <source>Fit image to height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="317"/>
+        <source>Fit Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="320"/>
+        <source>Fit image to width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="327"/>
+        <source>Show full size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="335"/>
+        <source>Fit to page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="366"/>
+        <source>Reset zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="371"/>
+        <source>Show zoom slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="374"/>
+        <source>Zoom+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="379"/>
+        <source>Zoom-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="384"/>
+        <source>Rotate image to the left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="390"/>
+        <source>Rotate image to the right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="396"/>
+        <source>Double page mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="397"/>
+        <source>Switch to double page mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="406"/>
+        <source>Double page manga mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="407"/>
+        <source>Reverse reading order in double page mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="416"/>
+        <source>Go To</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="418"/>
+        <source>Go to page ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="423"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="424"/>
+        <source>YACReader options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="431"/>
+        <location filename="main_window_viewer.cpp" line="715"/>
+        <source>Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="432"/>
+        <source>Help, About YACReader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="438"/>
+        <source>Magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="439"/>
+        <source>Switch Magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="446"/>
+        <source>Set bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="447"/>
+        <source>Set a bookmark on the current page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="456"/>
+        <source>Show bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="457"/>
+        <source>Show the bookmarks of the current comic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="463"/>
+        <source>Show keyboard shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="470"/>
+        <source>Show Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="476"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="482"/>
+        <source>Show Dictionary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="489"/>
+        <source>Show go to flow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="495"/>
+        <source>Edit shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="515"/>
+        <source>&amp;File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="529"/>
+        <location filename="main_window_viewer.cpp" line="670"/>
+        <source>Open recent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="659"/>
+        <source>File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="680"/>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="684"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="700"/>
+        <source>Go</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="708"/>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="809"/>
+        <location filename="main_window_viewer.cpp" line="811"/>
+        <source>Open Comic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="809"/>
+        <location filename="main_window_viewer.cpp" line="811"/>
+        <source>Comic files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="898"/>
+        <source>Open folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>page_%1.jpg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>Image files (*.jpg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1159"/>
+        <source>Comics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1169"/>
+        <source>Toggle fullscreen mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1172"/>
+        <source>Hide/show toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1175"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1194"/>
+        <source>Size up magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1197"/>
+        <source>Size down magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1200"/>
+        <source>Zoom in magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1203"/>
+        <source>Zoom out magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1209"/>
+        <source>Magnifiying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1216"/>
+        <source>Toggle between fit to width and fit to height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1220"/>
+        <source>Page adjustement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1237"/>
+        <source>Autoscroll down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1240"/>
+        <source>Autoscroll up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1243"/>
+        <source>Autoscroll forward, horizontal first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1247"/>
+        <source>Autoscroll backward, horizontal first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1251"/>
+        <source>Autoscroll forward, vertical first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1255"/>
+        <source>Autoscroll backward, vertical first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1259"/>
+        <source>Move down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1262"/>
+        <source>Move up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1265"/>
+        <source>Move left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1268"/>
+        <source>Move right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1271"/>
+        <source>Go to the first page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1274"/>
+        <source>Go to the last page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1290"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1335"/>
+        <source>There is a new version available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1336"/>
+        <source>Do you want to download the new version?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1339"/>
+        <source>Remind me in 14 days</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1340"/>
+        <source>Not now</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
-        <location filename="../custom_widgets/whats_new_dialog.cpp" line="99"/>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1141,7 +1156,7 @@
     </message>
     <message>
         <location filename="translator.cpp" line="116"/>
-        <location filename="translator.cpp" line="208"/>
+        <location filename="translator.cpp" line="207"/>
         <source>Translation</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1151,7 +1166,7 @@
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="translator.cpp" line="217"/>
+        <location filename="translator.cpp" line="216"/>
         <source>Service not available</source>
         <translation type="unfinished"></translation>
     </message>

--- a/YACReader/yacreader_en.ts
+++ b/YACReader/yacreader_en.ts
@@ -1,0 +1,1159 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>ActionsShortcutsModel</name>
+    <message>
+        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="72"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>BookmarksDialog</name>
+    <message>
+        <location filename="bookmarks_dialog.cpp" line="25"/>
+        <source>Lastest Page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="bookmarks_dialog.cpp" line="70"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="bookmarks_dialog.cpp" line="80"/>
+        <source>Click on any image to go to the bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="bookmarks_dialog.cpp" line="102"/>
+        <location filename="bookmarks_dialog.cpp" line="119"/>
+        <source>Loading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditShortcutsDialog</name>
+    <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="21"/>
+        <source>Restore defaults</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="22"/>
+        <source>To change a shortcut, double click in the key combination and type the new keys.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="69"/>
+        <source>Shortcuts settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
+        <source>Shortcut in use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
+        <source>The shortcut &quot;%1&quot; is already assigned to other function</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileComic</name>
+    <message>
+        <location filename="../common/comic.cpp" line="454"/>
+        <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/comic.cpp" line="461"/>
+        <source>Unknown error opening the file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/comic.cpp" line="562"/>
+        <source>7z not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/comic.cpp" line="568"/>
+        <source>Format not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GoToDialog</name>
+    <message>
+        <location filename="goto_dialog.cpp" line="15"/>
+        <source>Page : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="goto_dialog.cpp" line="23"/>
+        <source>Go To</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="goto_dialog.cpp" line="25"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="goto_dialog.cpp" line="39"/>
+        <location filename="goto_dialog.cpp" line="73"/>
+        <source>Total pages : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="goto_dialog.cpp" line="53"/>
+        <source>Go to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GoToFlowToolBar</name>
+    <message>
+        <location filename="goto_flow_toolbar.cpp" line="37"/>
+        <source>Page : </source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>HelpAboutDialog</name>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="21"/>
+        <source>About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="24"/>
+        <source>Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LogWindow</name>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="14"/>
+        <source>Log window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="22"/>
+        <source>&amp;Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="39"/>
+        <source>&amp;Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="56"/>
+        <source>C&amp;lear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="73"/>
+        <source>&amp;Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="90"/>
+        <source>Level:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="136"/>
+        <source>&amp;Auto scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>MainWindowViewer</name>
+    <message>
+        <location filename="main_window_viewer.cpp" line="211"/>
+        <source>&amp;Open</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="213"/>
+        <source>Open a comic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="238"/>
+        <source>Open Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="240"/>
+        <source>Open image folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="264"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="266"/>
+        <location filename="main_window_viewer.cpp" line="969"/>
+        <source>Save current page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="272"/>
+        <source>Previous Comic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="274"/>
+        <location filename="main_window_viewer.cpp" line="1735"/>
+        <location filename="main_window_viewer.cpp" line="1739"/>
+        <source>Open previous comic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="280"/>
+        <source>Next Comic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="282"/>
+        <location filename="main_window_viewer.cpp" line="1734"/>
+        <location filename="main_window_viewer.cpp" line="1740"/>
+        <source>Open next comic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="288"/>
+        <source>&amp;Previous</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="291"/>
+        <location filename="main_window_viewer.cpp" line="1737"/>
+        <location filename="main_window_viewer.cpp" line="1741"/>
+        <source>Go to previous page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="297"/>
+        <source>&amp;Next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="300"/>
+        <location filename="main_window_viewer.cpp" line="1736"/>
+        <location filename="main_window_viewer.cpp" line="1742"/>
+        <source>Go to next page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="317"/>
+        <source>Fit Width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="310"/>
+        <source>Fit image to height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="245"/>
+        <source>Open latest comic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="246"/>
+        <source>Open the latest comic opened in the previous reading session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="261"/>
+        <source>Clear open recent list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="306"/>
+        <source>Fit Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="321"/>
+        <source>Fit image to width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="391"/>
+        <source>Rotate image to the left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="398"/>
+        <source>Rotate image to the right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="405"/>
+        <source>Double page mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="406"/>
+        <source>Switch to double page mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="427"/>
+        <source>Go To</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="430"/>
+        <source>Go to page ...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="435"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="436"/>
+        <source>YACReader options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="443"/>
+        <location filename="main_window_viewer.cpp" line="734"/>
+        <source>Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="444"/>
+        <source>Help, About YACReader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="450"/>
+        <source>Magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="451"/>
+        <source>Switch Magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="459"/>
+        <source>Set bookmark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="460"/>
+        <source>Set a bookmark on the current page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="470"/>
+        <source>Show bookmarks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="471"/>
+        <source>Show the bookmarks of the current comic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="478"/>
+        <source>Show keyboard shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="485"/>
+        <source>Show Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="492"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="498"/>
+        <source>Show Dictionary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="507"/>
+        <source>Always on top</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="328"/>
+        <source>Show full size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="219"/>
+        <source>New instance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="260"/>
+        <source>Clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="337"/>
+        <source>Fit to page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="369"/>
+        <source>Reset zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="375"/>
+        <source>Show zoom slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="379"/>
+        <source>Zoom+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="385"/>
+        <source>Zoom-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="416"/>
+        <source>Double page manga mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="417"/>
+        <source>Reverse reading order in double page mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="516"/>
+        <source>Show go to flow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="523"/>
+        <source>Edit shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="534"/>
+        <source>&amp;File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="548"/>
+        <location filename="main_window_viewer.cpp" line="689"/>
+        <source>Open recent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="678"/>
+        <source>File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="699"/>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="703"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="719"/>
+        <source>Go</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="727"/>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="825"/>
+        <location filename="main_window_viewer.cpp" line="827"/>
+        <source>Open Comic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="825"/>
+        <location filename="main_window_viewer.cpp" line="827"/>
+        <source>Comic files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="913"/>
+        <source>Open folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="969"/>
+        <source>Image files (*.jpg)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="969"/>
+        <source>page_%1.jpg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1251"/>
+        <source>Comics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1262"/>
+        <source>Toggle fullscreen mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1266"/>
+        <source>Hide/show toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1270"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1290"/>
+        <source>Size up magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1294"/>
+        <source>Size down magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1298"/>
+        <source>Zoom in magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1302"/>
+        <source>Zoom out magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1306"/>
+        <source>Magnifiying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1317"/>
+        <source>Toggle between fit to width and fit to height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1321"/>
+        <source>Page adjustement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1337"/>
+        <source>Autoscroll down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1341"/>
+        <source>Autoscroll up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1345"/>
+        <source>Autoscroll forward, horizontal first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1349"/>
+        <source>Autoscroll backward, horizontal first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1353"/>
+        <source>Autoscroll forward, vertical first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1357"/>
+        <source>Autoscroll backward, vertical first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1361"/>
+        <source>Move down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1365"/>
+        <source>Move up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1369"/>
+        <source>Move left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1373"/>
+        <source>Move right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1377"/>
+        <source>Go to the first page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1381"/>
+        <source>Go to the last page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1385"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1441"/>
+        <source>There is a new version available</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1442"/>
+        <source>Do you want to download the new version?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1445"/>
+        <source>Remind me in 14 days</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1446"/>
+        <source>Not now</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OptionsDialog</name>
+    <message>
+        <location filename="options_dialog.cpp" line="38"/>
+        <source>&quot;Go to flow&quot; size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="49"/>
+        <source>My comics path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="68"/>
+        <source>Background color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="71"/>
+        <source>Choose</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="97"/>
+        <source>Quick Navigation Mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="98"/>
+        <source>Disable mouse over activation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="102"/>
+        <source>Restart is needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="122"/>
+        <source>Brightness</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="123"/>
+        <source>Contrast</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="124"/>
+        <source>Gamma</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="128"/>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="133"/>
+        <source>Image options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="137"/>
+        <source>Fit options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="139"/>
+        <source>Enlarge images to fit width/height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="150"/>
+        <source>Double Page options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="152"/>
+        <source>Show covers as single page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="168"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="169"/>
+        <source>Page Flow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="170"/>
+        <source>Image adjustment</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="184"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="191"/>
+        <source>Comics directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
+        <source>7z lib not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
+        <source>unable to load 7z lib from ./utils</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41"/>
+        <source>Trace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43"/>
+        <source>Debug</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45"/>
+        <source>Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51"/>
+        <source>Fatal</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QsLogging::LogWindowModel</name>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="141"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="143"/>
+        <source>Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="145"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QsLogging::Window</name>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
+        <source>&amp;Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
+        <source>&amp;Resume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="236"/>
+        <source>Save log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="237"/>
+        <source>Log file (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ShortcutsDialog</name>
+    <message>
+        <location filename="shortcuts_dialog.cpp" line="16"/>
+        <source>YACReader keyboard shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="shortcuts_dialog.cpp" line="20"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="shortcuts_dialog.cpp" line="54"/>
+        <source>Keyboard Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>Viewer</name>
+    <message>
+        <location filename="viewer.cpp" line="50"/>
+        <location filename="viewer.cpp" line="949"/>
+        <source>Press &apos;O&apos; to open comic.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="viewer.cpp" line="229"/>
+        <source>Not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="viewer.cpp" line="229"/>
+        <source>Comic not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="viewer.cpp" line="235"/>
+        <source>Error opening comic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="viewer.cpp" line="241"/>
+        <source>CRC Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="viewer.cpp" line="961"/>
+        <source>Loading...please wait!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="viewer.cpp" line="971"/>
+        <source>Page not available!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="viewer.cpp" line="1107"/>
+        <source>Cover!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="viewer.cpp" line="1121"/>
+        <source>Last page!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReader::WhatsNewDialog</name>
+    <message>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="99"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderFieldEdit</name>
+    <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28"/>
+        <source>Click to overwrite</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11"/>
+        <source>Restore to default</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderFieldPlainTextEdit</name>
+    <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50"/>
+        <source>Click to overwrite</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10"/>
+        <source>Restore to default</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderFlowConfigWidget</name>
+    <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="13"/>
+        <source>How to show covers:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="15"/>
+        <source>CoverFlow look</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="16"/>
+        <source>Stripe look</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="17"/>
+        <source>Overlapped Stripe look</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderGLFlowConfigWidget</name>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="18"/>
+        <source>Presets:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="20"/>
+        <source>Classic look</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="23"/>
+        <source>Stripe look</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="26"/>
+        <source>Overlapped Stripe look</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="29"/>
+        <source>Modern look</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="32"/>
+        <source>Roulette look</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="76"/>
+        <source>Show advanced settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="85"/>
+        <source>Custom:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="88"/>
+        <source>View angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="94"/>
+        <source>Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="100"/>
+        <source>Cover gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="106"/>
+        <source>Central gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="112"/>
+        <source>Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="118"/>
+        <source>Y offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="124"/>
+        <source>Z offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="130"/>
+        <source>Cover Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="136"/>
+        <source>Visibility</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="142"/>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="148"/>
+        <source>Max angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="180"/>
+        <source>Low Performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="182"/>
+        <source>High Performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="193"/>
+        <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="201"/>
+        <source>Performance:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderOptionsDialog</name>
+    <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="29"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="34"/>
+        <source>Edit shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="37"/>
+        <source>Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="46"/>
+        <source>Use hardware acceleration (restart needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderSlider</name>
+    <message>
+        <location filename="width_slider.cpp" line="49"/>
+        <source>Reset</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderTranslator</name>
+    <message>
+        <location filename="translator.cpp" line="62"/>
+        <source>YACReader translator</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="translator.cpp" line="116"/>
+        <location filename="translator.cpp" line="208"/>
+        <source>Translation</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="translator.cpp" line="139"/>
+        <source>clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="translator.cpp" line="217"/>
+        <source>Service not available</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/YACReader/yacreader_es.ts
+++ b/YACReader/yacreader_es.ts
@@ -4,6 +4,7 @@
 <context>
     <name>ActionsShortcutsModel</name>
     <message>
+        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="73"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11,18 +12,23 @@
 <context>
     <name>BookmarksDialog</name>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="75"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="107"/>
+        <location filename="bookmarks_dialog.cpp" line="124"/>
         <source>Loading...</source>
         <translation>Cargando...</translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="85"/>
         <source>Click on any image to go to the bookmark</source>
         <translation>Pulsa en cualquier imagen para ir al marcador</translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="25"/>
         <source>Lastest Page</source>
         <translation>Última página</translation>
     </message>
@@ -30,22 +36,27 @@
 <context>
     <name>EditShortcutsDialog</name>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="21"/>
         <source>Restore defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="22"/>
         <source>To change a shortcut, double click in the key combination and type the new keys.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="69"/>
         <source>Shortcuts settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>Shortcut in use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>The shortcut &quot;%1&quot; is already assigned to other function</source>
         <translation type="unfinished"></translation>
     </message>
@@ -53,18 +64,22 @@
 <context>
     <name>FileComic</name>
     <message>
+        <location filename="../common/comic.cpp" line="568"/>
         <source>Format not supported</source>
         <translation>Formato no soportado</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="562"/>
         <source>7z not found</source>
         <translation>7z no encontrado</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="461"/>
         <source>Unknown error opening the file</source>
         <translation>Error desconocido abriendo el archivo</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="454"/>
         <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
         <translation>Error CRC en la página (%1): algunas de las páginas no se mostrarán correctamente</translation>
     </message>
@@ -72,22 +87,28 @@
 <context>
     <name>GoToDialog</name>
     <message>
+        <location filename="goto_dialog.cpp" line="23"/>
         <source>Go To</source>
         <translation>Ir a</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="53"/>
         <source>Go to...</source>
         <translation>Ir a...</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="39"/>
+        <location filename="goto_dialog.cpp" line="71"/>
         <source>Total pages : </source>
         <translation>Páginas totales:</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="25"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="15"/>
         <source>Page : </source>
         <translation>Página :</translation>
     </message>
@@ -95,6 +116,7 @@
 <context>
     <name>GoToFlowToolBar</name>
     <message>
+        <location filename="goto_flow_toolbar.cpp" line="38"/>
         <source>Page : </source>
         <translation>Página : </translation>
     </message>
@@ -102,10 +124,17 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Ayuda</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
+        <source>System info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation>Acerca de</translation>
     </message>
@@ -113,30 +142,37 @@
 <context>
     <name>LogWindow</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="14"/>
         <source>Log window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="22"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="39"/>
         <source>&amp;Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="56"/>
         <source>C&amp;lear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="73"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="90"/>
         <source>Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="136"/>
         <source>&amp;Auto scroll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -145,464 +181,336 @@
     <name>MainWindowViewer</name>
     <message>
         <source>File</source>
-        <translation>Archivo</translation>
+        <translation type="vanished">Archivo</translation>
     </message>
     <message>
         <source>Help</source>
-        <translation>Ayuda</translation>
+        <translation type="vanished">Ayuda</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation>Guardar</translation>
+        <translation type="vanished">Guardar</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation>&amp;Archivo</translation>
+        <translation type="vanished">&amp;Archivo</translation>
     </message>
     <message>
         <source>&amp;Next</source>
-        <translation>Siguie&amp;nte</translation>
+        <translation type="vanished">Siguie&amp;nte</translation>
     </message>
     <message>
         <source>&amp;Open</source>
-        <translation>&amp;Abrir</translation>
+        <translation type="vanished">&amp;Abrir</translation>
     </message>
     <message>
         <source>Close</source>
-        <translation>Cerrar</translation>
+        <translation type="vanished">Cerrar</translation>
     </message>
     <message>
         <source>Open Comic</source>
-        <translation>Abrir cómic</translation>
+        <translation type="vanished">Abrir cómic</translation>
     </message>
     <message>
         <source>Go To</source>
-        <translation>Ir a</translation>
+        <translation type="vanished">Ir a</translation>
     </message>
     <message>
         <source>Open image folder</source>
-        <translation>Abrir carpeta de imágenes</translation>
+        <translation type="vanished">Abrir carpeta de imágenes</translation>
     </message>
     <message>
         <source>Set bookmark</source>
-        <translation>Añadir marcador</translation>
+        <translation type="vanished">Añadir marcador</translation>
     </message>
     <message>
         <source>page_%1.jpg</source>
-        <translation>página_%1.jpg</translation>
+        <translation type="vanished">página_%1.jpg</translation>
     </message>
     <message>
         <source>Switch to double page mode</source>
-        <translation>Cambiar a modo de doble página</translation>
+        <translation type="vanished">Cambiar a modo de doble página</translation>
     </message>
     <message>
         <source>Save current page</source>
-        <translation>Guardar la página actual</translation>
+        <translation type="vanished">Guardar la página actual</translation>
     </message>
     <message>
         <source>Double page mode</source>
-        <translation>Modo a doble página</translation>
+        <translation type="vanished">Modo a doble página</translation>
     </message>
     <message>
         <source>Switch Magnifying glass</source>
-        <translation>Lupa On/Off</translation>
+        <translation type="vanished">Lupa On/Off</translation>
     </message>
     <message>
         <source>Open Folder</source>
-        <translation>Abrir carpeta</translation>
+        <translation type="vanished">Abrir carpeta</translation>
     </message>
     <message>
         <source>Fit Height</source>
-        <translation>Ajustar altura</translation>
+        <translation type="vanished">Ajustar altura</translation>
     </message>
     <message>
         <source>Comic files</source>
-        <translation>Archivos de cómic</translation>
+        <translation type="vanished">Archivos de cómic</translation>
     </message>
     <message>
         <source>Not now</source>
-        <translation>Ahora no</translation>
+        <translation type="vanished">Ahora no</translation>
     </message>
     <message>
         <source>Go to previous page</source>
-        <translation>Ir a la página anterior</translation>
+        <translation type="vanished">Ir a la página anterior</translation>
     </message>
     <message>
         <source>Open a comic</source>
-        <translation>Abrir cómic</translation>
+        <translation type="vanished">Abrir cómic</translation>
     </message>
     <message>
         <source>Image files (*.jpg)</source>
-        <translation>Archivos de imagen (*.jpg)</translation>
+        <translation type="vanished">Archivos de imagen (*.jpg)</translation>
     </message>
     <message>
         <source>Next Comic</source>
-        <translation>Siguiente Cómic</translation>
+        <translation type="vanished">Siguiente Cómic</translation>
     </message>
     <message>
         <source>Fit Width</source>
-        <translation>Ajustar anchura</translation>
+        <translation type="vanished">Ajustar anchura</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation>Opciones</translation>
+        <translation type="vanished">Opciones</translation>
     </message>
     <message>
         <source>Show Info</source>
-        <translation>Mostrar información</translation>
+        <translation type="vanished">Mostrar información</translation>
     </message>
     <message>
         <source>Open folder</source>
-        <translation>Abrir carpeta</translation>
+        <translation type="vanished">Abrir carpeta</translation>
     </message>
     <message>
         <source>Go to page ...</source>
-        <translation>Ir a página...</translation>
+        <translation type="vanished">Ir a página...</translation>
     </message>
     <message>
         <source>Fit image to width</source>
-        <translation>Ajustar página a lo ancho</translation>
+        <translation type="vanished">Ajustar página a lo ancho</translation>
     </message>
     <message>
         <source>&amp;Previous</source>
-        <translation>A&amp;nterior</translation>
+        <translation type="vanished">A&amp;nterior</translation>
     </message>
     <message>
         <source>Go to next page</source>
-        <translation>Ir a la página siguiente</translation>
+        <translation type="vanished">Ir a la página siguiente</translation>
     </message>
     <message>
         <source>Show keyboard shortcuts</source>
-        <translation>Mostrar atajos de teclado</translation>
+        <translation type="vanished">Mostrar atajos de teclado</translation>
     </message>
     <message>
         <source>There is a new version available</source>
-        <translation>Hay una nueva versión disponible</translation>
+        <translation type="vanished">Hay una nueva versión disponible</translation>
     </message>
     <message>
         <source>Open next comic</source>
-        <translation>Abrir siguiente cómic</translation>
+        <translation type="vanished">Abrir siguiente cómic</translation>
     </message>
     <message>
         <source>Remind me in 14 days</source>
-        <translation>Recordar en 14 días</translation>
+        <translation type="vanished">Recordar en 14 días</translation>
     </message>
     <message>
         <source>Show bookmarks</source>
-        <translation>Mostrar marcadores</translation>
+        <translation type="vanished">Mostrar marcadores</translation>
     </message>
     <message>
         <source>Open previous comic</source>
-        <translation>Abrir cómic anterior</translation>
+        <translation type="vanished">Abrir cómic anterior</translation>
     </message>
     <message>
         <source>Rotate image to the left</source>
-        <translation>Rotar imagen a la izquierda</translation>
+        <translation type="vanished">Rotar imagen a la izquierda</translation>
     </message>
     <message>
         <source>Fit image to height</source>
-        <translation>Ajustar página a lo alto</translation>
+        <translation type="vanished">Ajustar página a lo alto</translation>
     </message>
     <message>
         <source>Show the bookmarks of the current comic</source>
-        <translation>Mostrar los marcadores del cómic actual</translation>
+        <translation type="vanished">Mostrar los marcadores del cómic actual</translation>
     </message>
     <message>
         <source>Show Dictionary</source>
-        <translation>Mostrar diccionario</translation>
+        <translation type="vanished">Mostrar diccionario</translation>
     </message>
     <message>
         <source>YACReader options</source>
-        <translation>Opciones de YACReader</translation>
+        <translation type="vanished">Opciones de YACReader</translation>
     </message>
     <message>
         <source>Help, About YACReader</source>
-        <translation>Ayuda, Sobre YACReader</translation>
+        <translation type="vanished">Ayuda, Sobre YACReader</translation>
     </message>
     <message>
         <source>Show go to flow</source>
-        <translation>Mostrar flow ir a</translation>
+        <translation type="vanished">Mostrar flow ir a</translation>
     </message>
     <message>
         <source>Previous Comic</source>
-        <translation>Cómic anterior</translation>
+        <translation type="vanished">Cómic anterior</translation>
     </message>
     <message>
         <source>Show full size</source>
-        <translation>Mostrar a tamaño original</translation>
+        <translation type="vanished">Mostrar a tamaño original</translation>
     </message>
     <message>
         <source>Magnifying glass</source>
-        <translation>Lupa</translation>
+        <translation type="vanished">Lupa</translation>
     </message>
     <message>
         <source>General</source>
-        <translation>General</translation>
+        <translation type="vanished">General</translation>
     </message>
     <message>
         <source>Set a bookmark on the current page</source>
-        <translation>Añadir un marcador en la página actual</translation>
+        <translation type="vanished">Añadir un marcador en la página actual</translation>
     </message>
     <message>
         <source>Do you want to download the new version?</source>
-        <translation>¿Desea descargar la nueva versión?</translation>
+        <translation type="vanished">¿Desea descargar la nueva versión?</translation>
     </message>
     <message>
         <source>Rotate image to the right</source>
-        <translation>Rotar imagen a la derecha</translation>
+        <translation type="vanished">Rotar imagen a la derecha</translation>
     </message>
     <message>
         <source>Always on top</source>
-        <translation>Siempre visible</translation>
-    </message>
-    <message>
-        <source>New instance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open latest comic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open the latest comic opened in the previous reading session</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Clear</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Clear open recent list</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fit to page</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reset zoom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show zoom slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Zoom+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Zoom-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Double page manga mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reverse reading order in double page mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit shortcuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open recent</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Go</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Comics</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Toggle fullscreen mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide/show toolbar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Size up magnifying glass</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Size down magnifying glass</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Zoom in magnifying glass</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Zoom out magnifying glass</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Magnifiying glass</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Toggle between fit to width and fit to height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page adjustement</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Autoscroll down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Autoscroll up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Autoscroll forward, horizontal first</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Autoscroll backward, horizontal first</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Autoscroll forward, vertical first</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Autoscroll backward, vertical first</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Go to the first page</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Go to the last page</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reading</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">Siempre visible</translation>
     </message>
 </context>
 <context>
     <name>OptionsDialog</name>
     <message>
+        <location filename="options_dialog.cpp" line="143"/>
         <source>Gamma</source>
         <translation>Gamma</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="147"/>
         <source>Reset</source>
         <translation>Reset</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="34"/>
         <source>My comics path</source>
         <translation>Ruta a mis cómics</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="191"/>
         <source>Image adjustment</source>
         <translation>Ajustes de imagen</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="43"/>
         <source>&quot;Go to flow&quot; size</source>
         <translation>Tamaño de &quot;Go to flow&quot;</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="64"/>
         <source>Choose</source>
         <translation>Elegir</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="152"/>
         <source>Image options</source>
         <translation>Opciones de imagen</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="142"/>
         <source>Contrast</source>
         <translation>Contraste</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="206"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="213"/>
         <source>Comics directory</source>
         <translation>Directorio de cómics</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="61"/>
         <source>Background color</source>
         <translation>Color de fondo</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="190"/>
         <source>Page Flow</source>
         <translation>Page Flow</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="189"/>
         <source>General</source>
         <translation>General</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="141"/>
         <source>Brightness</source>
         <translation>Brillo</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="197"/>
         <source>Restart is needed</source>
         <translation>Es necesario reiniciar</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="97"/>
         <source>Quick Navigation Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="71"/>
+        <source>Scroll behaviour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="74"/>
+        <source>Do not turn page using scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="75"/>
+        <source>Use single scroll step to turn page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="98"/>
         <source>Disable mouse over activation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="156"/>
         <source>Fit options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="158"/>
         <source>Enlarge images to fit width/height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="169"/>
         <source>Double Page options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="171"/>
         <source>Show covers as single page</source>
         <translation type="unfinished"></translation>
     </message>
@@ -610,34 +518,42 @@
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>7z lib not found</source>
         <translation>7z lib no encontrado</translation>
     </message>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>unable to load 7z lib from ./utils</source>
         <translation>imposible cargar 7z lib de ./utils</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41"/>
         <source>Trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45"/>
         <source>Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51"/>
         <source>Fatal</source>
         <translation type="unfinished"></translation>
     </message>
@@ -645,14 +561,17 @@
 <context>
     <name>QsLogging::LogWindowModel</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="141"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="143"/>
         <source>Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="145"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
@@ -660,18 +579,22 @@
 <context>
     <name>QsLogging::Window</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="236"/>
         <source>Save log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="237"/>
         <source>Log file (*.log)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -679,14 +602,17 @@
 <context>
     <name>ShortcutsDialog</name>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="23"/>
         <source>Close</source>
         <translation>Cerrar</translation>
     </message>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="19"/>
         <source>YACReader keyboard shortcuts</source>
         <translation>Atajos de teclado de YACReader</translation>
     </message>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="63"/>
         <source>Keyboard Shortcuts</source>
         <translation>Atajos de teclado</translation>
     </message>
@@ -694,45 +620,537 @@
 <context>
     <name>Viewer</name>
     <message>
+        <location filename="viewer.cpp" line="937"/>
         <source>Page not available!</source>
         <translation>¡Página no disponible!</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="51"/>
+        <location filename="viewer.cpp" line="915"/>
         <source>Press &apos;O&apos; to open comic.</source>
         <translation>Pulsa &apos;O&apos; para abrir un fichero.</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="240"/>
         <source>Error opening comic</source>
         <translation>Error abriendo cómic</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="1089"/>
         <source>Cover!</source>
         <translation>¡Portada!</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="246"/>
         <source>CRC Error</source>
         <translation>Error CRC</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="234"/>
         <source>Comic not found</source>
         <translation>Cómic no encontrado</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="234"/>
         <source>Not found</source>
         <translation>No encontrado</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="1103"/>
         <source>Last page!</source>
         <translation>¡Última página!</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="927"/>
         <source>Loading...please wait!</source>
         <translation>Cargando...espere, por favor!</translation>
     </message>
 </context>
 <context>
+    <name>YACReader::MainWindowViewer</name>
+    <message>
+        <location filename="main_window_viewer.cpp" line="219"/>
+        <source>&amp;Open</source>
+        <translation type="unfinished">&amp;Abrir</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="221"/>
+        <source>Open a comic</source>
+        <translation type="unfinished">Abrir cómic</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="227"/>
+        <source>New instance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="246"/>
+        <source>Open Folder</source>
+        <translation type="unfinished">Abrir carpeta</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="248"/>
+        <source>Open image folder</source>
+        <translation type="unfinished">Abrir carpeta de imágenes</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="253"/>
+        <source>Open latest comic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="254"/>
+        <source>Open the latest comic opened in the previous reading session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="266"/>
+        <source>Clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="267"/>
+        <source>Clear open recent list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="270"/>
+        <source>Save</source>
+        <translation type="unfinished">Guardar</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="272"/>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>Save current page</source>
+        <translation type="unfinished">Guardar la página actual</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="277"/>
+        <source>Previous Comic</source>
+        <translation type="unfinished">Cómic anterior</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="279"/>
+        <location filename="main_window_viewer.cpp" line="1656"/>
+        <location filename="main_window_viewer.cpp" line="1660"/>
+        <source>Open previous comic</source>
+        <translation type="unfinished">Abrir cómic anterior</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="284"/>
+        <source>Next Comic</source>
+        <translation type="unfinished">Siguiente Cómic</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="286"/>
+        <location filename="main_window_viewer.cpp" line="1655"/>
+        <location filename="main_window_viewer.cpp" line="1661"/>
+        <source>Open next comic</source>
+        <translation type="unfinished">Abrir siguiente cómic</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="291"/>
+        <source>&amp;Previous</source>
+        <translation type="unfinished">A&amp;nterior</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="294"/>
+        <location filename="main_window_viewer.cpp" line="1658"/>
+        <location filename="main_window_viewer.cpp" line="1662"/>
+        <source>Go to previous page</source>
+        <translation type="unfinished">Ir a la página anterior</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="299"/>
+        <source>&amp;Next</source>
+        <translation type="unfinished">Siguie&amp;nte</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="302"/>
+        <location filename="main_window_viewer.cpp" line="1657"/>
+        <location filename="main_window_viewer.cpp" line="1663"/>
+        <source>Go to next page</source>
+        <translation type="unfinished">Ir a la página siguiente</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="307"/>
+        <source>Fit Height</source>
+        <translation type="unfinished">Ajustar altura</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="310"/>
+        <source>Fit image to height</source>
+        <translation type="unfinished">Ajustar página a lo alto</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="317"/>
+        <source>Fit Width</source>
+        <translation type="unfinished">Ajustar anchura</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="320"/>
+        <source>Fit image to width</source>
+        <translation type="unfinished">Ajustar página a lo ancho</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="327"/>
+        <source>Show full size</source>
+        <translation type="unfinished">Mostrar a tamaño original</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="335"/>
+        <source>Fit to page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="366"/>
+        <source>Reset zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="371"/>
+        <source>Show zoom slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="374"/>
+        <source>Zoom+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="379"/>
+        <source>Zoom-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="384"/>
+        <source>Rotate image to the left</source>
+        <translation type="unfinished">Rotar imagen a la izquierda</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="390"/>
+        <source>Rotate image to the right</source>
+        <translation type="unfinished">Rotar imagen a la derecha</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="396"/>
+        <source>Double page mode</source>
+        <translation type="unfinished">Modo a doble página</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="397"/>
+        <source>Switch to double page mode</source>
+        <translation type="unfinished">Cambiar a modo de doble página</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="406"/>
+        <source>Double page manga mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="407"/>
+        <source>Reverse reading order in double page mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="416"/>
+        <source>Go To</source>
+        <translation type="unfinished">Ir a</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="418"/>
+        <source>Go to page ...</source>
+        <translation type="unfinished">Ir a página...</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="423"/>
+        <source>Options</source>
+        <translation type="unfinished">Opciones</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="424"/>
+        <source>YACReader options</source>
+        <translation type="unfinished">Opciones de YACReader</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="431"/>
+        <location filename="main_window_viewer.cpp" line="715"/>
+        <source>Help</source>
+        <translation type="unfinished">Ayuda</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="432"/>
+        <source>Help, About YACReader</source>
+        <translation type="unfinished">Ayuda, Sobre YACReader</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="438"/>
+        <source>Magnifying glass</source>
+        <translation type="unfinished">Lupa</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="439"/>
+        <source>Switch Magnifying glass</source>
+        <translation type="unfinished">Lupa On/Off</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="446"/>
+        <source>Set bookmark</source>
+        <translation type="unfinished">Añadir marcador</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="447"/>
+        <source>Set a bookmark on the current page</source>
+        <translation type="unfinished">Añadir un marcador en la página actual</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="456"/>
+        <source>Show bookmarks</source>
+        <translation type="unfinished">Mostrar marcadores</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="457"/>
+        <source>Show the bookmarks of the current comic</source>
+        <translation type="unfinished">Mostrar los marcadores del cómic actual</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="463"/>
+        <source>Show keyboard shortcuts</source>
+        <translation type="unfinished">Mostrar atajos de teclado</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="470"/>
+        <source>Show Info</source>
+        <translation type="unfinished">Mostrar información</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="476"/>
+        <source>Close</source>
+        <translation type="unfinished">Cerrar</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="482"/>
+        <source>Show Dictionary</source>
+        <translation type="unfinished">Mostrar diccionario</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="489"/>
+        <source>Show go to flow</source>
+        <translation type="unfinished">Mostrar flow ir a</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="495"/>
+        <source>Edit shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="515"/>
+        <source>&amp;File</source>
+        <translation type="unfinished">&amp;Archivo</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="529"/>
+        <location filename="main_window_viewer.cpp" line="670"/>
+        <source>Open recent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="659"/>
+        <source>File</source>
+        <translation type="unfinished">Archivo</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="680"/>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="684"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="700"/>
+        <source>Go</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="708"/>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="809"/>
+        <location filename="main_window_viewer.cpp" line="811"/>
+        <source>Open Comic</source>
+        <translation type="unfinished">Abrir cómic</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="809"/>
+        <location filename="main_window_viewer.cpp" line="811"/>
+        <source>Comic files</source>
+        <translation type="unfinished">Archivos de cómic</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="898"/>
+        <source>Open folder</source>
+        <translation type="unfinished">Abrir carpeta</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>page_%1.jpg</source>
+        <translation type="unfinished">página_%1.jpg</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>Image files (*.jpg)</source>
+        <translation type="unfinished">Archivos de imagen (*.jpg)</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1159"/>
+        <source>Comics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1169"/>
+        <source>Toggle fullscreen mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1172"/>
+        <source>Hide/show toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1175"/>
+        <source>General</source>
+        <translation type="unfinished">General</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1194"/>
+        <source>Size up magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1197"/>
+        <source>Size down magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1200"/>
+        <source>Zoom in magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1203"/>
+        <source>Zoom out magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1209"/>
+        <source>Magnifiying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1216"/>
+        <source>Toggle between fit to width and fit to height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1220"/>
+        <source>Page adjustement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1237"/>
+        <source>Autoscroll down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1240"/>
+        <source>Autoscroll up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1243"/>
+        <source>Autoscroll forward, horizontal first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1247"/>
+        <source>Autoscroll backward, horizontal first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1251"/>
+        <source>Autoscroll forward, vertical first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1255"/>
+        <source>Autoscroll backward, vertical first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1259"/>
+        <source>Move down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1262"/>
+        <source>Move up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1265"/>
+        <source>Move left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1268"/>
+        <source>Move right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1271"/>
+        <source>Go to the first page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1274"/>
+        <source>Go to the last page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1290"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1335"/>
+        <source>There is a new version available</source>
+        <translation type="unfinished">Hay una nueva versión disponible</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1336"/>
+        <source>Do you want to download the new version?</source>
+        <translation type="unfinished">¿Desea descargar la nueva versión?</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1339"/>
+        <source>Remind me in 14 days</source>
+        <translation type="unfinished">Recordar en 14 días</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1340"/>
+        <source>Not now</source>
+        <translation type="unfinished">Ahora no</translation>
+    </message>
+</context>
+<context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation type="unfinished">Cerrar</translation>
     </message>
@@ -740,10 +1158,13 @@
 <context>
     <name>YACReaderFieldEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11"/>
         <source>Restore to default</source>
         <translation>Restaurar valor por defecto</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28"/>
         <source>Click to overwrite</source>
         <translation>Click para sobreescribir</translation>
     </message>
@@ -751,10 +1172,15 @@
 <context>
     <name>YACReaderFieldPlainTextEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10"/>
         <source>Restore to default</source>
         <translation>Restaurar valor por defecto</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50"/>
         <source>Click to overwrite</source>
         <translation>Click para sobreescribir</translation>
     </message>
@@ -762,18 +1188,22 @@
 <context>
     <name>YACReaderFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="15"/>
         <source>CoverFlow look</source>
         <translation>Tipo CoverFlow</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="13"/>
         <source>How to show covers:</source>
         <translation>Cómo mostrar las portadas:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="16"/>
         <source>Stripe look</source>
         <translation>Tipo tira</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="17"/>
         <source>Overlapped Stripe look</source>
         <translation>Tipo tira solapada</translation>
     </message>
@@ -781,94 +1211,117 @@
 <context>
     <name>YACReaderGLFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="112"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="142"/>
         <source>Light</source>
         <translation>Luz</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="76"/>
         <source>Show advanced settings</source>
         <translation>Opciones avanzadas</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="32"/>
         <source>Roulette look</source>
         <translation>Tipo ruleta</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="130"/>
         <source>Cover Angle</source>
         <translation>Ángulo de las portadas</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="23"/>
         <source>Stripe look</source>
         <translation>Tipo tira</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="94"/>
         <source>Position</source>
         <translation>Posición</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="124"/>
         <source>Z offset</source>
         <translation>Desplazamiento en Z </translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="118"/>
         <source>Y offset</source>
         <translation>Desplazamiento en Y</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="106"/>
         <source>Central gap</source>
         <translation>Hueco central</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="18"/>
         <source>Presets:</source>
         <translation>Predefinidos:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="26"/>
         <source>Overlapped Stripe look</source>
         <translation>Tipo tira solapada</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="29"/>
         <source>Modern look</source>
         <translation>Tipo moderno</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="88"/>
         <source>View angle</source>
         <translation>Ángulo de vista</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="148"/>
         <source>Max angle</source>
         <translation>Ángulo máximo</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="85"/>
         <source>Custom:</source>
         <translation>Personalizado:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="20"/>
         <source>Classic look</source>
         <translation>Tipo clásico</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="100"/>
         <source>Cover gap</source>
         <translation>Hueco entre portadas</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="182"/>
         <source>High Performance</source>
         <translation>Alto rendimiento</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="201"/>
         <source>Performance:</source>
         <translation>Rendimiento:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="193"/>
         <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
         <translation>Utilizar VSync (mejora la calidad de imagen en pantalla completa, peor rendimiento)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="136"/>
         <source>Visibility</source>
         <translation>Visibilidad</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="180"/>
         <source>Low Performance</source>
         <translation>Rendimiento bajo</translation>
     </message>
@@ -876,22 +1329,27 @@
 <context>
     <name>YACReaderOptionsDialog</name>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="46"/>
         <source>Use hardware acceleration (restart needed)</source>
         <translation>Utilizar aceleración por hardware (necesario reiniciar)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="29"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="34"/>
         <source>Edit shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="37"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -899,6 +1357,7 @@
 <context>
     <name>YACReaderSlider</name>
     <message>
+        <location filename="width_slider.cpp" line="49"/>
         <source>Reset</source>
         <translation>Reset</translation>
     </message>
@@ -906,18 +1365,23 @@
 <context>
     <name>YACReaderTranslator</name>
     <message>
+        <location filename="translator.cpp" line="139"/>
         <source>clear</source>
         <translation>limpiar</translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="216"/>
         <source>Service not available</source>
         <translation>Servicio no disponible</translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="116"/>
+        <location filename="translator.cpp" line="207"/>
         <source>Translation</source>
         <translation>Traducción</translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="62"/>
         <source>YACReader translator</source>
         <translation>Traductor YACReader</translation>
     </message>

--- a/YACReader/yacreader_fr.ts
+++ b/YACReader/yacreader_fr.ts
@@ -4,6 +4,7 @@
 <context>
     <name>ActionsShortcutsModel</name>
     <message>
+        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="73"/>
         <source>None</source>
         <translation>Rien</translation>
     </message>
@@ -11,18 +12,23 @@
 <context>
     <name>BookmarksDialog</name>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="75"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="107"/>
+        <location filename="bookmarks_dialog.cpp" line="124"/>
         <source>Loading...</source>
         <translation>Chargement...</translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="85"/>
         <source>Click on any image to go to the bookmark</source>
         <translation>Cliquez sur une image pour aller au marque-page</translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="25"/>
         <source>Lastest Page</source>
         <translation>Aller à la dernière page</translation>
     </message>
@@ -30,22 +36,27 @@
 <context>
     <name>EditShortcutsDialog</name>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>Shortcut in use</source>
         <translation>Raccourci en cours d&apos;utilisation</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="21"/>
         <source>Restore defaults</source>
         <translation>Réinitialiser</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="69"/>
         <source>Shortcuts settings</source>
         <translation>Paramètres de raccourcis</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>The shortcut &quot;%1&quot; is already assigned to other function</source>
         <translation>Le raccourci &quot;%1&quot; est déjà affecté à une autre fonction</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="22"/>
         <source>To change a shortcut, double click in the key combination and type the new keys.</source>
         <translation>Pour modifier un raccourci, double-cliquez sur la combinaison de touches et tapez les nouvelles clés.</translation>
     </message>
@@ -53,18 +64,22 @@
 <context>
     <name>FileComic</name>
     <message>
+        <location filename="../common/comic.cpp" line="568"/>
         <source>Format not supported</source>
         <translation>Format non supporté</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="562"/>
         <source>7z not found</source>
         <translation>7z introuvable</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="461"/>
         <source>Unknown error opening the file</source>
         <translation>Erreur inconnue lors de l&apos;ouverture du fichier</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="454"/>
         <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
         <translation>Erreur CRC sur la page (%1): certaines pages ne s&apos;afficheront pas correctement</translation>
     </message>
@@ -72,22 +87,28 @@
 <context>
     <name>GoToDialog</name>
     <message>
+        <location filename="goto_dialog.cpp" line="23"/>
         <source>Go To</source>
         <translation>Aller à</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="53"/>
         <source>Go to...</source>
         <translation>Aller à...</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="39"/>
+        <location filename="goto_dialog.cpp" line="71"/>
         <source>Total pages : </source>
         <translation>Nombre de pages :</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="25"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="15"/>
         <source>Page : </source>
         <translation>Page :</translation>
     </message>
@@ -95,6 +116,7 @@
 <context>
     <name>GoToFlowToolBar</name>
     <message>
+        <location filename="goto_flow_toolbar.cpp" line="38"/>
         <source>Page : </source>
         <translation>Page : </translation>
     </message>
@@ -102,10 +124,17 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Aide</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
+        <source>System info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation>A propos</translation>
     </message>
@@ -113,30 +142,37 @@
 <context>
     <name>LogWindow</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="14"/>
         <source>Log window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="22"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="39"/>
         <source>&amp;Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="56"/>
         <source>C&amp;lear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="73"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="90"/>
         <source>Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="136"/>
         <source>&amp;Auto scroll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -145,464 +181,492 @@
     <name>MainWindowViewer</name>
     <message>
         <source>Go</source>
-        <translation>Aller</translation>
+        <translation type="vanished">Aller</translation>
     </message>
     <message>
         <source>Edit</source>
-        <translation>Editer</translation>
+        <translation type="vanished">Editer</translation>
     </message>
     <message>
         <source>File</source>
-        <translation>Fichier</translation>
+        <translation type="vanished">Fichier</translation>
     </message>
     <message>
         <source>Help</source>
-        <translation>Aide</translation>
+        <translation type="vanished">Aide</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation>Sauvegarder</translation>
+        <translation type="vanished">Sauvegarder</translation>
     </message>
     <message>
         <source>View</source>
-        <translation>Vue</translation>
+        <translation type="vanished">Vue</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation>&amp;Fichier</translation>
+        <translation type="vanished">&amp;Fichier</translation>
     </message>
     <message>
         <source>&amp;Next</source>
-        <translation>&amp;Suivant</translation>
+        <translation type="vanished">&amp;Suivant</translation>
     </message>
     <message>
         <source>&amp;Open</source>
-        <translation>&amp;Ouvrir</translation>
+        <translation type="vanished">&amp;Ouvrir</translation>
     </message>
     <message>
         <source>Close</source>
-        <translation>Fermer</translation>
+        <translation type="vanished">Fermer</translation>
     </message>
     <message>
         <source>Open Comic</source>
-        <translation>Ouvrir la bande dessinée</translation>
+        <translation type="vanished">Ouvrir la bande dessinée</translation>
     </message>
     <message>
         <source>Go To</source>
-        <translation>Aller à</translation>
+        <translation type="vanished">Aller à</translation>
     </message>
     <message>
         <source>Zoom+</source>
-        <translation>Zoom+</translation>
+        <translation type="vanished">Zoom+</translation>
     </message>
     <message>
         <source>Zoom-</source>
-        <translation>Zoom-</translation>
+        <translation type="vanished">Zoom-</translation>
     </message>
     <message>
         <source>Open image folder</source>
-        <translation>Ouvrir un dossier d&apos;images</translation>
+        <translation type="vanished">Ouvrir un dossier d&apos;images</translation>
     </message>
     <message>
         <source>Size down magnifying glass</source>
-        <translation>Réduire la taille de la loupe</translation>
+        <translation type="vanished">Réduire la taille de la loupe</translation>
     </message>
     <message>
         <source>Zoom out magnifying glass</source>
-        <translation>Dézoomer</translation>
+        <translation type="vanished">Dézoomer</translation>
     </message>
     <message>
         <source>Open latest comic</source>
-        <translation>Ouvrir la dernière bande dessinée</translation>
+        <translation type="vanished">Ouvrir la dernière bande dessinée</translation>
     </message>
     <message>
         <source>Autoscroll up</source>
-        <translation>Défilement automatique vers le haut</translation>
+        <translation type="vanished">Défilement automatique vers le haut</translation>
     </message>
     <message>
         <source>Set bookmark</source>
-        <translation>Placer un marque-page</translation>
+        <translation type="vanished">Placer un marque-page</translation>
     </message>
     <message>
         <source>page_%1.jpg</source>
-        <translation>page_%1.jpg</translation>
+        <translation type="vanished">page_%1.jpg</translation>
     </message>
     <message>
         <source>Autoscroll forward, vertical first</source>
-        <translation>Défilement automatique en avant, vertical</translation>
+        <translation type="vanished">Défilement automatique en avant, vertical</translation>
     </message>
     <message>
         <source>Switch to double page mode</source>
-        <translation>Passer en mode double page</translation>
+        <translation type="vanished">Passer en mode double page</translation>
     </message>
     <message>
         <source>Save current page</source>
-        <translation>Sauvegarder la page actuelle</translation>
+        <translation type="vanished">Sauvegarder la page actuelle</translation>
     </message>
     <message>
         <source>Size up magnifying glass</source>
-        <translation>Augmenter la taille de la loupe</translation>
+        <translation type="vanished">Augmenter la taille de la loupe</translation>
     </message>
     <message>
         <source>Double page mode</source>
-        <translation>Mode double page</translation>
+        <translation type="vanished">Mode double page</translation>
     </message>
     <message>
         <source>Move up</source>
-        <translation>Monter</translation>
+        <translation type="vanished">Monter</translation>
     </message>
     <message>
         <source>Switch Magnifying glass</source>
-        <translation>Utiliser la loupe</translation>
+        <translation type="vanished">Utiliser la loupe</translation>
     </message>
     <message>
         <source>Open Folder</source>
-        <translation>Ouvrir un dossier</translation>
+        <translation type="vanished">Ouvrir un dossier</translation>
     </message>
     <message>
         <source>Comics</source>
-        <translation>Bandes dessinées</translation>
+        <translation type="vanished">Bandes dessinées</translation>
     </message>
     <message>
         <source>Fit Height</source>
-        <translation>Ajuster la hauteur</translation>
+        <translation type="vanished">Ajuster la hauteur</translation>
     </message>
     <message>
         <source>Autoscroll backward, vertical first</source>
-        <translation>Défilement automatique en arrière, verticak</translation>
+        <translation type="vanished">Défilement automatique en arrière, verticak</translation>
     </message>
     <message>
         <source>Comic files</source>
-        <translation>Bande dessinée</translation>
+        <translation type="vanished">Bande dessinée</translation>
     </message>
     <message>
         <source>Not now</source>
-        <translation>Pas maintenant</translation>
+        <translation type="vanished">Pas maintenant</translation>
     </message>
     <message>
         <source>Go to the first page</source>
-        <translation>Aller à la première page</translation>
+        <translation type="vanished">Aller à la première page</translation>
     </message>
     <message>
         <source>Go to previous page</source>
-        <translation>Aller à la page précédente</translation>
+        <translation type="vanished">Aller à la page précédente</translation>
     </message>
     <message>
         <source>Window</source>
-        <translation>Fenêtre</translation>
+        <translation type="vanished">Fenêtre</translation>
     </message>
     <message>
         <source>Open the latest comic opened in the previous reading session</source>
-        <translation>Ouvrir la dernière bande dessinée ouverte lors de la session de lecture précédente</translation>
+        <translation type="vanished">Ouvrir la dernière bande dessinée ouverte lors de la session de lecture précédente</translation>
     </message>
     <message>
         <source>Open a comic</source>
-        <translation>Ouvrir une bande dessinée</translation>
+        <translation type="vanished">Ouvrir une bande dessinée</translation>
     </message>
     <message>
         <source>Image files (*.jpg)</source>
-        <translation>Image(*.jpg)</translation>
+        <translation type="vanished">Image(*.jpg)</translation>
     </message>
     <message>
         <source>Next Comic</source>
-        <translation>Bande dessinée suivante</translation>
+        <translation type="vanished">Bande dessinée suivante</translation>
     </message>
     <message>
         <source>Fit Width</source>
-        <translation>Ajuster la largeur</translation>
+        <translation type="vanished">Ajuster la largeur</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation>Options</translation>
+        <translation type="vanished">Options</translation>
     </message>
     <message>
         <source>Show Info</source>
-        <translation>Voir les infos</translation>
+        <translation type="vanished">Voir les infos</translation>
     </message>
     <message>
         <source>Open folder</source>
-        <translation>Ouvirir le dossier</translation>
+        <translation type="vanished">Ouvirir le dossier</translation>
     </message>
     <message>
         <source>Go to page ...</source>
-        <translation>Aller à la page ...</translation>
+        <translation type="vanished">Aller à la page ...</translation>
     </message>
     <message>
         <source>Magnifiying glass</source>
-        <translation>Loupe</translation>
+        <translation type="vanished">Loupe</translation>
     </message>
     <message>
         <source>Fit image to width</source>
-        <translation>Ajuster l&apos;image à la largeur</translation>
+        <translation type="vanished">Ajuster l&apos;image à la largeur</translation>
     </message>
     <message>
         <source>Toggle fullscreen mode</source>
-        <translation>Basculer en mode plein écran</translation>
+        <translation type="vanished">Basculer en mode plein écran</translation>
     </message>
     <message>
         <source>Toggle between fit to width and fit to height</source>
-        <translation>Basculer entre adapter à la largeur et adapter à la hauteur</translation>
+        <translation type="vanished">Basculer entre adapter à la largeur et adapter à la hauteur</translation>
     </message>
     <message>
         <source>Move right</source>
-        <translation>Déplacer à droite</translation>
+        <translation type="vanished">Déplacer à droite</translation>
     </message>
     <message>
         <source>Zoom in magnifying glass</source>
-        <translation>Zoomer</translation>
+        <translation type="vanished">Zoomer</translation>
     </message>
     <message>
         <source>Open recent</source>
-        <translation>Ouvrir récent</translation>
+        <translation type="vanished">Ouvrir récent</translation>
     </message>
     <message>
         <source>Reading</source>
-        <translation>Lecture</translation>
+        <translation type="vanished">Lecture</translation>
     </message>
     <message>
         <source>&amp;Previous</source>
-        <translation>&amp;Précédent</translation>
+        <translation type="vanished">&amp;Précédent</translation>
     </message>
     <message>
         <source>Autoscroll forward, horizontal first</source>
-        <translation>Défilement automatique en avant, horizontal</translation>
+        <translation type="vanished">Défilement automatique en avant, horizontal</translation>
     </message>
     <message>
         <source>Go to next page</source>
-        <translation>Aller à la page suivante</translation>
+        <translation type="vanished">Aller à la page suivante</translation>
     </message>
     <message>
         <source>Show keyboard shortcuts</source>
-        <translation>Voir les raccourcis</translation>
+        <translation type="vanished">Voir les raccourcis</translation>
     </message>
     <message>
         <source>Double page manga mode</source>
-        <translation>Mode manga en double page</translation>
+        <translation type="vanished">Mode manga en double page</translation>
     </message>
     <message>
         <source>There is a new version available</source>
-        <translation>Une nouvelle version est disponible</translation>
+        <translation type="vanished">Une nouvelle version est disponible</translation>
     </message>
     <message>
         <source>Autoscroll down</source>
-        <translation>Défilement automatique vers le bas</translation>
+        <translation type="vanished">Défilement automatique vers le bas</translation>
     </message>
     <message>
         <source>Open next comic</source>
-        <translation>Ouvrir la bande dessinée suivante</translation>
+        <translation type="vanished">Ouvrir la bande dessinée suivante</translation>
     </message>
     <message>
         <source>Remind me in 14 days</source>
-        <translation>Rappelez-moi dans 14 jours</translation>
+        <translation type="vanished">Rappelez-moi dans 14 jours</translation>
     </message>
     <message>
         <source>Fit to page</source>
-        <translation>Ajuster à la page</translation>
+        <translation type="vanished">Ajuster à la page</translation>
     </message>
     <message>
         <source>Show bookmarks</source>
-        <translation>Voir les marque-pages</translation>
+        <translation type="vanished">Voir les marque-pages</translation>
     </message>
     <message>
         <source>Open previous comic</source>
-        <translation>Ouvrir la bande dessiné précédente</translation>
+        <translation type="vanished">Ouvrir la bande dessiné précédente</translation>
     </message>
     <message>
         <source>Rotate image to the left</source>
-        <translation>Rotation à gauche</translation>
+        <translation type="vanished">Rotation à gauche</translation>
     </message>
     <message>
         <source>Fit image to height</source>
-        <translation>Ajuster l&apos;image à la hauteur</translation>
+        <translation type="vanished">Ajuster l&apos;image à la hauteur</translation>
     </message>
     <message>
         <source>Reset zoom</source>
-        <translation>Réinitialiser le zoom</translation>
+        <translation type="vanished">Réinitialiser le zoom</translation>
     </message>
     <message>
         <source>Show the bookmarks of the current comic</source>
-        <translation>Voir les marque-pages de cette bande dessinée</translation>
+        <translation type="vanished">Voir les marque-pages de cette bande dessinée</translation>
     </message>
     <message>
         <source>Show Dictionary</source>
-        <translation>Dictionnaire</translation>
+        <translation type="vanished">Dictionnaire</translation>
     </message>
     <message>
         <source>Move down</source>
-        <translation>Descendre</translation>
+        <translation type="vanished">Descendre</translation>
     </message>
     <message>
         <source>Move left</source>
-        <translation>Déplacer à gauche</translation>
+        <translation type="vanished">Déplacer à gauche</translation>
     </message>
     <message>
         <source>Reverse reading order in double page mode</source>
-        <translation>Ordre de lecture inversée en mode double page</translation>
+        <translation type="vanished">Ordre de lecture inversée en mode double page</translation>
     </message>
     <message>
         <source>YACReader options</source>
-        <translation>Options de YACReader</translation>
+        <translation type="vanished">Options de YACReader</translation>
     </message>
     <message>
         <source>Clear open recent list</source>
-        <translation>Vider la liste d&apos;ouverture récente</translation>
+        <translation type="vanished">Vider la liste d&apos;ouverture récente</translation>
     </message>
     <message>
         <source>Help, About YACReader</source>
-        <translation>Aide, à propos de YACReader</translation>
+        <translation type="vanished">Aide, à propos de YACReader</translation>
     </message>
     <message>
         <source>Show go to flow</source>
-        <translation>Afficher le flux</translation>
+        <translation type="vanished">Afficher le flux</translation>
     </message>
     <message>
         <source>Previous Comic</source>
-        <translation>Bande dessinée précédente</translation>
+        <translation type="vanished">Bande dessinée précédente</translation>
     </message>
     <message>
         <source>Show full size</source>
-        <translation>Plein écran</translation>
+        <translation type="vanished">Plein écran</translation>
     </message>
     <message>
         <source>Hide/show toolbar</source>
-        <translation>Masquer / afficher la barre d&apos;outils</translation>
+        <translation type="vanished">Masquer / afficher la barre d&apos;outils</translation>
     </message>
     <message>
         <source>Magnifying glass</source>
-        <translation>Loupe</translation>
+        <translation type="vanished">Loupe</translation>
     </message>
     <message>
         <source>Edit shortcuts</source>
-        <translation>Modifier les raccourcis</translation>
+        <translation type="vanished">Modifier les raccourcis</translation>
     </message>
     <message>
         <source>General</source>
-        <translation>Général</translation>
+        <translation type="vanished">Général</translation>
     </message>
     <message>
         <source>Set a bookmark on the current page</source>
-        <translation>Placer un marque-page sur la page actuelle</translation>
+        <translation type="vanished">Placer un marque-page sur la page actuelle</translation>
     </message>
     <message>
         <source>Page adjustement</source>
-        <translation>Ajustement de la page</translation>
+        <translation type="vanished">Ajustement de la page</translation>
     </message>
     <message>
         <source>Show zoom slider</source>
-        <translation>Afficher le curseur de zoom</translation>
+        <translation type="vanished">Afficher le curseur de zoom</translation>
     </message>
     <message>
         <source>Go to the last page</source>
-        <translation>Aller à la dernière page</translation>
+        <translation type="vanished">Aller à la dernière page</translation>
     </message>
     <message>
         <source>Do you want to download the new version?</source>
-        <translation>Voulez-vous télécharger la nouvelle version?</translation>
+        <translation type="vanished">Voulez-vous télécharger la nouvelle version?</translation>
     </message>
     <message>
         <source>Rotate image to the right</source>
-        <translation>Rotation à droite</translation>
+        <translation type="vanished">Rotation à droite</translation>
     </message>
     <message>
         <source>Always on top</source>
-        <translation>Toujours au dessus</translation>
+        <translation type="vanished">Toujours au dessus</translation>
     </message>
     <message>
         <source>Autoscroll backward, horizontal first</source>
-        <translation>Défilement automatique en arrière horizontal</translation>
-    </message>
-    <message>
-        <source>New instance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Clear</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">Défilement automatique en arrière horizontal</translation>
     </message>
 </context>
 <context>
     <name>OptionsDialog</name>
     <message>
+        <location filename="options_dialog.cpp" line="143"/>
         <source>Gamma</source>
         <translation>Gamma</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="147"/>
         <source>Reset</source>
         <translation>Remise à zéro</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="34"/>
         <source>My comics path</source>
         <translation>Chemin de mes bandes dessinées</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="191"/>
         <source>Image adjustment</source>
         <translation>Ajustement de l&apos;image</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="43"/>
         <source>&quot;Go to flow&quot; size</source>
         <translation>Taille du flux</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="64"/>
         <source>Choose</source>
         <translation>Choisir</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="152"/>
         <source>Image options</source>
         <translation>Option de l&apos;image</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="142"/>
         <source>Contrast</source>
         <translation>Contraste</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="206"/>
         <source>Options</source>
         <translation>Options</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="213"/>
         <source>Comics directory</source>
         <translation>Répertoire des bandes dessinées</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="97"/>
         <source>Quick Navigation Mode</source>
         <translation>Mode navigation rapide</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="61"/>
         <source>Background color</source>
         <translation>Couleur d&apos;arrière plan</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="71"/>
+        <source>Scroll behaviour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="74"/>
+        <source>Do not turn page using scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="75"/>
+        <source>Use single scroll step to turn page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="98"/>
         <source>Disable mouse over activation</source>
         <translation>Désactiver la souris sur l&apos;activation</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="190"/>
         <source>Page Flow</source>
         <translation>Flux des pages</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="189"/>
         <source>General</source>
         <translation>Général</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="141"/>
         <source>Brightness</source>
         <translation>Luminosité</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="197"/>
         <source>Restart is needed</source>
         <translation>Redémarrage nécessaire</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="156"/>
         <source>Fit options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="158"/>
         <source>Enlarge images to fit width/height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="169"/>
         <source>Double Page options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="171"/>
         <source>Show covers as single page</source>
         <translation type="unfinished"></translation>
     </message>
@@ -610,34 +674,42 @@
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>7z lib not found</source>
         <translation>lib 7z introuvable</translation>
     </message>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>unable to load 7z lib from ./utils</source>
         <translation>impossible de charger 7z depuis ./utils</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41"/>
         <source>Trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45"/>
         <source>Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51"/>
         <source>Fatal</source>
         <translation type="unfinished"></translation>
     </message>
@@ -645,14 +717,17 @@
 <context>
     <name>QsLogging::LogWindowModel</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="141"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="143"/>
         <source>Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="145"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
@@ -660,18 +735,22 @@
 <context>
     <name>QsLogging::Window</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="236"/>
         <source>Save log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="237"/>
         <source>Log file (*.log)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -679,14 +758,17 @@
 <context>
     <name>ShortcutsDialog</name>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="23"/>
         <source>Close</source>
         <translation>Fermer</translation>
     </message>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="19"/>
         <source>YACReader keyboard shortcuts</source>
         <translation>Raccourcis clavier de YACReader</translation>
     </message>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="63"/>
         <source>Keyboard Shortcuts</source>
         <translation>Raccourcis clavier</translation>
     </message>
@@ -694,45 +776,537 @@
 <context>
     <name>Viewer</name>
     <message>
+        <location filename="viewer.cpp" line="937"/>
         <source>Page not available!</source>
         <translation>Page non disponible !</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="51"/>
+        <location filename="viewer.cpp" line="915"/>
         <source>Press &apos;O&apos; to open comic.</source>
         <translation>Appuyez sur &quot;O&quot; pour ouvrir une bande dessinée.</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="240"/>
         <source>Error opening comic</source>
         <translation>Erreur d&apos;ouverture de la bande dessinée</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="1089"/>
         <source>Cover!</source>
         <translation>Couverture!</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="246"/>
         <source>CRC Error</source>
         <translation>Erreur CRC</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="234"/>
         <source>Comic not found</source>
         <translation>Bande dessinée introuvable</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="234"/>
         <source>Not found</source>
         <translation>Introuvable</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="1103"/>
         <source>Last page!</source>
         <translation>Dernière page!</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="927"/>
         <source>Loading...please wait!</source>
         <translation>Chargement... Patientez</translation>
     </message>
 </context>
 <context>
+    <name>YACReader::MainWindowViewer</name>
+    <message>
+        <location filename="main_window_viewer.cpp" line="219"/>
+        <source>&amp;Open</source>
+        <translation type="unfinished">&amp;Ouvrir</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="221"/>
+        <source>Open a comic</source>
+        <translation type="unfinished">Ouvrir une bande dessinée</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="227"/>
+        <source>New instance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="246"/>
+        <source>Open Folder</source>
+        <translation type="unfinished">Ouvrir un dossier</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="248"/>
+        <source>Open image folder</source>
+        <translation type="unfinished">Ouvrir un dossier d&apos;images</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="253"/>
+        <source>Open latest comic</source>
+        <translation type="unfinished">Ouvrir la dernière bande dessinée</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="254"/>
+        <source>Open the latest comic opened in the previous reading session</source>
+        <translation type="unfinished">Ouvrir la dernière bande dessinée ouverte lors de la session de lecture précédente</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="266"/>
+        <source>Clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="267"/>
+        <source>Clear open recent list</source>
+        <translation type="unfinished">Vider la liste d&apos;ouverture récente</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="270"/>
+        <source>Save</source>
+        <translation type="unfinished">Sauvegarder</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="272"/>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>Save current page</source>
+        <translation type="unfinished">Sauvegarder la page actuelle</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="277"/>
+        <source>Previous Comic</source>
+        <translation type="unfinished">Bande dessinée précédente</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="279"/>
+        <location filename="main_window_viewer.cpp" line="1656"/>
+        <location filename="main_window_viewer.cpp" line="1660"/>
+        <source>Open previous comic</source>
+        <translation type="unfinished">Ouvrir la bande dessiné précédente</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="284"/>
+        <source>Next Comic</source>
+        <translation type="unfinished">Bande dessinée suivante</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="286"/>
+        <location filename="main_window_viewer.cpp" line="1655"/>
+        <location filename="main_window_viewer.cpp" line="1661"/>
+        <source>Open next comic</source>
+        <translation type="unfinished">Ouvrir la bande dessinée suivante</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="291"/>
+        <source>&amp;Previous</source>
+        <translation type="unfinished">&amp;Précédent</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="294"/>
+        <location filename="main_window_viewer.cpp" line="1658"/>
+        <location filename="main_window_viewer.cpp" line="1662"/>
+        <source>Go to previous page</source>
+        <translation type="unfinished">Aller à la page précédente</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="299"/>
+        <source>&amp;Next</source>
+        <translation type="unfinished">&amp;Suivant</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="302"/>
+        <location filename="main_window_viewer.cpp" line="1657"/>
+        <location filename="main_window_viewer.cpp" line="1663"/>
+        <source>Go to next page</source>
+        <translation type="unfinished">Aller à la page suivante</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="307"/>
+        <source>Fit Height</source>
+        <translation type="unfinished">Ajuster la hauteur</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="310"/>
+        <source>Fit image to height</source>
+        <translation type="unfinished">Ajuster l&apos;image à la hauteur</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="317"/>
+        <source>Fit Width</source>
+        <translation type="unfinished">Ajuster la largeur</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="320"/>
+        <source>Fit image to width</source>
+        <translation type="unfinished">Ajuster l&apos;image à la largeur</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="327"/>
+        <source>Show full size</source>
+        <translation type="unfinished">Plein écran</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="335"/>
+        <source>Fit to page</source>
+        <translation type="unfinished">Ajuster à la page</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="366"/>
+        <source>Reset zoom</source>
+        <translation type="unfinished">Réinitialiser le zoom</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="371"/>
+        <source>Show zoom slider</source>
+        <translation type="unfinished">Afficher le curseur de zoom</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="374"/>
+        <source>Zoom+</source>
+        <translation type="unfinished">Zoom+</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="379"/>
+        <source>Zoom-</source>
+        <translation type="unfinished">Zoom-</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="384"/>
+        <source>Rotate image to the left</source>
+        <translation type="unfinished">Rotation à gauche</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="390"/>
+        <source>Rotate image to the right</source>
+        <translation type="unfinished">Rotation à droite</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="396"/>
+        <source>Double page mode</source>
+        <translation type="unfinished">Mode double page</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="397"/>
+        <source>Switch to double page mode</source>
+        <translation type="unfinished">Passer en mode double page</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="406"/>
+        <source>Double page manga mode</source>
+        <translation type="unfinished">Mode manga en double page</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="407"/>
+        <source>Reverse reading order in double page mode</source>
+        <translation type="unfinished">Ordre de lecture inversée en mode double page</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="416"/>
+        <source>Go To</source>
+        <translation type="unfinished">Aller à</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="418"/>
+        <source>Go to page ...</source>
+        <translation type="unfinished">Aller à la page ...</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="423"/>
+        <source>Options</source>
+        <translation type="unfinished">Options</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="424"/>
+        <source>YACReader options</source>
+        <translation type="unfinished">Options de YACReader</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="431"/>
+        <location filename="main_window_viewer.cpp" line="715"/>
+        <source>Help</source>
+        <translation type="unfinished">Aide</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="432"/>
+        <source>Help, About YACReader</source>
+        <translation type="unfinished">Aide, à propos de YACReader</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="438"/>
+        <source>Magnifying glass</source>
+        <translation type="unfinished">Loupe</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="439"/>
+        <source>Switch Magnifying glass</source>
+        <translation type="unfinished">Utiliser la loupe</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="446"/>
+        <source>Set bookmark</source>
+        <translation type="unfinished">Placer un marque-page</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="447"/>
+        <source>Set a bookmark on the current page</source>
+        <translation type="unfinished">Placer un marque-page sur la page actuelle</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="456"/>
+        <source>Show bookmarks</source>
+        <translation type="unfinished">Voir les marque-pages</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="457"/>
+        <source>Show the bookmarks of the current comic</source>
+        <translation type="unfinished">Voir les marque-pages de cette bande dessinée</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="463"/>
+        <source>Show keyboard shortcuts</source>
+        <translation type="unfinished">Voir les raccourcis</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="470"/>
+        <source>Show Info</source>
+        <translation type="unfinished">Voir les infos</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="476"/>
+        <source>Close</source>
+        <translation type="unfinished">Fermer</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="482"/>
+        <source>Show Dictionary</source>
+        <translation type="unfinished">Dictionnaire</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="489"/>
+        <source>Show go to flow</source>
+        <translation type="unfinished">Afficher le flux</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="495"/>
+        <source>Edit shortcuts</source>
+        <translation type="unfinished">Modifier les raccourcis</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="515"/>
+        <source>&amp;File</source>
+        <translation type="unfinished">&amp;Fichier</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="529"/>
+        <location filename="main_window_viewer.cpp" line="670"/>
+        <source>Open recent</source>
+        <translation type="unfinished">Ouvrir récent</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="659"/>
+        <source>File</source>
+        <translation type="unfinished">Fichier</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="680"/>
+        <source>Edit</source>
+        <translation type="unfinished">Editer</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="684"/>
+        <source>View</source>
+        <translation type="unfinished">Vue</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="700"/>
+        <source>Go</source>
+        <translation type="unfinished">Aller</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="708"/>
+        <source>Window</source>
+        <translation type="unfinished">Fenêtre</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="809"/>
+        <location filename="main_window_viewer.cpp" line="811"/>
+        <source>Open Comic</source>
+        <translation type="unfinished">Ouvrir la bande dessinée</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="809"/>
+        <location filename="main_window_viewer.cpp" line="811"/>
+        <source>Comic files</source>
+        <translation type="unfinished">Bande dessinée</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="898"/>
+        <source>Open folder</source>
+        <translation type="unfinished">Ouvirir le dossier</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>page_%1.jpg</source>
+        <translation type="unfinished">page_%1.jpg</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>Image files (*.jpg)</source>
+        <translation type="unfinished">Image(*.jpg)</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1159"/>
+        <source>Comics</source>
+        <translation type="unfinished">Bandes dessinées</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1169"/>
+        <source>Toggle fullscreen mode</source>
+        <translation type="unfinished">Basculer en mode plein écran</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1172"/>
+        <source>Hide/show toolbar</source>
+        <translation type="unfinished">Masquer / afficher la barre d&apos;outils</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1175"/>
+        <source>General</source>
+        <translation type="unfinished">Général</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1194"/>
+        <source>Size up magnifying glass</source>
+        <translation type="unfinished">Augmenter la taille de la loupe</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1197"/>
+        <source>Size down magnifying glass</source>
+        <translation type="unfinished">Réduire la taille de la loupe</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1200"/>
+        <source>Zoom in magnifying glass</source>
+        <translation type="unfinished">Zoomer</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1203"/>
+        <source>Zoom out magnifying glass</source>
+        <translation type="unfinished">Dézoomer</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1209"/>
+        <source>Magnifiying glass</source>
+        <translation type="unfinished">Loupe</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1216"/>
+        <source>Toggle between fit to width and fit to height</source>
+        <translation type="unfinished">Basculer entre adapter à la largeur et adapter à la hauteur</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1220"/>
+        <source>Page adjustement</source>
+        <translation type="unfinished">Ajustement de la page</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1237"/>
+        <source>Autoscroll down</source>
+        <translation type="unfinished">Défilement automatique vers le bas</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1240"/>
+        <source>Autoscroll up</source>
+        <translation type="unfinished">Défilement automatique vers le haut</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1243"/>
+        <source>Autoscroll forward, horizontal first</source>
+        <translation type="unfinished">Défilement automatique en avant, horizontal</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1247"/>
+        <source>Autoscroll backward, horizontal first</source>
+        <translation type="unfinished">Défilement automatique en arrière horizontal</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1251"/>
+        <source>Autoscroll forward, vertical first</source>
+        <translation type="unfinished">Défilement automatique en avant, vertical</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1255"/>
+        <source>Autoscroll backward, vertical first</source>
+        <translation type="unfinished">Défilement automatique en arrière, verticak</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1259"/>
+        <source>Move down</source>
+        <translation type="unfinished">Descendre</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1262"/>
+        <source>Move up</source>
+        <translation type="unfinished">Monter</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1265"/>
+        <source>Move left</source>
+        <translation type="unfinished">Déplacer à gauche</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1268"/>
+        <source>Move right</source>
+        <translation type="unfinished">Déplacer à droite</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1271"/>
+        <source>Go to the first page</source>
+        <translation type="unfinished">Aller à la première page</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1274"/>
+        <source>Go to the last page</source>
+        <translation type="unfinished">Aller à la dernière page</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1290"/>
+        <source>Reading</source>
+        <translation type="unfinished">Lecture</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1335"/>
+        <source>There is a new version available</source>
+        <translation type="unfinished">Une nouvelle version est disponible</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1336"/>
+        <source>Do you want to download the new version?</source>
+        <translation type="unfinished">Voulez-vous télécharger la nouvelle version?</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1339"/>
+        <source>Remind me in 14 days</source>
+        <translation type="unfinished">Rappelez-moi dans 14 jours</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1340"/>
+        <source>Not now</source>
+        <translation type="unfinished">Pas maintenant</translation>
+    </message>
+</context>
+<context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation type="unfinished">Fermer</translation>
     </message>
@@ -740,10 +1314,13 @@
 <context>
     <name>YACReaderFieldEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11"/>
         <source>Restore to default</source>
         <translation>Rétablir les paramètres par défaut</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28"/>
         <source>Click to overwrite</source>
         <translation>Cliquez pour remplacer</translation>
     </message>
@@ -751,10 +1328,15 @@
 <context>
     <name>YACReaderFieldPlainTextEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10"/>
         <source>Restore to default</source>
         <translation>Rétablir les paramètres par défaut</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50"/>
         <source>Click to overwrite</source>
         <translation>Cliquez pour remplacer</translation>
     </message>
@@ -762,18 +1344,22 @@
 <context>
     <name>YACReaderFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="15"/>
         <source>CoverFlow look</source>
         <translation>Vue CoverFlow</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="13"/>
         <source>How to show covers:</source>
         <translation>Comment voir les couvertures:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="16"/>
         <source>Stripe look</source>
         <translation>Vue alignée</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="17"/>
         <source>Overlapped Stripe look</source>
         <translation>Vue superposée</translation>
     </message>
@@ -781,94 +1367,117 @@
 <context>
     <name>YACReaderGLFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="112"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="142"/>
         <source>Light</source>
         <translation>Lumière</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="76"/>
         <source>Show advanced settings</source>
         <translation>Voir les paramètres avancés</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="32"/>
         <source>Roulette look</source>
         <translation>Vue roulette</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="130"/>
         <source>Cover Angle</source>
         <translation>Angle des couvertures</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="23"/>
         <source>Stripe look</source>
         <translation>Vue alignée</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="94"/>
         <source>Position</source>
         <translation>Position</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="124"/>
         <source>Z offset</source>
         <translation>Axe Z</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="118"/>
         <source>Y offset</source>
         <translation>Axe Y</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="106"/>
         <source>Central gap</source>
         <translation>Espace couverture centrale</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="18"/>
         <source>Presets:</source>
         <translation>Réglages:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="26"/>
         <source>Overlapped Stripe look</source>
         <translation>Vue superposée</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="29"/>
         <source>Modern look</source>
         <translation>Vue moderne</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="88"/>
         <source>View angle</source>
         <translation>Angle de vue</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="148"/>
         <source>Max angle</source>
         <translation>Angle Maximum</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="85"/>
         <source>Custom:</source>
         <translation>Personnalisation:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="20"/>
         <source>Classic look</source>
         <translation>Vue classique</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="100"/>
         <source>Cover gap</source>
         <translation>Espace entre les couvertures</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="182"/>
         <source>High Performance</source>
         <translation>Haute performance</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="201"/>
         <source>Performance:</source>
         <translation>Performance:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="193"/>
         <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
         <translation>Utiliser VSync (Améliore la qualité d&apos;image en mode plein écran, ralentit la performance)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="136"/>
         <source>Visibility</source>
         <translation>Visibilité</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="180"/>
         <source>Low Performance</source>
         <translation>Faible performance</translation>
     </message>
@@ -876,22 +1485,27 @@
 <context>
     <name>YACReaderOptionsDialog</name>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28"/>
         <source>Save</source>
         <translation>Sauvegarder</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="46"/>
         <source>Use hardware acceleration (restart needed)</source>
         <translation>Utiliser accélération hardware (redémarrage nécessaire)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="29"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="37"/>
         <source>Shortcuts</source>
         <translation>Raccourcis</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="34"/>
         <source>Edit shortcuts</source>
         <translation>Modifier les raccourcis</translation>
     </message>
@@ -899,6 +1513,7 @@
 <context>
     <name>YACReaderSlider</name>
     <message>
+        <location filename="width_slider.cpp" line="49"/>
         <source>Reset</source>
         <translation>Remise à zéro</translation>
     </message>
@@ -906,18 +1521,23 @@
 <context>
     <name>YACReaderTranslator</name>
     <message>
+        <location filename="translator.cpp" line="139"/>
         <source>clear</source>
         <translation>effacer</translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="216"/>
         <source>Service not available</source>
         <translation>Service non disponible</translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="116"/>
+        <location filename="translator.cpp" line="207"/>
         <source>Translation</source>
         <translation>Traduction</translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="62"/>
         <source>YACReader translator</source>
         <translation>Traducteur YACReader</translation>
     </message>

--- a/YACReader/yacreader_it.ts
+++ b/YACReader/yacreader_it.ts
@@ -4,6 +4,7 @@
 <context>
     <name>ActionsShortcutsModel</name>
     <message>
+        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="73"/>
         <source>None</source>
         <translation>Nessuno</translation>
     </message>
@@ -11,18 +12,23 @@
 <context>
     <name>BookmarksDialog</name>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="75"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="107"/>
+        <location filename="bookmarks_dialog.cpp" line="124"/>
         <source>Loading...</source>
         <translation>Caricamento...</translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="85"/>
         <source>Click on any image to go to the bookmark</source>
         <translation>Click su qualsiasi immagine per andare al bookmark</translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="25"/>
         <source>Lastest Page</source>
         <translation>Ultima Pagina</translation>
     </message>
@@ -30,22 +36,27 @@
 <context>
     <name>EditShortcutsDialog</name>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>Shortcut in use</source>
         <translation>Scorciatoia in uso</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="21"/>
         <source>Restore defaults</source>
         <translation>Resetta al default</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="69"/>
         <source>Shortcuts settings</source>
         <translation>impostazione scorciatoie</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>The shortcut &quot;%1&quot; is already assigned to other function</source>
         <translation>La scorciatoia &quot;%1&quot; è già assegnata ad un&apos;altra funzione</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="22"/>
         <source>To change a shortcut, double click in the key combination and type the new keys.</source>
         <translation>Per cambiare una scorciatoia doppio click sulla combinazione tasti e digita la nuova combinazione.</translation>
     </message>
@@ -53,18 +64,22 @@
 <context>
     <name>FileComic</name>
     <message>
+        <location filename="../common/comic.cpp" line="568"/>
         <source>Format not supported</source>
         <translation>Formato non supportato</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="562"/>
         <source>7z not found</source>
         <translation>7z non trovato</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="461"/>
         <source>Unknown error opening the file</source>
         <translation>Errore sconosciuto aprendo il file</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="454"/>
         <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
         <translation>Errore CRC alla pagina (%1): alcune pagine non saranno visualizzate correttamente</translation>
     </message>
@@ -72,22 +87,28 @@
 <context>
     <name>GoToDialog</name>
     <message>
+        <location filename="goto_dialog.cpp" line="23"/>
         <source>Go To</source>
         <translation>Vai a</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="53"/>
         <source>Go to...</source>
         <translation>Vai a...</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="39"/>
+        <location filename="goto_dialog.cpp" line="71"/>
         <source>Total pages : </source>
         <translation>Pagine totali: </translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="25"/>
         <source>Cancel</source>
         <translation>Annulla</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="15"/>
         <source>Page : </source>
         <translation>Pagina: </translation>
     </message>
@@ -95,6 +116,7 @@
 <context>
     <name>GoToFlowToolBar</name>
     <message>
+        <location filename="goto_flow_toolbar.cpp" line="38"/>
         <source>Page : </source>
         <translation>Pagina: </translation>
     </message>
@@ -102,10 +124,17 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Aiuto</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
+        <source>System info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation>About</translation>
     </message>
@@ -113,30 +142,37 @@
 <context>
     <name>LogWindow</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="14"/>
         <source>Log window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="22"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="39"/>
         <source>&amp;Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="56"/>
         <source>C&amp;lear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="73"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="90"/>
         <source>Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="136"/>
         <source>&amp;Auto scroll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -145,464 +181,496 @@
     <name>MainWindowViewer</name>
     <message>
         <source>Go</source>
-        <translation>Vai</translation>
+        <translation type="vanished">Vai</translation>
     </message>
     <message>
         <source>Edit</source>
-        <translation>Edit</translation>
+        <translation type="vanished">Edit</translation>
     </message>
     <message>
         <source>File</source>
-        <translation>File</translation>
+        <translation type="vanished">File</translation>
     </message>
     <message>
         <source>Help</source>
-        <translation>Aiuto</translation>
+        <translation type="vanished">Aiuto</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation>Salva</translation>
+        <translation type="vanished">Salva</translation>
     </message>
     <message>
         <source>View</source>
-        <translation>Mostra</translation>
+        <translation type="vanished">Mostra</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation>&amp;File</translation>
+        <translation type="vanished">&amp;File</translation>
     </message>
     <message>
         <source>&amp;Next</source>
-        <translation>&amp;Prossimo</translation>
+        <translation type="vanished">&amp;Prossimo</translation>
     </message>
     <message>
         <source>&amp;Open</source>
-        <translation>&amp;Apri</translation>
+        <translation type="vanished">&amp;Apri</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation>Cancella</translation>
+        <translation type="vanished">Cancella</translation>
     </message>
     <message>
         <source>Close</source>
-        <translation>Chiudi</translation>
+        <translation type="vanished">Chiudi</translation>
     </message>
     <message>
         <source>Open Comic</source>
-        <translation>Apri Fumetto</translation>
+        <translation type="vanished">Apri Fumetto</translation>
     </message>
     <message>
         <source>Go To</source>
-        <translation>Vai a</translation>
+        <translation type="vanished">Vai a</translation>
     </message>
     <message>
         <source>Zoom+</source>
-        <translation>Zoom+</translation>
+        <translation type="vanished">Zoom+</translation>
     </message>
     <message>
         <source>Zoom-</source>
-        <translation>Zoom-</translation>
+        <translation type="vanished">Zoom-</translation>
     </message>
     <message>
         <source>Open image folder</source>
-        <translation>Apri la crettal immagini</translation>
+        <translation type="vanished">Apri la crettal immagini</translation>
     </message>
     <message>
         <source>Size down magnifying glass</source>
-        <translation>Riduci lente ingrandimento</translation>
+        <translation type="vanished">Riduci lente ingrandimento</translation>
     </message>
     <message>
         <source>Zoom out magnifying glass</source>
-        <translation>Riduci in lente di ingrandimento</translation>
+        <translation type="vanished">Riduci in lente di ingrandimento</translation>
     </message>
     <message>
         <source>Open latest comic</source>
-        <translation>Apri l&apos;ultimo fumetto</translation>
+        <translation type="vanished">Apri l&apos;ultimo fumetto</translation>
     </message>
     <message>
         <source>Autoscroll up</source>
-        <translation>Autoscorri Sù</translation>
+        <translation type="vanished">Autoscorri Sù</translation>
     </message>
     <message>
         <source>Set bookmark</source>
-        <translation>Imposta Segnalibro</translation>
+        <translation type="vanished">Imposta Segnalibro</translation>
     </message>
     <message>
         <source>page_%1.jpg</source>
-        <translation>Pagina_%1.jpg</translation>
+        <translation type="vanished">Pagina_%1.jpg</translation>
     </message>
     <message>
         <source>Autoscroll forward, vertical first</source>
-        <translation>Autoscorri avanti, priorità Verticale</translation>
+        <translation type="vanished">Autoscorri avanti, priorità Verticale</translation>
     </message>
     <message>
         <source>Switch to double page mode</source>
-        <translation>Passa alla modalità doppia pagina</translation>
+        <translation type="vanished">Passa alla modalità doppia pagina</translation>
     </message>
     <message>
         <source>Save current page</source>
-        <translation>Salva la pagina corrente</translation>
+        <translation type="vanished">Salva la pagina corrente</translation>
     </message>
     <message>
         <source>Size up magnifying glass</source>
-        <translation>Ingrandisci lente ingrandimento</translation>
+        <translation type="vanished">Ingrandisci lente ingrandimento</translation>
     </message>
     <message>
         <source>Double page mode</source>
-        <translation>Modalita doppia pagina</translation>
+        <translation type="vanished">Modalita doppia pagina</translation>
     </message>
     <message>
         <source>Move up</source>
-        <translation>Muovi Sù</translation>
+        <translation type="vanished">Muovi Sù</translation>
     </message>
     <message>
         <source>Switch Magnifying glass</source>
-        <translation>Passa a lente ingrandimento</translation>
+        <translation type="vanished">Passa a lente ingrandimento</translation>
     </message>
     <message>
         <source>Open Folder</source>
-        <translation>Apri una cartella</translation>
+        <translation type="vanished">Apri una cartella</translation>
     </message>
     <message>
         <source>Comics</source>
-        <translation>Fumetto</translation>
+        <translation type="vanished">Fumetto</translation>
     </message>
     <message>
         <source>Fit Height</source>
-        <translation>Adatta altezza</translation>
+        <translation type="vanished">Adatta altezza</translation>
     </message>
     <message>
         <source>Autoscroll backward, vertical first</source>
-        <translation>Autoscorri indietro, priorità Verticale</translation>
+        <translation type="vanished">Autoscorri indietro, priorità Verticale</translation>
     </message>
     <message>
         <source>Comic files</source>
-        <translation>File Fumetto</translation>
+        <translation type="vanished">File Fumetto</translation>
     </message>
     <message>
         <source>Not now</source>
-        <translation>Non ora</translation>
+        <translation type="vanished">Non ora</translation>
     </message>
     <message>
         <source>Go to the first page</source>
-        <translation>Vai alla pagina iniziale</translation>
+        <translation type="vanished">Vai alla pagina iniziale</translation>
     </message>
     <message>
         <source>Go to previous page</source>
-        <translation>Vai alla pagina precedente</translation>
+        <translation type="vanished">Vai alla pagina precedente</translation>
     </message>
     <message>
         <source>Window</source>
-        <translation>Finestra</translation>
+        <translation type="vanished">Finestra</translation>
     </message>
     <message>
         <source>Open the latest comic opened in the previous reading session</source>
-        <translation>Apri l&apos;ultimo fumetto aperto nella sessione precedente</translation>
+        <translation type="vanished">Apri l&apos;ultimo fumetto aperto nella sessione precedente</translation>
     </message>
     <message>
         <source>Open a comic</source>
-        <translation>Apri un Fumetto</translation>
+        <translation type="vanished">Apri un Fumetto</translation>
     </message>
     <message>
         <source>Image files (*.jpg)</source>
-        <translation>File immagine (*.jpg)</translation>
+        <translation type="vanished">File immagine (*.jpg)</translation>
     </message>
     <message>
         <source>Next Comic</source>
-        <translation>Prossimo fumetto</translation>
+        <translation type="vanished">Prossimo fumetto</translation>
     </message>
     <message>
         <source>Fit Width</source>
-        <translation>Adatta Larghezza</translation>
+        <translation type="vanished">Adatta Larghezza</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation>Opzioni</translation>
+        <translation type="vanished">Opzioni</translation>
     </message>
     <message>
         <source>Show Info</source>
-        <translation>Mostra info</translation>
+        <translation type="vanished">Mostra info</translation>
     </message>
     <message>
         <source>Open folder</source>
-        <translation>Apri cartella</translation>
+        <translation type="vanished">Apri cartella</translation>
     </message>
     <message>
         <source>Go to page ...</source>
-        <translation>Vai a Pagina ...</translation>
+        <translation type="vanished">Vai a Pagina ...</translation>
     </message>
     <message>
         <source>Magnifiying glass</source>
-        <translation>Lente ingrandimento</translation>
+        <translation type="vanished">Lente ingrandimento</translation>
     </message>
     <message>
         <source>Fit image to width</source>
-        <translation>Adatta immagine in larghezza</translation>
+        <translation type="vanished">Adatta immagine in larghezza</translation>
     </message>
     <message>
         <source>Toggle fullscreen mode</source>
-        <translation>Attiva/Disattiva schermo intero</translation>
+        <translation type="vanished">Attiva/Disattiva schermo intero</translation>
     </message>
     <message>
         <source>Toggle between fit to width and fit to height</source>
-        <translation>Passa tra adatta in larghezza ad altezza</translation>
+        <translation type="vanished">Passa tra adatta in larghezza ad altezza</translation>
     </message>
     <message>
         <source>Move right</source>
-        <translation>Muovi Destra</translation>
+        <translation type="vanished">Muovi Destra</translation>
     </message>
     <message>
         <source>Zoom in magnifying glass</source>
-        <translation>Ingrandisci in lente di ingrandimento</translation>
+        <translation type="vanished">Ingrandisci in lente di ingrandimento</translation>
     </message>
     <message>
         <source>Open recent</source>
-        <translation>Apri i recenti</translation>
+        <translation type="vanished">Apri i recenti</translation>
     </message>
     <message>
         <source>Reading</source>
-        <translation>Leggi</translation>
+        <translation type="vanished">Leggi</translation>
     </message>
     <message>
         <source>&amp;Previous</source>
-        <translation>&amp;Precedente</translation>
+        <translation type="vanished">&amp;Precedente</translation>
     </message>
     <message>
         <source>Autoscroll forward, horizontal first</source>
-        <translation>Autoscorri avanti, priorità Orizzontale</translation>
+        <translation type="vanished">Autoscorri avanti, priorità Orizzontale</translation>
     </message>
     <message>
         <source>Go to next page</source>
-        <translation>Vai alla prossima Pagina</translation>
+        <translation type="vanished">Vai alla prossima Pagina</translation>
     </message>
     <message>
         <source>Show keyboard shortcuts</source>
-        <translation>Mostra scorciatoie da tastiera</translation>
+        <translation type="vanished">Mostra scorciatoie da tastiera</translation>
     </message>
     <message>
         <source>Double page manga mode</source>
-        <translation>Modalità doppia pagina Manga</translation>
+        <translation type="vanished">Modalità doppia pagina Manga</translation>
     </message>
     <message>
         <source>There is a new version available</source>
-        <translation>Nuova versione disponibile</translation>
+        <translation type="vanished">Nuova versione disponibile</translation>
     </message>
     <message>
         <source>Autoscroll down</source>
-        <translation>Autoscorri Giù</translation>
+        <translation type="vanished">Autoscorri Giù</translation>
     </message>
     <message>
         <source>Open next comic</source>
-        <translation>Apri il prossimo fumetto</translation>
+        <translation type="vanished">Apri il prossimo fumetto</translation>
     </message>
     <message>
         <source>Remind me in 14 days</source>
-        <translation>Ricordamelo in 14 giorni</translation>
+        <translation type="vanished">Ricordamelo in 14 giorni</translation>
     </message>
     <message>
         <source>Fit to page</source>
-        <translation>Adatta alla pagina</translation>
+        <translation type="vanished">Adatta alla pagina</translation>
     </message>
     <message>
         <source>Show bookmarks</source>
-        <translation>Mostra segnalibro</translation>
+        <translation type="vanished">Mostra segnalibro</translation>
     </message>
     <message>
         <source>Open previous comic</source>
-        <translation>Apri il fumetto precendente</translation>
+        <translation type="vanished">Apri il fumetto precendente</translation>
     </message>
     <message>
         <source>Rotate image to the left</source>
-        <translation>Ruota immagine a sinistra</translation>
+        <translation type="vanished">Ruota immagine a sinistra</translation>
     </message>
     <message>
         <source>Fit image to height</source>
-        <translation>Adatta immagine all&apos;altezza</translation>
+        <translation type="vanished">Adatta immagine all&apos;altezza</translation>
     </message>
     <message>
         <source>Reset zoom</source>
-        <translation>Resetta Zoom</translation>
+        <translation type="vanished">Resetta Zoom</translation>
     </message>
     <message>
         <source>Show the bookmarks of the current comic</source>
-        <translation>Mostra il segnalibro del fumetto corrente</translation>
+        <translation type="vanished">Mostra il segnalibro del fumetto corrente</translation>
     </message>
     <message>
         <source>Show Dictionary</source>
-        <translation>Mostra dizionario</translation>
+        <translation type="vanished">Mostra dizionario</translation>
     </message>
     <message>
         <source>Move down</source>
-        <translation>Muovi Giù</translation>
+        <translation type="vanished">Muovi Giù</translation>
     </message>
     <message>
         <source>Move left</source>
-        <translation>Muovi Sinistra</translation>
+        <translation type="vanished">Muovi Sinistra</translation>
     </message>
     <message>
         <source>Reverse reading order in double page mode</source>
-        <translation>Ordine lettura inverso in modo doppia pagina</translation>
+        <translation type="vanished">Ordine lettura inverso in modo doppia pagina</translation>
     </message>
     <message>
         <source>YACReader options</source>
-        <translation>Opzioni YACReader</translation>
+        <translation type="vanished">Opzioni YACReader</translation>
     </message>
     <message>
         <source>Clear open recent list</source>
-        <translation>Svuota la lista degli aperti</translation>
+        <translation type="vanished">Svuota la lista degli aperti</translation>
     </message>
     <message>
         <source>Help, About YACReader</source>
-        <translation>Aiuto, crediti YACReader</translation>
+        <translation type="vanished">Aiuto, crediti YACReader</translation>
     </message>
     <message>
         <source>Show go to flow</source>
-        <translation>Mostra vai all&apos;elenco</translation>
+        <translation type="vanished">Mostra vai all&apos;elenco</translation>
     </message>
     <message>
         <source>Previous Comic</source>
-        <translation>Fumetto precendente</translation>
+        <translation type="vanished">Fumetto precendente</translation>
     </message>
     <message>
         <source>Show full size</source>
-        <translation>Mostra dimesioni reali</translation>
+        <translation type="vanished">Mostra dimesioni reali</translation>
     </message>
     <message>
         <source>Hide/show toolbar</source>
-        <translation>Mostra/Nascondi Barra strumenti</translation>
+        <translation type="vanished">Mostra/Nascondi Barra strumenti</translation>
     </message>
     <message>
         <source>Magnifying glass</source>
-        <translation>Lente ingrandimento</translation>
+        <translation type="vanished">Lente ingrandimento</translation>
     </message>
     <message>
         <source>Edit shortcuts</source>
-        <translation>Edita scorciatoie</translation>
+        <translation type="vanished">Edita scorciatoie</translation>
     </message>
     <message>
         <source>General</source>
-        <translation>Generale</translation>
+        <translation type="vanished">Generale</translation>
     </message>
     <message>
         <source>Set a bookmark on the current page</source>
-        <translation>Imposta segnalibro a pagina corrente</translation>
+        <translation type="vanished">Imposta segnalibro a pagina corrente</translation>
     </message>
     <message>
         <source>Page adjustement</source>
-        <translation>Correzioni di pagna</translation>
+        <translation type="vanished">Correzioni di pagna</translation>
     </message>
     <message>
         <source>Show zoom slider</source>
-        <translation>Mostra cursore di zoom</translation>
+        <translation type="vanished">Mostra cursore di zoom</translation>
     </message>
     <message>
         <source>Go to the last page</source>
-        <translation>Vai all&apos;ultima pagina</translation>
+        <translation type="vanished">Vai all&apos;ultima pagina</translation>
     </message>
     <message>
         <source>Do you want to download the new version?</source>
-        <translation>Vuoi scaricare la nuova versione?</translation>
+        <translation type="vanished">Vuoi scaricare la nuova versione?</translation>
     </message>
     <message>
         <source>Rotate image to the right</source>
-        <translation>Ruota immagine a destra</translation>
+        <translation type="vanished">Ruota immagine a destra</translation>
     </message>
     <message>
         <source>Always on top</source>
-        <translation>Sempre in primo piano</translation>
+        <translation type="vanished">Sempre in primo piano</translation>
     </message>
     <message>
         <source>Autoscroll backward, horizontal first</source>
-        <translation>Autoscorri indietro, priorità Orizzontale</translation>
-    </message>
-    <message>
-        <source>New instance</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">Autoscorri indietro, priorità Orizzontale</translation>
     </message>
 </context>
 <context>
     <name>OptionsDialog</name>
     <message>
+        <location filename="options_dialog.cpp" line="143"/>
         <source>Gamma</source>
         <translation>Gamma</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="147"/>
         <source>Reset</source>
         <translation>Reset</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="34"/>
         <source>My comics path</source>
         <translation>Percorso dei miei fumetti</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="191"/>
         <source>Image adjustment</source>
         <translation>Correzioni immagine</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="43"/>
         <source>&quot;Go to flow&quot; size</source>
         <translation>Dimensione &quot;Vai all&apos;elenco&quot;</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="64"/>
         <source>Choose</source>
         <translation>Scegli</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="152"/>
         <source>Image options</source>
         <translation>Opzione immagine</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="142"/>
         <source>Contrast</source>
         <translation>Contrasto</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="206"/>
         <source>Options</source>
         <translation>Opzioni</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="213"/>
         <source>Comics directory</source>
         <translation>Cartella Fumetti</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="97"/>
         <source>Quick Navigation Mode</source>
         <translation>Modo navigazione rapida</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="61"/>
         <source>Background color</source>
         <translation>Colore di sfondo</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="71"/>
+        <source>Scroll behaviour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="74"/>
+        <source>Do not turn page using scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="75"/>
+        <source>Use single scroll step to turn page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="98"/>
         <source>Disable mouse over activation</source>
         <translation>Disabilita il mouse all&apos;attivazione</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="190"/>
         <source>Page Flow</source>
         <translation>Flusso pagine</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="189"/>
         <source>General</source>
         <translation>Generale</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="141"/>
         <source>Brightness</source>
         <translation>Luminosità</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="197"/>
         <source>Restart is needed</source>
         <translation>Riavvio Necessario</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="156"/>
         <source>Fit options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="158"/>
         <source>Enlarge images to fit width/height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="169"/>
         <source>Double Page options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="171"/>
         <source>Show covers as single page</source>
         <translation type="unfinished"></translation>
     </message>
@@ -610,34 +678,42 @@
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>7z lib not found</source>
         <translation>Libreria 7z non trovata</translation>
     </message>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>unable to load 7z lib from ./utils</source>
         <translation>Impossibile caricare 7z da ./utils</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41"/>
         <source>Trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45"/>
         <source>Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51"/>
         <source>Fatal</source>
         <translation type="unfinished"></translation>
     </message>
@@ -645,14 +721,17 @@
 <context>
     <name>QsLogging::LogWindowModel</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="141"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="143"/>
         <source>Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="145"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
@@ -660,18 +739,22 @@
 <context>
     <name>QsLogging::Window</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="236"/>
         <source>Save log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="237"/>
         <source>Log file (*.log)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -679,14 +762,17 @@
 <context>
     <name>ShortcutsDialog</name>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="23"/>
         <source>Close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="19"/>
         <source>YACReader keyboard shortcuts</source>
         <translation>Scorciatoie  da tastiera di YACReader</translation>
     </message>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="63"/>
         <source>Keyboard Shortcuts</source>
         <translation>Scorciatoia da tastiera</translation>
     </message>
@@ -694,45 +780,537 @@
 <context>
     <name>Viewer</name>
     <message>
+        <location filename="viewer.cpp" line="937"/>
         <source>Page not available!</source>
         <translation>Pagina non disponibile!</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="51"/>
+        <location filename="viewer.cpp" line="915"/>
         <source>Press &apos;O&apos; to open comic.</source>
         <translation>Premi &quot;O&quot; per aprire il fumettto.</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="240"/>
         <source>Error opening comic</source>
         <translation>Errore nell&apos;apertura</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="1089"/>
         <source>Cover!</source>
         <translation>Copertina!</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="246"/>
         <source>CRC Error</source>
         <translation>Errore CRC</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="234"/>
         <source>Comic not found</source>
         <translation>Fumetto non trovato</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="234"/>
         <source>Not found</source>
         <translation>Non trovato</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="1103"/>
         <source>Last page!</source>
         <translation>Ultima pagina!</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="927"/>
         <source>Loading...please wait!</source>
         <translation>In caricamento...Attendi!</translation>
     </message>
 </context>
 <context>
+    <name>YACReader::MainWindowViewer</name>
+    <message>
+        <location filename="main_window_viewer.cpp" line="219"/>
+        <source>&amp;Open</source>
+        <translation type="unfinished">&amp;Apri</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="221"/>
+        <source>Open a comic</source>
+        <translation type="unfinished">Apri un Fumetto</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="227"/>
+        <source>New instance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="246"/>
+        <source>Open Folder</source>
+        <translation type="unfinished">Apri una cartella</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="248"/>
+        <source>Open image folder</source>
+        <translation type="unfinished">Apri la crettal immagini</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="253"/>
+        <source>Open latest comic</source>
+        <translation type="unfinished">Apri l&apos;ultimo fumetto</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="254"/>
+        <source>Open the latest comic opened in the previous reading session</source>
+        <translation type="unfinished">Apri l&apos;ultimo fumetto aperto nella sessione precedente</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="266"/>
+        <source>Clear</source>
+        <translation type="unfinished">Cancella</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="267"/>
+        <source>Clear open recent list</source>
+        <translation type="unfinished">Svuota la lista degli aperti</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="270"/>
+        <source>Save</source>
+        <translation type="unfinished">Salva</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="272"/>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>Save current page</source>
+        <translation type="unfinished">Salva la pagina corrente</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="277"/>
+        <source>Previous Comic</source>
+        <translation type="unfinished">Fumetto precendente</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="279"/>
+        <location filename="main_window_viewer.cpp" line="1656"/>
+        <location filename="main_window_viewer.cpp" line="1660"/>
+        <source>Open previous comic</source>
+        <translation type="unfinished">Apri il fumetto precendente</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="284"/>
+        <source>Next Comic</source>
+        <translation type="unfinished">Prossimo fumetto</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="286"/>
+        <location filename="main_window_viewer.cpp" line="1655"/>
+        <location filename="main_window_viewer.cpp" line="1661"/>
+        <source>Open next comic</source>
+        <translation type="unfinished">Apri il prossimo fumetto</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="291"/>
+        <source>&amp;Previous</source>
+        <translation type="unfinished">&amp;Precedente</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="294"/>
+        <location filename="main_window_viewer.cpp" line="1658"/>
+        <location filename="main_window_viewer.cpp" line="1662"/>
+        <source>Go to previous page</source>
+        <translation type="unfinished">Vai alla pagina precedente</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="299"/>
+        <source>&amp;Next</source>
+        <translation type="unfinished">&amp;Prossimo</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="302"/>
+        <location filename="main_window_viewer.cpp" line="1657"/>
+        <location filename="main_window_viewer.cpp" line="1663"/>
+        <source>Go to next page</source>
+        <translation type="unfinished">Vai alla prossima Pagina</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="307"/>
+        <source>Fit Height</source>
+        <translation type="unfinished">Adatta altezza</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="310"/>
+        <source>Fit image to height</source>
+        <translation type="unfinished">Adatta immagine all&apos;altezza</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="317"/>
+        <source>Fit Width</source>
+        <translation type="unfinished">Adatta Larghezza</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="320"/>
+        <source>Fit image to width</source>
+        <translation type="unfinished">Adatta immagine in larghezza</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="327"/>
+        <source>Show full size</source>
+        <translation type="unfinished">Mostra dimesioni reali</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="335"/>
+        <source>Fit to page</source>
+        <translation type="unfinished">Adatta alla pagina</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="366"/>
+        <source>Reset zoom</source>
+        <translation type="unfinished">Resetta Zoom</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="371"/>
+        <source>Show zoom slider</source>
+        <translation type="unfinished">Mostra cursore di zoom</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="374"/>
+        <source>Zoom+</source>
+        <translation type="unfinished">Zoom+</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="379"/>
+        <source>Zoom-</source>
+        <translation type="unfinished">Zoom-</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="384"/>
+        <source>Rotate image to the left</source>
+        <translation type="unfinished">Ruota immagine a sinistra</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="390"/>
+        <source>Rotate image to the right</source>
+        <translation type="unfinished">Ruota immagine a destra</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="396"/>
+        <source>Double page mode</source>
+        <translation type="unfinished">Modalita doppia pagina</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="397"/>
+        <source>Switch to double page mode</source>
+        <translation type="unfinished">Passa alla modalità doppia pagina</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="406"/>
+        <source>Double page manga mode</source>
+        <translation type="unfinished">Modalità doppia pagina Manga</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="407"/>
+        <source>Reverse reading order in double page mode</source>
+        <translation type="unfinished">Ordine lettura inverso in modo doppia pagina</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="416"/>
+        <source>Go To</source>
+        <translation type="unfinished">Vai a</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="418"/>
+        <source>Go to page ...</source>
+        <translation type="unfinished">Vai a Pagina ...</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="423"/>
+        <source>Options</source>
+        <translation type="unfinished">Opzioni</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="424"/>
+        <source>YACReader options</source>
+        <translation type="unfinished">Opzioni YACReader</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="431"/>
+        <location filename="main_window_viewer.cpp" line="715"/>
+        <source>Help</source>
+        <translation type="unfinished">Aiuto</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="432"/>
+        <source>Help, About YACReader</source>
+        <translation type="unfinished">Aiuto, crediti YACReader</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="438"/>
+        <source>Magnifying glass</source>
+        <translation type="unfinished">Lente ingrandimento</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="439"/>
+        <source>Switch Magnifying glass</source>
+        <translation type="unfinished">Passa a lente ingrandimento</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="446"/>
+        <source>Set bookmark</source>
+        <translation type="unfinished">Imposta Segnalibro</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="447"/>
+        <source>Set a bookmark on the current page</source>
+        <translation type="unfinished">Imposta segnalibro a pagina corrente</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="456"/>
+        <source>Show bookmarks</source>
+        <translation type="unfinished">Mostra segnalibro</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="457"/>
+        <source>Show the bookmarks of the current comic</source>
+        <translation type="unfinished">Mostra il segnalibro del fumetto corrente</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="463"/>
+        <source>Show keyboard shortcuts</source>
+        <translation type="unfinished">Mostra scorciatoie da tastiera</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="470"/>
+        <source>Show Info</source>
+        <translation type="unfinished">Mostra info</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="476"/>
+        <source>Close</source>
+        <translation type="unfinished">Chiudi</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="482"/>
+        <source>Show Dictionary</source>
+        <translation type="unfinished">Mostra dizionario</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="489"/>
+        <source>Show go to flow</source>
+        <translation type="unfinished">Mostra vai all&apos;elenco</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="495"/>
+        <source>Edit shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="515"/>
+        <source>&amp;File</source>
+        <translation type="unfinished">&amp;File</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="529"/>
+        <location filename="main_window_viewer.cpp" line="670"/>
+        <source>Open recent</source>
+        <translation type="unfinished">Apri i recenti</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="659"/>
+        <source>File</source>
+        <translation type="unfinished">File</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="680"/>
+        <source>Edit</source>
+        <translation type="unfinished">Edit</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="684"/>
+        <source>View</source>
+        <translation type="unfinished">Mostra</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="700"/>
+        <source>Go</source>
+        <translation type="unfinished">Vai</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="708"/>
+        <source>Window</source>
+        <translation type="unfinished">Finestra</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="809"/>
+        <location filename="main_window_viewer.cpp" line="811"/>
+        <source>Open Comic</source>
+        <translation type="unfinished">Apri Fumetto</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="809"/>
+        <location filename="main_window_viewer.cpp" line="811"/>
+        <source>Comic files</source>
+        <translation type="unfinished">File Fumetto</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="898"/>
+        <source>Open folder</source>
+        <translation type="unfinished">Apri cartella</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>page_%1.jpg</source>
+        <translation type="unfinished">Pagina_%1.jpg</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>Image files (*.jpg)</source>
+        <translation type="unfinished">File immagine (*.jpg)</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1159"/>
+        <source>Comics</source>
+        <translation type="unfinished">Fumetto</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1169"/>
+        <source>Toggle fullscreen mode</source>
+        <translation type="unfinished">Attiva/Disattiva schermo intero</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1172"/>
+        <source>Hide/show toolbar</source>
+        <translation type="unfinished">Mostra/Nascondi Barra strumenti</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1175"/>
+        <source>General</source>
+        <translation type="unfinished">Generale</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1194"/>
+        <source>Size up magnifying glass</source>
+        <translation type="unfinished">Ingrandisci lente ingrandimento</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1197"/>
+        <source>Size down magnifying glass</source>
+        <translation type="unfinished">Riduci lente ingrandimento</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1200"/>
+        <source>Zoom in magnifying glass</source>
+        <translation type="unfinished">Ingrandisci in lente di ingrandimento</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1203"/>
+        <source>Zoom out magnifying glass</source>
+        <translation type="unfinished">Riduci in lente di ingrandimento</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1209"/>
+        <source>Magnifiying glass</source>
+        <translation type="unfinished">Lente ingrandimento</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1216"/>
+        <source>Toggle between fit to width and fit to height</source>
+        <translation type="unfinished">Passa tra adatta in larghezza ad altezza</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1220"/>
+        <source>Page adjustement</source>
+        <translation type="unfinished">Correzioni di pagna</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1237"/>
+        <source>Autoscroll down</source>
+        <translation type="unfinished">Autoscorri Giù</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1240"/>
+        <source>Autoscroll up</source>
+        <translation type="unfinished">Autoscorri Sù</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1243"/>
+        <source>Autoscroll forward, horizontal first</source>
+        <translation type="unfinished">Autoscorri avanti, priorità Orizzontale</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1247"/>
+        <source>Autoscroll backward, horizontal first</source>
+        <translation type="unfinished">Autoscorri indietro, priorità Orizzontale</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1251"/>
+        <source>Autoscroll forward, vertical first</source>
+        <translation type="unfinished">Autoscorri avanti, priorità Verticale</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1255"/>
+        <source>Autoscroll backward, vertical first</source>
+        <translation type="unfinished">Autoscorri indietro, priorità Verticale</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1259"/>
+        <source>Move down</source>
+        <translation type="unfinished">Muovi Giù</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1262"/>
+        <source>Move up</source>
+        <translation type="unfinished">Muovi Sù</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1265"/>
+        <source>Move left</source>
+        <translation type="unfinished">Muovi Sinistra</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1268"/>
+        <source>Move right</source>
+        <translation type="unfinished">Muovi Destra</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1271"/>
+        <source>Go to the first page</source>
+        <translation type="unfinished">Vai alla pagina iniziale</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1274"/>
+        <source>Go to the last page</source>
+        <translation type="unfinished">Vai all&apos;ultima pagina</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1290"/>
+        <source>Reading</source>
+        <translation type="unfinished">Leggi</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1335"/>
+        <source>There is a new version available</source>
+        <translation type="unfinished">Nuova versione disponibile</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1336"/>
+        <source>Do you want to download the new version?</source>
+        <translation type="unfinished">Vuoi scaricare la nuova versione?</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1339"/>
+        <source>Remind me in 14 days</source>
+        <translation type="unfinished">Ricordamelo in 14 giorni</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1340"/>
+        <source>Not now</source>
+        <translation type="unfinished">Non ora</translation>
+    </message>
+</context>
+<context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation type="unfinished">Chiudi</translation>
     </message>
@@ -740,10 +1318,13 @@
 <context>
     <name>YACReaderFieldEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11"/>
         <source>Restore to default</source>
         <translation>Resetta al default</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28"/>
         <source>Click to overwrite</source>
         <translation>Click per sovrascrivere</translation>
     </message>
@@ -751,10 +1332,15 @@
 <context>
     <name>YACReaderFieldPlainTextEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10"/>
         <source>Restore to default</source>
         <translation>Resetta al default</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50"/>
         <source>Click to overwrite</source>
         <translation>Click per sovrascrivere</translation>
     </message>
@@ -762,18 +1348,22 @@
 <context>
     <name>YACReaderFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="15"/>
         <source>CoverFlow look</source>
         <translation>Aspetto flusso Copertine</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="13"/>
         <source>How to show covers:</source>
         <translation>Come mostrare le copertine:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="16"/>
         <source>Stripe look</source>
         <translation>Aspetto a strisce</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="17"/>
         <source>Overlapped Stripe look</source>
         <translation>Aspetto a strisce sovrapposto</translation>
     </message>
@@ -781,94 +1371,117 @@
 <context>
     <name>YACReaderGLFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="112"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="142"/>
         <source>Light</source>
         <translation>Luce</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="76"/>
         <source>Show advanced settings</source>
         <translation>Mostra opzioni avanzate</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="32"/>
         <source>Roulette look</source>
         <translation>Aspetto Roulette</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="130"/>
         <source>Cover Angle</source>
         <translation>Angolo copertine</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="23"/>
         <source>Stripe look</source>
         <translation>Aspetto a strisce</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="94"/>
         <source>Position</source>
         <translation>Posizione</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="124"/>
         <source>Z offset</source>
         <translation>Compensazione Z</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="118"/>
         <source>Y offset</source>
         <translation>Compensazione Y</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="106"/>
         <source>Central gap</source>
         <translation>Distanza centrale</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="18"/>
         <source>Presets:</source>
         <translation>Preselezioni:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="26"/>
         <source>Overlapped Stripe look</source>
         <translation>Aspetto a strisce sovrapposto</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="29"/>
         <source>Modern look</source>
         <translation>Aspetto moderno</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="88"/>
         <source>View angle</source>
         <translation>Angolo di vista</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="148"/>
         <source>Max angle</source>
         <translation>Angolo massimo</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="85"/>
         <source>Custom:</source>
         <translation>Personalizzazione:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="20"/>
         <source>Classic look</source>
         <translation>Aspetto Classico</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="100"/>
         <source>Cover gap</source>
         <translation>Distanza Copertine</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="182"/>
         <source>High Performance</source>
         <translation>Prestazioni Alte</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="201"/>
         <source>Performance:</source>
         <translation>Prestazioni:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="193"/>
         <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
         <translation>Usa VSync (migliora la qualtà a tutto schermo, peggiora le prestazioni)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="136"/>
         <source>Visibility</source>
         <translation>Visibilità</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="180"/>
         <source>Low Performance</source>
         <translation>Prestazioni Basse</translation>
     </message>
@@ -876,22 +1489,27 @@
 <context>
     <name>YACReaderOptionsDialog</name>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28"/>
         <source>Save</source>
         <translation>Salva</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="46"/>
         <source>Use hardware acceleration (restart needed)</source>
         <translation>Usa accelerazione Hardware (necessita restart)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="29"/>
         <source>Cancel</source>
         <translation>Cancella</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="37"/>
         <source>Shortcuts</source>
         <translation>Scorciatoia</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="34"/>
         <source>Edit shortcuts</source>
         <translation>Edita Scorciatoia</translation>
     </message>
@@ -899,6 +1517,7 @@
 <context>
     <name>YACReaderSlider</name>
     <message>
+        <location filename="width_slider.cpp" line="49"/>
         <source>Reset</source>
         <translation>Resetta</translation>
     </message>
@@ -906,18 +1525,23 @@
 <context>
     <name>YACReaderTranslator</name>
     <message>
+        <location filename="translator.cpp" line="139"/>
         <source>clear</source>
         <translation>Cancella</translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="216"/>
         <source>Service not available</source>
         <translation>Servizio non disponibile</translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="116"/>
+        <location filename="translator.cpp" line="207"/>
         <source>Translation</source>
         <translation>Traduzione</translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="62"/>
         <source>YACReader translator</source>
         <translation>Traduttore YACReader</translation>
     </message>

--- a/YACReader/yacreader_nl.ts
+++ b/YACReader/yacreader_nl.ts
@@ -4,6 +4,7 @@
 <context>
     <name>ActionsShortcutsModel</name>
     <message>
+        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="73"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11,18 +12,23 @@
 <context>
     <name>BookmarksDialog</name>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="75"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="107"/>
+        <location filename="bookmarks_dialog.cpp" line="124"/>
         <source>Loading...</source>
         <translation>Inladen...</translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="85"/>
         <source>Click on any image to go to the bookmark</source>
         <translation>Klik op een afbeelding om naar de bladwijzer te gaan </translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="25"/>
         <source>Lastest Page</source>
         <translation>Laatste Pagina</translation>
     </message>
@@ -30,22 +36,27 @@
 <context>
     <name>EditShortcutsDialog</name>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="21"/>
         <source>Restore defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="22"/>
         <source>To change a shortcut, double click in the key combination and type the new keys.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="69"/>
         <source>Shortcuts settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>Shortcut in use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>The shortcut &quot;%1&quot; is already assigned to other function</source>
         <translation type="unfinished"></translation>
     </message>
@@ -53,18 +64,22 @@
 <context>
     <name>FileComic</name>
     <message>
+        <location filename="../common/comic.cpp" line="562"/>
         <source>7z not found</source>
         <translation>7Z Archiefbestand niet gevonden</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="454"/>
         <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="461"/>
         <source>Unknown error opening the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="568"/>
         <source>Format not supported</source>
         <translation type="unfinished"></translation>
     </message>
@@ -72,22 +87,28 @@
 <context>
     <name>GoToDialog</name>
     <message>
+        <location filename="goto_dialog.cpp" line="23"/>
         <source>Go To</source>
         <translation>Ga Naar</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="53"/>
         <source>Go to...</source>
         <translation>Ga naar...</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="39"/>
+        <location filename="goto_dialog.cpp" line="71"/>
         <source>Total pages : </source>
         <translation>Totaal aantal pagina&apos;s : </translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="25"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="15"/>
         <source>Page : </source>
         <translation>Pagina : </translation>
     </message>
@@ -95,6 +116,7 @@
 <context>
     <name>GoToFlowToolBar</name>
     <message>
+        <location filename="goto_flow_toolbar.cpp" line="38"/>
         <source>Page : </source>
         <translation>Pagina : </translation>
     </message>
@@ -102,10 +124,17 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Help</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
+        <source>System info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation>Over</translation>
     </message>
@@ -113,30 +142,37 @@
 <context>
     <name>LogWindow</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="14"/>
         <source>Log window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="22"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="39"/>
         <source>&amp;Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="56"/>
         <source>C&amp;lear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="73"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="90"/>
         <source>Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="136"/>
         <source>&amp;Auto scroll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -145,464 +181,320 @@
     <name>MainWindowViewer</name>
     <message>
         <source>Help</source>
-        <translation>Help</translation>
+        <translation type="vanished">Help</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation>Bewaar</translation>
+        <translation type="vanished">Bewaar</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation>&amp;Bestand</translation>
+        <translation type="vanished">&amp;Bestand</translation>
     </message>
     <message>
         <source>&amp;Next</source>
-        <translation>&amp;Volgende</translation>
+        <translation type="vanished">&amp;Volgende</translation>
     </message>
     <message>
         <source>&amp;Open</source>
-        <translation>&amp;Open</translation>
+        <translation type="vanished">&amp;Open</translation>
     </message>
     <message>
         <source>Close</source>
-        <translation>Sluiten</translation>
+        <translation type="vanished">Sluiten</translation>
     </message>
     <message>
         <source>Open Comic</source>
-        <translation>Open een Strip</translation>
+        <translation type="vanished">Open een Strip</translation>
     </message>
     <message>
         <source>Go To</source>
-        <translation>Ga Naar</translation>
+        <translation type="vanished">Ga Naar</translation>
     </message>
     <message>
         <source>Open image folder</source>
-        <translation>Open afbeeldings map</translation>
+        <translation type="vanished">Open afbeeldings map</translation>
     </message>
     <message>
         <source>Set bookmark</source>
-        <translation>Bladwijzer instellen</translation>
+        <translation type="vanished">Bladwijzer instellen</translation>
     </message>
     <message>
         <source>page_%1.jpg</source>
-        <translation>pagina_%1.jpg</translation>
+        <translation type="vanished">pagina_%1.jpg</translation>
     </message>
     <message>
         <source>Switch to double page mode</source>
-        <translation>Naar dubbele bladzijde modus</translation>
+        <translation type="vanished">Naar dubbele bladzijde modus</translation>
     </message>
     <message>
         <source>Save current page</source>
-        <translation>Bewaren huidige pagina</translation>
+        <translation type="vanished">Bewaren huidige pagina</translation>
     </message>
     <message>
         <source>Double page mode</source>
-        <translation>Dubbele bladzijde modus</translation>
+        <translation type="vanished">Dubbele bladzijde modus</translation>
     </message>
     <message>
         <source>Switch Magnifying glass</source>
-        <translation>Overschakelen naar Vergrootglas</translation>
+        <translation type="vanished">Overschakelen naar Vergrootglas</translation>
     </message>
     <message>
         <source>Open Folder</source>
-        <translation>Map Openen</translation>
+        <translation type="vanished">Map Openen</translation>
     </message>
     <message>
         <source>Comic files</source>
-        <translation>Strip bestanden</translation>
+        <translation type="vanished">Strip bestanden</translation>
     </message>
     <message>
         <source>Go to previous page</source>
-        <translation>Ga naar de vorige pagina</translation>
+        <translation type="vanished">Ga naar de vorige pagina</translation>
     </message>
     <message>
         <source>Open a comic</source>
-        <translation>Open een strip</translation>
+        <translation type="vanished">Open een strip</translation>
     </message>
     <message>
         <source>Image files (*.jpg)</source>
-        <translation>Afbeelding bestanden (*.jpg)</translation>
+        <translation type="vanished">Afbeelding bestanden (*.jpg)</translation>
     </message>
     <message>
         <source>Next Comic</source>
-        <translation>Volgende Strip</translation>
+        <translation type="vanished">Volgende Strip</translation>
     </message>
     <message>
         <source>Fit Width</source>
-        <translation>Vensterbreedte aanpassen</translation>
+        <translation type="vanished">Vensterbreedte aanpassen</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation>Opties</translation>
+        <translation type="vanished">Opties</translation>
     </message>
     <message>
         <source>Show Info</source>
-        <translation>Info tonen</translation>
+        <translation type="vanished">Info tonen</translation>
     </message>
     <message>
         <source>Open folder</source>
-        <translation>Open een Map</translation>
+        <translation type="vanished">Open een Map</translation>
     </message>
     <message>
         <source>Go to page ...</source>
-        <translation>Ga naar bladzijde ...</translation>
+        <translation type="vanished">Ga naar bladzijde ...</translation>
     </message>
     <message>
         <source>Fit image to width</source>
-        <translation>Afbeelding aanpassen aan breedte</translation>
+        <translation type="vanished">Afbeelding aanpassen aan breedte</translation>
     </message>
     <message>
         <source>&amp;Previous</source>
-        <translation>&amp;Vorige</translation>
+        <translation type="vanished">&amp;Vorige</translation>
     </message>
     <message>
         <source>Go to next page</source>
-        <translation>Ga naar de volgende pagina</translation>
+        <translation type="vanished">Ga naar de volgende pagina</translation>
     </message>
     <message>
         <source>Show keyboard shortcuts</source>
-        <translation>Toon de sneltoetsen</translation>
+        <translation type="vanished">Toon de sneltoetsen</translation>
     </message>
     <message>
         <source>There is a new version available</source>
-        <translation>Er is een nieuwe versie beschikbaar</translation>
+        <translation type="vanished">Er is een nieuwe versie beschikbaar</translation>
     </message>
     <message>
         <source>Open next comic</source>
-        <translation>Open volgende strip</translation>
+        <translation type="vanished">Open volgende strip</translation>
     </message>
     <message>
         <source>Show bookmarks</source>
-        <translation>Bladwijzers weergeven</translation>
+        <translation type="vanished">Bladwijzers weergeven</translation>
     </message>
     <message>
         <source>Open previous comic</source>
-        <translation>Open de vorige strip</translation>
+        <translation type="vanished">Open de vorige strip</translation>
     </message>
     <message>
         <source>Rotate image to the left</source>
-        <translation>Links omdraaien</translation>
+        <translation type="vanished">Links omdraaien</translation>
     </message>
     <message>
         <source>Fit image to height</source>
-        <translation>Afbeelding aanpassen aan hoogte</translation>
+        <translation type="vanished">Afbeelding aanpassen aan hoogte</translation>
     </message>
     <message>
         <source>Show the bookmarks of the current comic</source>
-        <translation>Toon de bladwijzers van de huidige strip</translation>
+        <translation type="vanished">Toon de bladwijzers van de huidige strip</translation>
     </message>
     <message>
         <source>Show Dictionary</source>
-        <translation>Woordenlijst weergeven</translation>
+        <translation type="vanished">Woordenlijst weergeven</translation>
     </message>
     <message>
         <source>YACReader options</source>
-        <translation>YACReader opties</translation>
+        <translation type="vanished">YACReader opties</translation>
     </message>
     <message>
         <source>Help, About YACReader</source>
-        <translation>Help, Over YACReader</translation>
+        <translation type="vanished">Help, Over YACReader</translation>
     </message>
     <message>
         <source>Show go to flow</source>
-        <translation>Toon ga naar de Omslagbrowser</translation>
+        <translation type="vanished">Toon ga naar de Omslagbrowser</translation>
     </message>
     <message>
         <source>Previous Comic</source>
-        <translation>Vorige Strip</translation>
+        <translation type="vanished">Vorige Strip</translation>
     </message>
     <message>
         <source>Show full size</source>
-        <translation>Volledig Scherm </translation>
+        <translation type="vanished">Volledig Scherm </translation>
     </message>
     <message>
         <source>Magnifying glass</source>
-        <translation>Vergrootglas</translation>
+        <translation type="vanished">Vergrootglas</translation>
     </message>
     <message>
         <source>General</source>
-        <translation>Algemeen</translation>
+        <translation type="vanished">Algemeen</translation>
     </message>
     <message>
         <source>Set a bookmark on the current page</source>
-        <translation>Een bladwijzer toevoegen aan de huidige pagina</translation>
+        <translation type="vanished">Een bladwijzer toevoegen aan de huidige pagina</translation>
     </message>
     <message>
         <source>Do you want to download the new version?</source>
-        <translation>Wilt u de nieuwe versie downloaden?</translation>
+        <translation type="vanished">Wilt u de nieuwe versie downloaden?</translation>
     </message>
     <message>
         <source>Rotate image to the right</source>
-        <translation>Rechts omdraaien</translation>
+        <translation type="vanished">Rechts omdraaien</translation>
     </message>
     <message>
         <source>Always on top</source>
-        <translation>Altijd op voorgrond</translation>
-    </message>
-    <message>
-        <source>New instance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open latest comic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open the latest comic opened in the previous reading session</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Clear</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Clear open recent list</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fit Height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fit to page</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reset zoom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show zoom slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Zoom+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Zoom-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Double page manga mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reverse reading order in double page mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit shortcuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open recent</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Go</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Comics</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Toggle fullscreen mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide/show toolbar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Size up magnifying glass</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Size down magnifying glass</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Zoom in magnifying glass</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Zoom out magnifying glass</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Magnifiying glass</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Toggle between fit to width and fit to height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page adjustement</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Autoscroll down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Autoscroll up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Autoscroll forward, horizontal first</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Autoscroll backward, horizontal first</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Autoscroll forward, vertical first</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Autoscroll backward, vertical first</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Go to the first page</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Go to the last page</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reading</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remind me in 14 days</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not now</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">Altijd op voorgrond</translation>
     </message>
 </context>
 <context>
     <name>OptionsDialog</name>
     <message>
+        <location filename="options_dialog.cpp" line="143"/>
         <source>Gamma</source>
         <translation>Gamma</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="147"/>
         <source>Reset</source>
         <translation>Standaardwaarden terugzetten</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="34"/>
         <source>My comics path</source>
         <translation>Pad naar mijn strips</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="191"/>
         <source>Image adjustment</source>
         <translation>Beeldaanpassing</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="43"/>
         <source>&quot;Go to flow&quot; size</source>
         <translation>&quot;Naar Omslagbrowser&quot; afmetingen</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="64"/>
         <source>Choose</source>
         <translation>Kies</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="152"/>
         <source>Image options</source>
         <translation>Afbeelding opties</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="142"/>
         <source>Contrast</source>
         <translation>Contrast</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="206"/>
         <source>Options</source>
         <translation>Opties</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="213"/>
         <source>Comics directory</source>
         <translation>Strips map</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="61"/>
         <source>Background color</source>
         <translation>Achtergrondkleur</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="190"/>
         <source>Page Flow</source>
         <translation>Omslagbrowser</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="189"/>
         <source>General</source>
         <translation>Algemeen</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="141"/>
         <source>Brightness</source>
         <translation>Helderheid</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="197"/>
         <source>Restart is needed</source>
         <translation>Herstart is nodig</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="97"/>
         <source>Quick Navigation Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="71"/>
+        <source>Scroll behaviour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="74"/>
+        <source>Do not turn page using scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="75"/>
+        <source>Use single scroll step to turn page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="98"/>
         <source>Disable mouse over activation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="156"/>
         <source>Fit options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="158"/>
         <source>Enlarge images to fit width/height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="169"/>
         <source>Double Page options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="171"/>
         <source>Show covers as single page</source>
         <translation type="unfinished"></translation>
     </message>
@@ -610,34 +502,42 @@
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>7z lib not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>unable to load 7z lib from ./utils</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41"/>
         <source>Trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45"/>
         <source>Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51"/>
         <source>Fatal</source>
         <translation type="unfinished"></translation>
     </message>
@@ -645,14 +545,17 @@
 <context>
     <name>QsLogging::LogWindowModel</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="141"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="143"/>
         <source>Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="145"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
@@ -660,18 +563,22 @@
 <context>
     <name>QsLogging::Window</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="236"/>
         <source>Save log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="237"/>
         <source>Log file (*.log)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -679,14 +586,17 @@
 <context>
     <name>ShortcutsDialog</name>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="23"/>
         <source>Close</source>
         <translation>Sluiten</translation>
     </message>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="19"/>
         <source>YACReader keyboard shortcuts</source>
         <translation>YACReader sneltoetsen</translation>
     </message>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="63"/>
         <source>Keyboard Shortcuts</source>
         <translation>Sneltoetsen</translation>
     </message>
@@ -694,45 +604,537 @@
 <context>
     <name>Viewer</name>
     <message>
+        <location filename="viewer.cpp" line="51"/>
+        <location filename="viewer.cpp" line="915"/>
         <source>Press &apos;O&apos; to open comic.</source>
         <translation>Druk &apos;O&apos; om een strip te openen.</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="1089"/>
         <source>Cover!</source>
         <translation>Omslag!</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="234"/>
         <source>Comic not found</source>
         <translation>Strip niet gevonden</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="234"/>
         <source>Not found</source>
         <translation>Niet gevonden</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="1103"/>
         <source>Last page!</source>
         <translation>Laatste pagina!</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="927"/>
         <source>Loading...please wait!</source>
         <translation>Inladen...even wachten!</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="240"/>
         <source>Error opening comic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="246"/>
         <source>CRC Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="937"/>
         <source>Page not available!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReader::MainWindowViewer</name>
+    <message>
+        <location filename="main_window_viewer.cpp" line="219"/>
+        <source>&amp;Open</source>
+        <translation type="unfinished">&amp;Open</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="221"/>
+        <source>Open a comic</source>
+        <translation type="unfinished">Open een strip</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="227"/>
+        <source>New instance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="246"/>
+        <source>Open Folder</source>
+        <translation type="unfinished">Map Openen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="248"/>
+        <source>Open image folder</source>
+        <translation type="unfinished">Open afbeeldings map</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="253"/>
+        <source>Open latest comic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="254"/>
+        <source>Open the latest comic opened in the previous reading session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="266"/>
+        <source>Clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="267"/>
+        <source>Clear open recent list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="270"/>
+        <source>Save</source>
+        <translation type="unfinished">Bewaar</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="272"/>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>Save current page</source>
+        <translation type="unfinished">Bewaren huidige pagina</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="277"/>
+        <source>Previous Comic</source>
+        <translation type="unfinished">Vorige Strip</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="279"/>
+        <location filename="main_window_viewer.cpp" line="1656"/>
+        <location filename="main_window_viewer.cpp" line="1660"/>
+        <source>Open previous comic</source>
+        <translation type="unfinished">Open de vorige strip</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="284"/>
+        <source>Next Comic</source>
+        <translation type="unfinished">Volgende Strip</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="286"/>
+        <location filename="main_window_viewer.cpp" line="1655"/>
+        <location filename="main_window_viewer.cpp" line="1661"/>
+        <source>Open next comic</source>
+        <translation type="unfinished">Open volgende strip</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="291"/>
+        <source>&amp;Previous</source>
+        <translation type="unfinished">&amp;Vorige</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="294"/>
+        <location filename="main_window_viewer.cpp" line="1658"/>
+        <location filename="main_window_viewer.cpp" line="1662"/>
+        <source>Go to previous page</source>
+        <translation type="unfinished">Ga naar de vorige pagina</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="299"/>
+        <source>&amp;Next</source>
+        <translation type="unfinished">&amp;Volgende</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="302"/>
+        <location filename="main_window_viewer.cpp" line="1657"/>
+        <location filename="main_window_viewer.cpp" line="1663"/>
+        <source>Go to next page</source>
+        <translation type="unfinished">Ga naar de volgende pagina</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="307"/>
+        <source>Fit Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="310"/>
+        <source>Fit image to height</source>
+        <translation type="unfinished">Afbeelding aanpassen aan hoogte</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="317"/>
+        <source>Fit Width</source>
+        <translation type="unfinished">Vensterbreedte aanpassen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="320"/>
+        <source>Fit image to width</source>
+        <translation type="unfinished">Afbeelding aanpassen aan breedte</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="327"/>
+        <source>Show full size</source>
+        <translation type="unfinished">Volledig Scherm </translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="335"/>
+        <source>Fit to page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="366"/>
+        <source>Reset zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="371"/>
+        <source>Show zoom slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="374"/>
+        <source>Zoom+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="379"/>
+        <source>Zoom-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="384"/>
+        <source>Rotate image to the left</source>
+        <translation type="unfinished">Links omdraaien</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="390"/>
+        <source>Rotate image to the right</source>
+        <translation type="unfinished">Rechts omdraaien</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="396"/>
+        <source>Double page mode</source>
+        <translation type="unfinished">Dubbele bladzijde modus</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="397"/>
+        <source>Switch to double page mode</source>
+        <translation type="unfinished">Naar dubbele bladzijde modus</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="406"/>
+        <source>Double page manga mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="407"/>
+        <source>Reverse reading order in double page mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="416"/>
+        <source>Go To</source>
+        <translation type="unfinished">Ga Naar</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="418"/>
+        <source>Go to page ...</source>
+        <translation type="unfinished">Ga naar bladzijde ...</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="423"/>
+        <source>Options</source>
+        <translation type="unfinished">Opties</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="424"/>
+        <source>YACReader options</source>
+        <translation type="unfinished">YACReader opties</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="431"/>
+        <location filename="main_window_viewer.cpp" line="715"/>
+        <source>Help</source>
+        <translation type="unfinished">Help</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="432"/>
+        <source>Help, About YACReader</source>
+        <translation type="unfinished">Help, Over YACReader</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="438"/>
+        <source>Magnifying glass</source>
+        <translation type="unfinished">Vergrootglas</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="439"/>
+        <source>Switch Magnifying glass</source>
+        <translation type="unfinished">Overschakelen naar Vergrootglas</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="446"/>
+        <source>Set bookmark</source>
+        <translation type="unfinished">Bladwijzer instellen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="447"/>
+        <source>Set a bookmark on the current page</source>
+        <translation type="unfinished">Een bladwijzer toevoegen aan de huidige pagina</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="456"/>
+        <source>Show bookmarks</source>
+        <translation type="unfinished">Bladwijzers weergeven</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="457"/>
+        <source>Show the bookmarks of the current comic</source>
+        <translation type="unfinished">Toon de bladwijzers van de huidige strip</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="463"/>
+        <source>Show keyboard shortcuts</source>
+        <translation type="unfinished">Toon de sneltoetsen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="470"/>
+        <source>Show Info</source>
+        <translation type="unfinished">Info tonen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="476"/>
+        <source>Close</source>
+        <translation type="unfinished">Sluiten</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="482"/>
+        <source>Show Dictionary</source>
+        <translation type="unfinished">Woordenlijst weergeven</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="489"/>
+        <source>Show go to flow</source>
+        <translation type="unfinished">Toon ga naar de Omslagbrowser</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="495"/>
+        <source>Edit shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="515"/>
+        <source>&amp;File</source>
+        <translation type="unfinished">&amp;Bestand</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="529"/>
+        <location filename="main_window_viewer.cpp" line="670"/>
+        <source>Open recent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="659"/>
+        <source>File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="680"/>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="684"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="700"/>
+        <source>Go</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="708"/>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="809"/>
+        <location filename="main_window_viewer.cpp" line="811"/>
+        <source>Open Comic</source>
+        <translation type="unfinished">Open een Strip</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="809"/>
+        <location filename="main_window_viewer.cpp" line="811"/>
+        <source>Comic files</source>
+        <translation type="unfinished">Strip bestanden</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="898"/>
+        <source>Open folder</source>
+        <translation type="unfinished">Open een Map</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>page_%1.jpg</source>
+        <translation type="unfinished">pagina_%1.jpg</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>Image files (*.jpg)</source>
+        <translation type="unfinished">Afbeelding bestanden (*.jpg)</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1159"/>
+        <source>Comics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1169"/>
+        <source>Toggle fullscreen mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1172"/>
+        <source>Hide/show toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1175"/>
+        <source>General</source>
+        <translation type="unfinished">Algemeen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1194"/>
+        <source>Size up magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1197"/>
+        <source>Size down magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1200"/>
+        <source>Zoom in magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1203"/>
+        <source>Zoom out magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1209"/>
+        <source>Magnifiying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1216"/>
+        <source>Toggle between fit to width and fit to height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1220"/>
+        <source>Page adjustement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1237"/>
+        <source>Autoscroll down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1240"/>
+        <source>Autoscroll up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1243"/>
+        <source>Autoscroll forward, horizontal first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1247"/>
+        <source>Autoscroll backward, horizontal first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1251"/>
+        <source>Autoscroll forward, vertical first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1255"/>
+        <source>Autoscroll backward, vertical first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1259"/>
+        <source>Move down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1262"/>
+        <source>Move up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1265"/>
+        <source>Move left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1268"/>
+        <source>Move right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1271"/>
+        <source>Go to the first page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1274"/>
+        <source>Go to the last page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1290"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1335"/>
+        <source>There is a new version available</source>
+        <translation type="unfinished">Er is een nieuwe versie beschikbaar</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1336"/>
+        <source>Do you want to download the new version?</source>
+        <translation type="unfinished">Wilt u de nieuwe versie downloaden?</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1339"/>
+        <source>Remind me in 14 days</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1340"/>
+        <source>Not now</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation type="unfinished">Sluiten</translation>
     </message>
@@ -740,10 +1142,13 @@
 <context>
     <name>YACReaderFieldEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11"/>
         <source>Restore to default</source>
         <translation>Standaardwaarden herstellen</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28"/>
         <source>Click to overwrite</source>
         <translation>Klik hier om te overschrijven</translation>
     </message>
@@ -751,10 +1156,15 @@
 <context>
     <name>YACReaderFieldPlainTextEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10"/>
         <source>Restore to default</source>
         <translation>Standaardwaarden herstellen</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50"/>
         <source>Click to overwrite</source>
         <translation>Klik hier om te overschrijven</translation>
     </message>
@@ -762,18 +1172,22 @@
 <context>
     <name>YACReaderFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="15"/>
         <source>CoverFlow look</source>
         <translation>Omslagbrowser uiterlijk </translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="13"/>
         <source>How to show covers:</source>
         <translation>Omslagbladen bekijken:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="16"/>
         <source>Stripe look</source>
         <translation>Brede band </translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="17"/>
         <source>Overlapped Stripe look</source>
         <translation>Overlappende band</translation>
     </message>
@@ -781,94 +1195,117 @@
 <context>
     <name>YACReaderGLFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="112"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="142"/>
         <source>Light</source>
         <translation>Licht</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="76"/>
         <source>Show advanced settings</source>
         <translation>Toon geavanceerde instellingen</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="32"/>
         <source>Roulette look</source>
         <translation>Roulette</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="130"/>
         <source>Cover Angle</source>
         <translation>Omslag hoek</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="23"/>
         <source>Stripe look</source>
         <translation>Brede band</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="94"/>
         <source>Position</source>
         <translation>Positie</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="124"/>
         <source>Z offset</source>
         <translation>Z- positie</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="118"/>
         <source>Y offset</source>
         <translation>Y-positie</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="106"/>
         <source>Central gap</source>
         <translation>Centrale ruimte</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="18"/>
         <source>Presets:</source>
         <translation>Voorinstellingen:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="26"/>
         <source>Overlapped Stripe look</source>
         <translation>Overlappende band</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="29"/>
         <source>Modern look</source>
         <translation>Modern</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="88"/>
         <source>View angle</source>
         <translation>Kijkhoek</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="148"/>
         <source>Max angle</source>
         <translation>Maximale hoek</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="85"/>
         <source>Custom:</source>
         <translation>Aangepast:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="20"/>
         <source>Classic look</source>
         <translation>Klassiek</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="100"/>
         <source>Cover gap</source>
         <translation>Ruimte tss Omslag</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="182"/>
         <source>High Performance</source>
         <translation>Hoge Prestaties</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="201"/>
         <source>Performance:</source>
         <translation>Prestatie:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="193"/>
         <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
         <translation>Gebruik VSync (verbetering van de beeldkwaliteit in de modus volledig scherm, slechtere prestatie)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="136"/>
         <source>Visibility</source>
         <translation>Zichtbaarheid</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="180"/>
         <source>Low Performance</source>
         <translation>Lage Prestaties</translation>
     </message>
@@ -876,22 +1313,27 @@
 <context>
     <name>YACReaderOptionsDialog</name>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28"/>
         <source>Save</source>
         <translation>Bewaar</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="46"/>
         <source>Use hardware acceleration (restart needed)</source>
         <translation>Gebruik hardware versnelling (opnieuw opstarten vereist)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="29"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="34"/>
         <source>Edit shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="37"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -899,6 +1341,7 @@
 <context>
     <name>YACReaderSlider</name>
     <message>
+        <location filename="width_slider.cpp" line="49"/>
         <source>Reset</source>
         <translation>Standaardwaarden terugzetten</translation>
     </message>
@@ -906,18 +1349,23 @@
 <context>
     <name>YACReaderTranslator</name>
     <message>
+        <location filename="translator.cpp" line="62"/>
         <source>YACReader translator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="116"/>
+        <location filename="translator.cpp" line="207"/>
         <source>Translation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="139"/>
         <source>clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="216"/>
         <source>Service not available</source>
         <translation type="unfinished"></translation>
     </message>

--- a/YACReader/yacreader_pt.ts
+++ b/YACReader/yacreader_pt.ts
@@ -4,6 +4,7 @@
 <context>
     <name>ActionsShortcutsModel</name>
     <message>
+        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="73"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11,18 +12,23 @@
 <context>
     <name>BookmarksDialog</name>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="75"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="107"/>
+        <location filename="bookmarks_dialog.cpp" line="124"/>
         <source>Loading...</source>
         <translation>Carregando...</translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="85"/>
         <source>Click on any image to go to the bookmark</source>
         <translation>Clique em qualquer imagem para ir para o marcador</translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="25"/>
         <source>Lastest Page</source>
         <translation>Última Página</translation>
     </message>
@@ -30,22 +36,27 @@
 <context>
     <name>EditShortcutsDialog</name>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="21"/>
         <source>Restore defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="22"/>
         <source>To change a shortcut, double click in the key combination and type the new keys.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="69"/>
         <source>Shortcuts settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>Shortcut in use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>The shortcut &quot;%1&quot; is already assigned to other function</source>
         <translation type="unfinished"></translation>
     </message>
@@ -53,18 +64,22 @@
 <context>
     <name>FileComic</name>
     <message>
+        <location filename="../common/comic.cpp" line="562"/>
         <source>7z not found</source>
         <translation>7z não encontrado</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="454"/>
         <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="461"/>
         <source>Unknown error opening the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="568"/>
         <source>Format not supported</source>
         <translation type="unfinished"></translation>
     </message>
@@ -72,22 +87,28 @@
 <context>
     <name>GoToDialog</name>
     <message>
+        <location filename="goto_dialog.cpp" line="23"/>
         <source>Go To</source>
         <translation>Ir Para</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="53"/>
         <source>Go to...</source>
         <translation>Ir para...</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="39"/>
+        <location filename="goto_dialog.cpp" line="71"/>
         <source>Total pages : </source>
         <translation>Total de páginas : </translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="25"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="15"/>
         <source>Page : </source>
         <translation>Página : </translation>
     </message>
@@ -95,6 +116,7 @@
 <context>
     <name>GoToFlowToolBar</name>
     <message>
+        <location filename="goto_flow_toolbar.cpp" line="38"/>
         <source>Page : </source>
         <translation>Página : </translation>
     </message>
@@ -102,10 +124,17 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Ajuda</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
+        <source>System info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
@@ -113,30 +142,37 @@
 <context>
     <name>LogWindow</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="14"/>
         <source>Log window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="22"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="39"/>
         <source>&amp;Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="56"/>
         <source>C&amp;lear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="73"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="90"/>
         <source>Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="136"/>
         <source>&amp;Auto scroll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -145,464 +181,280 @@
     <name>MainWindowViewer</name>
     <message>
         <source>Help</source>
-        <translation>Ajuda</translation>
+        <translation type="vanished">Ajuda</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation>Salvar</translation>
+        <translation type="vanished">Salvar</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation>&amp;Arquivo</translation>
+        <translation type="vanished">&amp;Arquivo</translation>
     </message>
     <message>
         <source>&amp;Next</source>
-        <translation>&amp;Próxima</translation>
+        <translation type="vanished">&amp;Próxima</translation>
     </message>
     <message>
         <source>&amp;Open</source>
-        <translation>&amp;Abrir</translation>
+        <translation type="vanished">&amp;Abrir</translation>
     </message>
     <message>
         <source>Close</source>
-        <translation>Fechar</translation>
+        <translation type="vanished">Fechar</translation>
     </message>
     <message>
         <source>Open Comic</source>
-        <translation>Abrir Quadrinho</translation>
+        <translation type="vanished">Abrir Quadrinho</translation>
     </message>
     <message>
         <source>Go To</source>
-        <translation>Ir Para</translation>
+        <translation type="vanished">Ir Para</translation>
     </message>
     <message>
         <source>Set bookmark</source>
-        <translation>Definir marcador</translation>
+        <translation type="vanished">Definir marcador</translation>
     </message>
     <message>
         <source>Switch to double page mode</source>
-        <translation>Alternar para o modo dupla página</translation>
+        <translation type="vanished">Alternar para o modo dupla página</translation>
     </message>
     <message>
         <source>Save current page</source>
-        <translation>Salvar página atual</translation>
+        <translation type="vanished">Salvar página atual</translation>
     </message>
     <message>
         <source>Double page mode</source>
-        <translation>Modo dupla página</translation>
+        <translation type="vanished">Modo dupla página</translation>
     </message>
     <message>
         <source>Switch Magnifying glass</source>
-        <translation>Alternar Lupa</translation>
+        <translation type="vanished">Alternar Lupa</translation>
     </message>
     <message>
         <source>Open Folder</source>
-        <translation>Abrir Pasta</translation>
+        <translation type="vanished">Abrir Pasta</translation>
     </message>
     <message>
         <source>Go to previous page</source>
-        <translation>Ir para a página anterior</translation>
+        <translation type="vanished">Ir para a página anterior</translation>
     </message>
     <message>
         <source>Open a comic</source>
-        <translation>Abrir um quadrinho</translation>
+        <translation type="vanished">Abrir um quadrinho</translation>
     </message>
     <message>
         <source>Image files (*.jpg)</source>
-        <translation>Arquivos de imagem (*.jpg)</translation>
+        <translation type="vanished">Arquivos de imagem (*.jpg)</translation>
     </message>
     <message>
         <source>Next Comic</source>
-        <translation>Próximo Quadrinho</translation>
+        <translation type="vanished">Próximo Quadrinho</translation>
     </message>
     <message>
         <source>Fit Width</source>
-        <translation>Ajustar à Largura</translation>
+        <translation type="vanished">Ajustar à Largura</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation>Opções</translation>
+        <translation type="vanished">Opções</translation>
     </message>
     <message>
         <source>Show Info</source>
-        <translation>Mostrar Informações</translation>
+        <translation type="vanished">Mostrar Informações</translation>
     </message>
     <message>
         <source>Open folder</source>
-        <translation>Abrir pasta</translation>
+        <translation type="vanished">Abrir pasta</translation>
     </message>
     <message>
         <source>Go to page ...</source>
-        <translation>Ir para a página...</translation>
+        <translation type="vanished">Ir para a página...</translation>
     </message>
     <message>
         <source>&amp;Previous</source>
-        <translation>A&amp;nterior</translation>
+        <translation type="vanished">A&amp;nterior</translation>
     </message>
     <message>
         <source>Go to next page</source>
-        <translation>Ir para a próxima página</translation>
+        <translation type="vanished">Ir para a próxima página</translation>
     </message>
     <message>
         <source>Show keyboard shortcuts</source>
-        <translation>Mostrar teclas de atalhos</translation>
+        <translation type="vanished">Mostrar teclas de atalhos</translation>
     </message>
     <message>
         <source>There is a new version available</source>
-        <translation>Há uma nova versão disponível</translation>
+        <translation type="vanished">Há uma nova versão disponível</translation>
     </message>
     <message>
         <source>Open next comic</source>
-        <translation>Abrir próximo quadrinho</translation>
+        <translation type="vanished">Abrir próximo quadrinho</translation>
     </message>
     <message>
         <source>Show bookmarks</source>
-        <translation>Mostrar marcadores</translation>
+        <translation type="vanished">Mostrar marcadores</translation>
     </message>
     <message>
         <source>Open previous comic</source>
-        <translation>Abrir quadrinho anterior</translation>
+        <translation type="vanished">Abrir quadrinho anterior</translation>
     </message>
     <message>
         <source>Rotate image to the left</source>
-        <translation>Girar imagem à esquerda</translation>
+        <translation type="vanished">Girar imagem à esquerda</translation>
     </message>
     <message>
         <source>Show the bookmarks of the current comic</source>
-        <translation>Mostrar os marcadores do quadrinho atual</translation>
+        <translation type="vanished">Mostrar os marcadores do quadrinho atual</translation>
     </message>
     <message>
         <source>YACReader options</source>
-        <translation>Opções do YACReader</translation>
+        <translation type="vanished">Opções do YACReader</translation>
     </message>
     <message>
         <source>Help, About YACReader</source>
-        <translation>Ajuda, Sobre o YACReader</translation>
+        <translation type="vanished">Ajuda, Sobre o YACReader</translation>
     </message>
     <message>
         <source>Previous Comic</source>
-        <translation>Quadrinho Anterior</translation>
+        <translation type="vanished">Quadrinho Anterior</translation>
     </message>
     <message>
         <source>Magnifying glass</source>
-        <translation>Lupa</translation>
+        <translation type="vanished">Lupa</translation>
     </message>
     <message>
         <source>Set a bookmark on the current page</source>
-        <translation>Definir um marcador na página atual</translation>
+        <translation type="vanished">Definir um marcador na página atual</translation>
     </message>
     <message>
         <source>Do you want to download the new version?</source>
-        <translation>Você deseja baixar a nova versão?</translation>
+        <translation type="vanished">Você deseja baixar a nova versão?</translation>
     </message>
     <message>
         <source>Rotate image to the right</source>
-        <translation>Girar imagem à direita</translation>
-    </message>
-    <message>
-        <source>New instance</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open image folder</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open latest comic</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open the latest comic opened in the previous reading session</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Clear</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Clear open recent list</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fit Height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fit image to height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fit image to width</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show full size</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Fit to page</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reset zoom</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show zoom slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Zoom+</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Zoom-</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Double page manga mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reverse reading order in double page mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show Dictionary</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Always on top</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Show go to flow</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit shortcuts</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Open recent</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>File</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Edit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>View</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Go</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Window</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Comic files</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>page_%1.jpg</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Comics</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Toggle fullscreen mode</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Hide/show toolbar</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>General</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Size up magnifying glass</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Size down magnifying glass</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Zoom in magnifying glass</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Zoom out magnifying glass</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Magnifiying glass</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Toggle between fit to width and fit to height</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Page adjustement</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Autoscroll down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Autoscroll up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Autoscroll forward, horizontal first</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Autoscroll backward, horizontal first</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Autoscroll forward, vertical first</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Autoscroll backward, vertical first</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move down</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move up</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move left</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Move right</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Go to the first page</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Go to the last page</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Reading</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Remind me in 14 days</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <source>Not now</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">Girar imagem à direita</translation>
     </message>
 </context>
 <context>
     <name>OptionsDialog</name>
     <message>
+        <location filename="options_dialog.cpp" line="34"/>
         <source>My comics path</source>
         <translation>Meu caminho de quadrinhos</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="43"/>
         <source>&quot;Go to flow&quot; size</source>
         <translation>Tamanho do &quot;Ir para cheia&quot;</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="206"/>
         <source>Options</source>
         <translation>Opções</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="213"/>
         <source>Comics directory</source>
         <translation>Diretório de quadrinhos</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="197"/>
         <source>Restart is needed</source>
         <translation>Reiniciar é necessário</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="61"/>
         <source>Background color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="64"/>
         <source>Choose</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="71"/>
+        <source>Scroll behaviour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="74"/>
+        <source>Do not turn page using scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="75"/>
+        <source>Use single scroll step to turn page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="97"/>
         <source>Quick Navigation Mode</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="98"/>
         <source>Disable mouse over activation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="141"/>
         <source>Brightness</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="142"/>
         <source>Contrast</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="143"/>
         <source>Gamma</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="147"/>
         <source>Reset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="152"/>
         <source>Image options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="156"/>
         <source>Fit options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="158"/>
         <source>Enlarge images to fit width/height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="169"/>
         <source>Double Page options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="171"/>
         <source>Show covers as single page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="189"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="190"/>
         <source>Page Flow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="191"/>
         <source>Image adjustment</source>
         <translation type="unfinished"></translation>
     </message>
@@ -610,34 +462,42 @@
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>7z lib not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>unable to load 7z lib from ./utils</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41"/>
         <source>Trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45"/>
         <source>Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51"/>
         <source>Fatal</source>
         <translation type="unfinished"></translation>
     </message>
@@ -645,14 +505,17 @@
 <context>
     <name>QsLogging::LogWindowModel</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="141"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="143"/>
         <source>Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="145"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
@@ -660,18 +523,22 @@
 <context>
     <name>QsLogging::Window</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="236"/>
         <source>Save log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="237"/>
         <source>Log file (*.log)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -679,14 +546,17 @@
 <context>
     <name>ShortcutsDialog</name>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="23"/>
         <source>Close</source>
         <translation>Fechar</translation>
     </message>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="19"/>
         <source>YACReader keyboard shortcuts</source>
         <translation>Teclas de atalhos do YACReader</translation>
     </message>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="63"/>
         <source>Keyboard Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -694,45 +564,537 @@
 <context>
     <name>Viewer</name>
     <message>
+        <location filename="viewer.cpp" line="51"/>
+        <location filename="viewer.cpp" line="915"/>
         <source>Press &apos;O&apos; to open comic.</source>
         <translation>Pressione &apos;O&apos; para abrir um quadrinho.</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="927"/>
         <source>Loading...please wait!</source>
         <translation>Carregando... por favor, aguarde!</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="234"/>
         <source>Not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="234"/>
         <source>Comic not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="240"/>
         <source>Error opening comic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="246"/>
         <source>CRC Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="937"/>
         <source>Page not available!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="1089"/>
         <source>Cover!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="1103"/>
         <source>Last page!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReader::MainWindowViewer</name>
+    <message>
+        <location filename="main_window_viewer.cpp" line="219"/>
+        <source>&amp;Open</source>
+        <translation type="unfinished">&amp;Abrir</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="221"/>
+        <source>Open a comic</source>
+        <translation type="unfinished">Abrir um quadrinho</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="227"/>
+        <source>New instance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="246"/>
+        <source>Open Folder</source>
+        <translation type="unfinished">Abrir Pasta</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="248"/>
+        <source>Open image folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="253"/>
+        <source>Open latest comic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="254"/>
+        <source>Open the latest comic opened in the previous reading session</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="266"/>
+        <source>Clear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="267"/>
+        <source>Clear open recent list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="270"/>
+        <source>Save</source>
+        <translation type="unfinished">Salvar</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="272"/>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>Save current page</source>
+        <translation type="unfinished">Salvar página atual</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="277"/>
+        <source>Previous Comic</source>
+        <translation type="unfinished">Quadrinho Anterior</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="279"/>
+        <location filename="main_window_viewer.cpp" line="1656"/>
+        <location filename="main_window_viewer.cpp" line="1660"/>
+        <source>Open previous comic</source>
+        <translation type="unfinished">Abrir quadrinho anterior</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="284"/>
+        <source>Next Comic</source>
+        <translation type="unfinished">Próximo Quadrinho</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="286"/>
+        <location filename="main_window_viewer.cpp" line="1655"/>
+        <location filename="main_window_viewer.cpp" line="1661"/>
+        <source>Open next comic</source>
+        <translation type="unfinished">Abrir próximo quadrinho</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="291"/>
+        <source>&amp;Previous</source>
+        <translation type="unfinished">A&amp;nterior</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="294"/>
+        <location filename="main_window_viewer.cpp" line="1658"/>
+        <location filename="main_window_viewer.cpp" line="1662"/>
+        <source>Go to previous page</source>
+        <translation type="unfinished">Ir para a página anterior</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="299"/>
+        <source>&amp;Next</source>
+        <translation type="unfinished">&amp;Próxima</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="302"/>
+        <location filename="main_window_viewer.cpp" line="1657"/>
+        <location filename="main_window_viewer.cpp" line="1663"/>
+        <source>Go to next page</source>
+        <translation type="unfinished">Ir para a próxima página</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="307"/>
+        <source>Fit Height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="310"/>
+        <source>Fit image to height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="317"/>
+        <source>Fit Width</source>
+        <translation type="unfinished">Ajustar à Largura</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="320"/>
+        <source>Fit image to width</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="327"/>
+        <source>Show full size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="335"/>
+        <source>Fit to page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="366"/>
+        <source>Reset zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="371"/>
+        <source>Show zoom slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="374"/>
+        <source>Zoom+</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="379"/>
+        <source>Zoom-</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="384"/>
+        <source>Rotate image to the left</source>
+        <translation type="unfinished">Girar imagem à esquerda</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="390"/>
+        <source>Rotate image to the right</source>
+        <translation type="unfinished">Girar imagem à direita</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="396"/>
+        <source>Double page mode</source>
+        <translation type="unfinished">Modo dupla página</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="397"/>
+        <source>Switch to double page mode</source>
+        <translation type="unfinished">Alternar para o modo dupla página</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="406"/>
+        <source>Double page manga mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="407"/>
+        <source>Reverse reading order in double page mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="416"/>
+        <source>Go To</source>
+        <translation type="unfinished">Ir Para</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="418"/>
+        <source>Go to page ...</source>
+        <translation type="unfinished">Ir para a página...</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="423"/>
+        <source>Options</source>
+        <translation type="unfinished">Opções</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="424"/>
+        <source>YACReader options</source>
+        <translation type="unfinished">Opções do YACReader</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="431"/>
+        <location filename="main_window_viewer.cpp" line="715"/>
+        <source>Help</source>
+        <translation type="unfinished">Ajuda</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="432"/>
+        <source>Help, About YACReader</source>
+        <translation type="unfinished">Ajuda, Sobre o YACReader</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="438"/>
+        <source>Magnifying glass</source>
+        <translation type="unfinished">Lupa</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="439"/>
+        <source>Switch Magnifying glass</source>
+        <translation type="unfinished">Alternar Lupa</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="446"/>
+        <source>Set bookmark</source>
+        <translation type="unfinished">Definir marcador</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="447"/>
+        <source>Set a bookmark on the current page</source>
+        <translation type="unfinished">Definir um marcador na página atual</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="456"/>
+        <source>Show bookmarks</source>
+        <translation type="unfinished">Mostrar marcadores</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="457"/>
+        <source>Show the bookmarks of the current comic</source>
+        <translation type="unfinished">Mostrar os marcadores do quadrinho atual</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="463"/>
+        <source>Show keyboard shortcuts</source>
+        <translation type="unfinished">Mostrar teclas de atalhos</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="470"/>
+        <source>Show Info</source>
+        <translation type="unfinished">Mostrar Informações</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="476"/>
+        <source>Close</source>
+        <translation type="unfinished">Fechar</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="482"/>
+        <source>Show Dictionary</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="489"/>
+        <source>Show go to flow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="495"/>
+        <source>Edit shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="515"/>
+        <source>&amp;File</source>
+        <translation type="unfinished">&amp;Arquivo</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="529"/>
+        <location filename="main_window_viewer.cpp" line="670"/>
+        <source>Open recent</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="659"/>
+        <source>File</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="680"/>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="684"/>
+        <source>View</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="700"/>
+        <source>Go</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="708"/>
+        <source>Window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="809"/>
+        <location filename="main_window_viewer.cpp" line="811"/>
+        <source>Open Comic</source>
+        <translation type="unfinished">Abrir Quadrinho</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="809"/>
+        <location filename="main_window_viewer.cpp" line="811"/>
+        <source>Comic files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="898"/>
+        <source>Open folder</source>
+        <translation type="unfinished">Abrir pasta</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>page_%1.jpg</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>Image files (*.jpg)</source>
+        <translation type="unfinished">Arquivos de imagem (*.jpg)</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1159"/>
+        <source>Comics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1169"/>
+        <source>Toggle fullscreen mode</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1172"/>
+        <source>Hide/show toolbar</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1175"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1194"/>
+        <source>Size up magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1197"/>
+        <source>Size down magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1200"/>
+        <source>Zoom in magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1203"/>
+        <source>Zoom out magnifying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1209"/>
+        <source>Magnifiying glass</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1216"/>
+        <source>Toggle between fit to width and fit to height</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1220"/>
+        <source>Page adjustement</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1237"/>
+        <source>Autoscroll down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1240"/>
+        <source>Autoscroll up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1243"/>
+        <source>Autoscroll forward, horizontal first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1247"/>
+        <source>Autoscroll backward, horizontal first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1251"/>
+        <source>Autoscroll forward, vertical first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1255"/>
+        <source>Autoscroll backward, vertical first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1259"/>
+        <source>Move down</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1262"/>
+        <source>Move up</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1265"/>
+        <source>Move left</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1268"/>
+        <source>Move right</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1271"/>
+        <source>Go to the first page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1274"/>
+        <source>Go to the last page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1290"/>
+        <source>Reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1335"/>
+        <source>There is a new version available</source>
+        <translation type="unfinished">Há uma nova versão disponível</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1336"/>
+        <source>Do you want to download the new version?</source>
+        <translation type="unfinished">Você deseja baixar a nova versão?</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1339"/>
+        <source>Remind me in 14 days</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1340"/>
+        <source>Not now</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation type="unfinished">Fechar</translation>
     </message>
@@ -740,10 +1102,13 @@
 <context>
     <name>YACReaderFieldEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28"/>
         <source>Click to overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11"/>
         <source>Restore to default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -751,10 +1116,15 @@
 <context>
     <name>YACReaderFieldPlainTextEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50"/>
         <source>Click to overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10"/>
         <source>Restore to default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -762,18 +1132,22 @@
 <context>
     <name>YACReaderFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="15"/>
         <source>CoverFlow look</source>
         <translation>Olhar capa cheia</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="16"/>
         <source>Stripe look</source>
         <translation>Olhar lista</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="17"/>
         <source>Overlapped Stripe look</source>
         <translation>Olhar lista sobreposta</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="13"/>
         <source>How to show covers:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -781,94 +1155,117 @@
 <context>
     <name>YACReaderGLFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="23"/>
         <source>Stripe look</source>
         <translation>Olhar lista</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="26"/>
         <source>Overlapped Stripe look</source>
         <translation>Olhar lista sobreposta</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="18"/>
         <source>Presets:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="20"/>
         <source>Classic look</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="29"/>
         <source>Modern look</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="32"/>
         <source>Roulette look</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="76"/>
         <source>Show advanced settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="85"/>
         <source>Custom:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="88"/>
         <source>View angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="94"/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="100"/>
         <source>Cover gap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="106"/>
         <source>Central gap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="112"/>
         <source>Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="118"/>
         <source>Y offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="124"/>
         <source>Z offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="130"/>
         <source>Cover Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="136"/>
         <source>Visibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="142"/>
         <source>Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="148"/>
         <source>Max angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="180"/>
         <source>Low Performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="182"/>
         <source>High Performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="193"/>
         <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="201"/>
         <source>Performance:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -876,22 +1273,27 @@
 <context>
     <name>YACReaderOptionsDialog</name>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28"/>
         <source>Save</source>
         <translation>Salvar</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="29"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="34"/>
         <source>Edit shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="37"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="46"/>
         <source>Use hardware acceleration (restart needed)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -899,6 +1301,7 @@
 <context>
     <name>YACReaderSlider</name>
     <message>
+        <location filename="width_slider.cpp" line="49"/>
         <source>Reset</source>
         <translation type="unfinished"></translation>
     </message>
@@ -906,18 +1309,23 @@
 <context>
     <name>YACReaderTranslator</name>
     <message>
+        <location filename="translator.cpp" line="62"/>
         <source>YACReader translator</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="116"/>
+        <location filename="translator.cpp" line="207"/>
         <source>Translation</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="139"/>
         <source>clear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="216"/>
         <source>Service not available</source>
         <translation type="unfinished"></translation>
     </message>

--- a/YACReader/yacreader_ru.ts
+++ b/YACReader/yacreader_ru.ts
@@ -4,6 +4,7 @@
 <context>
     <name>ActionsShortcutsModel</name>
     <message>
+        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="73"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11,18 +12,23 @@
 <context>
     <name>BookmarksDialog</name>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="75"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="107"/>
+        <location filename="bookmarks_dialog.cpp" line="124"/>
         <source>Loading...</source>
         <translation>Загрузка...</translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="85"/>
         <source>Click on any image to go to the bookmark</source>
         <translation>Нажмите на любое изображение чтобы перейти к закладке</translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="25"/>
         <source>Lastest Page</source>
         <translation>Последняя страница</translation>
     </message>
@@ -30,22 +36,27 @@
 <context>
     <name>EditShortcutsDialog</name>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>Shortcut in use</source>
         <translation>Горячая клавиша уже занята</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="21"/>
         <source>Restore defaults</source>
         <translation>Восстановить значения по умолчанию</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="69"/>
         <source>Shortcuts settings</source>
         <translation>Горячие клавиши</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>The shortcut &quot;%1&quot; is already assigned to other function</source>
         <translation>Сочетание клавиш &quot;%1&quot; уже назначено для другой функции</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="22"/>
         <source>To change a shortcut, double click in the key combination and type the new keys.</source>
         <translation>Чтобы изменить горячую клавишу дважды щелкните по выбранной комбинации клавиш и введите новые сочетания клавиш.</translation>
     </message>
@@ -53,18 +64,22 @@
 <context>
     <name>FileComic</name>
     <message>
+        <location filename="../common/comic.cpp" line="568"/>
         <source>Format not supported</source>
         <translation>Формат не поддерживается</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="562"/>
         <source>7z not found</source>
         <translation>7z не найден</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="461"/>
         <source>Unknown error opening the file</source>
         <translation>Неизвестная ошибка при открытии файла</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="454"/>
         <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
         <translation>Ошибка контрольной суммы CRC на странице (%1): некоторые страницы будут отображаться неправильно</translation>
     </message>
@@ -72,22 +87,28 @@
 <context>
     <name>GoToDialog</name>
     <message>
+        <location filename="goto_dialog.cpp" line="23"/>
         <source>Go To</source>
         <translation>Перейти к странице...</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="53"/>
         <source>Go to...</source>
         <translation>Перейти к странице...</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="39"/>
+        <location filename="goto_dialog.cpp" line="71"/>
         <source>Total pages : </source>
         <translation>Общее количество страниц : </translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="25"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="15"/>
         <source>Page : </source>
         <translation>Страница :</translation>
     </message>
@@ -95,6 +116,7 @@
 <context>
     <name>GoToFlowToolBar</name>
     <message>
+        <location filename="goto_flow_toolbar.cpp" line="38"/>
         <source>Page : </source>
         <translation>Страница :</translation>
     </message>
@@ -102,10 +124,17 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Справка</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
+        <source>System info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation>О программе</translation>
     </message>
@@ -113,30 +142,37 @@
 <context>
     <name>LogWindow</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="14"/>
         <source>Log window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="22"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="39"/>
         <source>&amp;Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="56"/>
         <source>C&amp;lear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="73"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="90"/>
         <source>Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="136"/>
         <source>&amp;Auto scroll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -145,464 +181,496 @@
     <name>MainWindowViewer</name>
     <message>
         <source>Go</source>
-        <translation>Перейти</translation>
+        <translation type="vanished">Перейти</translation>
     </message>
     <message>
         <source>Edit</source>
-        <translation>Редактировать</translation>
+        <translation type="vanished">Редактировать</translation>
     </message>
     <message>
         <source>File</source>
-        <translation>Файл</translation>
+        <translation type="vanished">Файл</translation>
     </message>
     <message>
         <source>Help</source>
-        <translation>Справка</translation>
+        <translation type="vanished">Справка</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation>Сохранить</translation>
+        <translation type="vanished">Сохранить</translation>
     </message>
     <message>
         <source>View</source>
-        <translation>Посмотреть</translation>
+        <translation type="vanished">Посмотреть</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation>&amp;Отображать панель инструментов</translation>
+        <translation type="vanished">&amp;Отображать панель инструментов</translation>
     </message>
     <message>
         <source>&amp;Next</source>
-        <translation>&amp;Следующий</translation>
+        <translation type="vanished">&amp;Следующий</translation>
     </message>
     <message>
         <source>&amp;Open</source>
-        <translation>&amp;Открыть</translation>
+        <translation type="vanished">&amp;Открыть</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation>Очистить</translation>
+        <translation type="vanished">Очистить</translation>
     </message>
     <message>
         <source>Close</source>
-        <translation>Закрыть</translation>
+        <translation type="vanished">Закрыть</translation>
     </message>
     <message>
         <source>Open Comic</source>
-        <translation>Открыть комикс</translation>
+        <translation type="vanished">Открыть комикс</translation>
     </message>
     <message>
         <source>Go To</source>
-        <translation>Перейти к странице...</translation>
+        <translation type="vanished">Перейти к странице...</translation>
     </message>
     <message>
         <source>Zoom+</source>
-        <translation>Увеличить масштаб</translation>
+        <translation type="vanished">Увеличить масштаб</translation>
     </message>
     <message>
         <source>Zoom-</source>
-        <translation>Уменьшить масштаб</translation>
+        <translation type="vanished">Уменьшить масштаб</translation>
     </message>
     <message>
         <source>Open image folder</source>
-        <translation>Открыть папку с изображениями</translation>
+        <translation type="vanished">Открыть папку с изображениями</translation>
     </message>
     <message>
         <source>Size down magnifying glass</source>
-        <translation>Уменьшение размера окошка увеличительного стекла</translation>
+        <translation type="vanished">Уменьшение размера окошка увеличительного стекла</translation>
     </message>
     <message>
         <source>Zoom out magnifying glass</source>
-        <translation>Уменьшить</translation>
+        <translation type="vanished">Уменьшить</translation>
     </message>
     <message>
         <source>Open latest comic</source>
-        <translation>Открыть последний комикс</translation>
+        <translation type="vanished">Открыть последний комикс</translation>
     </message>
     <message>
         <source>Autoscroll up</source>
-        <translation>Автопрокрутка вверх</translation>
+        <translation type="vanished">Автопрокрутка вверх</translation>
     </message>
     <message>
         <source>Set bookmark</source>
-        <translation>Установить закладку</translation>
+        <translation type="vanished">Установить закладку</translation>
     </message>
     <message>
         <source>page_%1.jpg</source>
-        <translation>страница_%1.jpg</translation>
+        <translation type="vanished">страница_%1.jpg</translation>
     </message>
     <message>
         <source>Autoscroll forward, vertical first</source>
-        <translation>Автопрокрутка вперед, вертикальная</translation>
+        <translation type="vanished">Автопрокрутка вперед, вертикальная</translation>
     </message>
     <message>
         <source>Switch to double page mode</source>
-        <translation>Двухстраничный режим</translation>
+        <translation type="vanished">Двухстраничный режим</translation>
     </message>
     <message>
         <source>Save current page</source>
-        <translation>Сохранить текущию страницу</translation>
+        <translation type="vanished">Сохранить текущию страницу</translation>
     </message>
     <message>
         <source>Size up magnifying glass</source>
-        <translation>Увеличение размера окошка увеличительного стекла</translation>
+        <translation type="vanished">Увеличение размера окошка увеличительного стекла</translation>
     </message>
     <message>
         <source>Double page mode</source>
-        <translation>Двухстраничный режим</translation>
+        <translation type="vanished">Двухстраничный режим</translation>
     </message>
     <message>
         <source>Move up</source>
-        <translation>Переместить вверх</translation>
+        <translation type="vanished">Переместить вверх</translation>
     </message>
     <message>
         <source>Switch Magnifying glass</source>
-        <translation>Увеличительное стекло</translation>
+        <translation type="vanished">Увеличительное стекло</translation>
     </message>
     <message>
         <source>Open Folder</source>
-        <translation>Открыть папку</translation>
+        <translation type="vanished">Открыть папку</translation>
     </message>
     <message>
         <source>Comics</source>
-        <translation>Комикс</translation>
+        <translation type="vanished">Комикс</translation>
     </message>
     <message>
         <source>Fit Height</source>
-        <translation>Подогнать по высоте</translation>
+        <translation type="vanished">Подогнать по высоте</translation>
     </message>
     <message>
         <source>Autoscroll backward, vertical first</source>
-        <translation>Автопрокрутка назад, вертикальная</translation>
+        <translation type="vanished">Автопрокрутка назад, вертикальная</translation>
     </message>
     <message>
         <source>Comic files</source>
-        <translation>Файлы комикса </translation>
+        <translation type="vanished">Файлы комикса </translation>
     </message>
     <message>
         <source>Not now</source>
-        <translation>Не сейчас</translation>
+        <translation type="vanished">Не сейчас</translation>
     </message>
     <message>
         <source>Go to the first page</source>
-        <translation>Перейти к первой странице</translation>
+        <translation type="vanished">Перейти к первой странице</translation>
     </message>
     <message>
         <source>Go to previous page</source>
-        <translation>Перейти к предыдущей странице</translation>
+        <translation type="vanished">Перейти к предыдущей странице</translation>
     </message>
     <message>
         <source>Window</source>
-        <translation>Окно</translation>
+        <translation type="vanished">Окно</translation>
     </message>
     <message>
         <source>Open the latest comic opened in the previous reading session</source>
-        <translation>Открыть комикс открытый в предыдущем сеансе чтения</translation>
+        <translation type="vanished">Открыть комикс открытый в предыдущем сеансе чтения</translation>
     </message>
     <message>
         <source>Open a comic</source>
-        <translation>Открыть комикс</translation>
+        <translation type="vanished">Открыть комикс</translation>
     </message>
     <message>
         <source>Image files (*.jpg)</source>
-        <translation>Файлы изображений (*.jpg)</translation>
+        <translation type="vanished">Файлы изображений (*.jpg)</translation>
     </message>
     <message>
         <source>Next Comic</source>
-        <translation>Следующий комикс</translation>
+        <translation type="vanished">Следующий комикс</translation>
     </message>
     <message>
         <source>Fit Width</source>
-        <translation>Подогнать по ширине</translation>
+        <translation type="vanished">Подогнать по ширине</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation>Настройки</translation>
+        <translation type="vanished">Настройки</translation>
     </message>
     <message>
         <source>Show Info</source>
-        <translation>Показать/скрыть номер страницы и текущее время</translation>
+        <translation type="vanished">Показать/скрыть номер страницы и текущее время</translation>
     </message>
     <message>
         <source>Open folder</source>
-        <translation>Открыть папку</translation>
+        <translation type="vanished">Открыть папку</translation>
     </message>
     <message>
         <source>Go to page ...</source>
-        <translation>Перейти к странице...</translation>
+        <translation type="vanished">Перейти к странице...</translation>
     </message>
     <message>
         <source>Magnifiying glass</source>
-        <translation>Увеличительное стекло</translation>
+        <translation type="vanished">Увеличительное стекло</translation>
     </message>
     <message>
         <source>Fit image to width</source>
-        <translation>Подогнать по ширине</translation>
+        <translation type="vanished">Подогнать по ширине</translation>
     </message>
     <message>
         <source>Toggle fullscreen mode</source>
-        <translation>Полноэкранный режим включить/выключить</translation>
+        <translation type="vanished">Полноэкранный режим включить/выключить</translation>
     </message>
     <message>
         <source>Toggle between fit to width and fit to height</source>
-        <translation>Переключение режима подгонки страницы по ширине/высоте</translation>
+        <translation type="vanished">Переключение режима подгонки страницы по ширине/высоте</translation>
     </message>
     <message>
         <source>Move right</source>
-        <translation>Переместить вправо</translation>
+        <translation type="vanished">Переместить вправо</translation>
     </message>
     <message>
         <source>Zoom in magnifying glass</source>
-        <translation>Увеличить</translation>
+        <translation type="vanished">Увеличить</translation>
     </message>
     <message>
         <source>Open recent</source>
-        <translation>Открыть недавние</translation>
+        <translation type="vanished">Открыть недавние</translation>
     </message>
     <message>
         <source>Reading</source>
-        <translation>Чтение</translation>
+        <translation type="vanished">Чтение</translation>
     </message>
     <message>
         <source>&amp;Previous</source>
-        <translation>&amp;Предыдущий</translation>
+        <translation type="vanished">&amp;Предыдущий</translation>
     </message>
     <message>
         <source>Autoscroll forward, horizontal first</source>
-        <translation>Автопрокрутка вперед, горизонтальная</translation>
+        <translation type="vanished">Автопрокрутка вперед, горизонтальная</translation>
     </message>
     <message>
         <source>Go to next page</source>
-        <translation>Перейти к следующей странице</translation>
+        <translation type="vanished">Перейти к следующей странице</translation>
     </message>
     <message>
         <source>Show keyboard shortcuts</source>
-        <translation>Показать горячие клавиши</translation>
+        <translation type="vanished">Показать горячие клавиши</translation>
     </message>
     <message>
         <source>Double page manga mode</source>
-        <translation>Двухстраничный режим манги</translation>
+        <translation type="vanished">Двухстраничный режим манги</translation>
     </message>
     <message>
         <source>There is a new version available</source>
-        <translation>Доступна новая версия</translation>
+        <translation type="vanished">Доступна новая версия</translation>
     </message>
     <message>
         <source>Autoscroll down</source>
-        <translation>Автопрокрутка вниз</translation>
+        <translation type="vanished">Автопрокрутка вниз</translation>
     </message>
     <message>
         <source>Open next comic</source>
-        <translation>Открыть следующий комикс</translation>
+        <translation type="vanished">Открыть следующий комикс</translation>
     </message>
     <message>
         <source>Remind me in 14 days</source>
-        <translation>Напомнить через 14 дней</translation>
+        <translation type="vanished">Напомнить через 14 дней</translation>
     </message>
     <message>
         <source>Fit to page</source>
-        <translation>Подогнать под размер страницы</translation>
+        <translation type="vanished">Подогнать под размер страницы</translation>
     </message>
     <message>
         <source>Show bookmarks</source>
-        <translation>Показать закладки</translation>
+        <translation type="vanished">Показать закладки</translation>
     </message>
     <message>
         <source>Open previous comic</source>
-        <translation>Открыть предыдуший комикс</translation>
+        <translation type="vanished">Открыть предыдуший комикс</translation>
     </message>
     <message>
         <source>Rotate image to the left</source>
-        <translation>Повернуть изображение против часовой стрелки</translation>
+        <translation type="vanished">Повернуть изображение против часовой стрелки</translation>
     </message>
     <message>
         <source>Fit image to height</source>
-        <translation>Подогнать по высоте</translation>
+        <translation type="vanished">Подогнать по высоте</translation>
     </message>
     <message>
         <source>Reset zoom</source>
-        <translation>Сбросить масштаб</translation>
+        <translation type="vanished">Сбросить масштаб</translation>
     </message>
     <message>
         <source>Show the bookmarks of the current comic</source>
-        <translation>Показать закладки в текущем комиксе</translation>
+        <translation type="vanished">Показать закладки в текущем комиксе</translation>
     </message>
     <message>
         <source>Show Dictionary</source>
-        <translation>Переводчик YACreader</translation>
+        <translation type="vanished">Переводчик YACreader</translation>
     </message>
     <message>
         <source>Move down</source>
-        <translation>Переместить вниз</translation>
+        <translation type="vanished">Переместить вниз</translation>
     </message>
     <message>
         <source>Move left</source>
-        <translation>Переместить влево</translation>
+        <translation type="vanished">Переместить влево</translation>
     </message>
     <message>
         <source>Reverse reading order in double page mode</source>
-        <translation>Двухстраничный режим манги</translation>
+        <translation type="vanished">Двухстраничный режим манги</translation>
     </message>
     <message>
         <source>YACReader options</source>
-        <translation>Настройки</translation>
+        <translation type="vanished">Настройки</translation>
     </message>
     <message>
         <source>Clear open recent list</source>
-        <translation>Очистить список недавно открытых файлов</translation>
+        <translation type="vanished">Очистить список недавно открытых файлов</translation>
     </message>
     <message>
         <source>Help, About YACReader</source>
-        <translation>Справка</translation>
+        <translation type="vanished">Справка</translation>
     </message>
     <message>
         <source>Show go to flow</source>
-        <translation>Показать поток страниц</translation>
+        <translation type="vanished">Показать поток страниц</translation>
     </message>
     <message>
         <source>Previous Comic</source>
-        <translation>Предыдущий комикс</translation>
+        <translation type="vanished">Предыдущий комикс</translation>
     </message>
     <message>
         <source>Show full size</source>
-        <translation>Показать в полном размере</translation>
+        <translation type="vanished">Показать в полном размере</translation>
     </message>
     <message>
         <source>Hide/show toolbar</source>
-        <translation>Показать/скрыть панель инструментов</translation>
+        <translation type="vanished">Показать/скрыть панель инструментов</translation>
     </message>
     <message>
         <source>Magnifying glass</source>
-        <translation>Увеличительное стекло</translation>
+        <translation type="vanished">Увеличительное стекло</translation>
     </message>
     <message>
         <source>Edit shortcuts</source>
-        <translation>Редактировать горячие клавиши</translation>
+        <translation type="vanished">Редактировать горячие клавиши</translation>
     </message>
     <message>
         <source>General</source>
-        <translation>Общие</translation>
+        <translation type="vanished">Общие</translation>
     </message>
     <message>
         <source>Set a bookmark on the current page</source>
-        <translation>Установить закладку на текущей странице</translation>
+        <translation type="vanished">Установить закладку на текущей странице</translation>
     </message>
     <message>
         <source>Page adjustement</source>
-        <translation>Настройка страницы</translation>
+        <translation type="vanished">Настройка страницы</translation>
     </message>
     <message>
         <source>Show zoom slider</source>
-        <translation>Показать ползунок масштабирования</translation>
+        <translation type="vanished">Показать ползунок масштабирования</translation>
     </message>
     <message>
         <source>Go to the last page</source>
-        <translation>Перейти к последней странице</translation>
+        <translation type="vanished">Перейти к последней странице</translation>
     </message>
     <message>
         <source>Do you want to download the new version?</source>
-        <translation>Хотите загрузить новую версию ?</translation>
+        <translation type="vanished">Хотите загрузить новую версию ?</translation>
     </message>
     <message>
         <source>Rotate image to the right</source>
-        <translation>Повернуть изображение по часовой стрелке</translation>
+        <translation type="vanished">Повернуть изображение по часовой стрелке</translation>
     </message>
     <message>
         <source>Always on top</source>
-        <translation>Всегда сверху</translation>
+        <translation type="vanished">Всегда сверху</translation>
     </message>
     <message>
         <source>Autoscroll backward, horizontal first</source>
-        <translation>Автопрокрутка назад, горизонтальная</translation>
-    </message>
-    <message>
-        <source>New instance</source>
-        <translation type="unfinished"></translation>
+        <translation type="vanished">Автопрокрутка назад, горизонтальная</translation>
     </message>
 </context>
 <context>
     <name>OptionsDialog</name>
     <message>
+        <location filename="options_dialog.cpp" line="143"/>
         <source>Gamma</source>
         <translation>Гамма</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="147"/>
         <source>Reset</source>
         <translation>Вернуть к первоначальным значениям</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="34"/>
         <source>My comics path</source>
         <translation>Папка комиксов</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="191"/>
         <source>Image adjustment</source>
         <translation>Настройка изображения</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="43"/>
         <source>&quot;Go to flow&quot; size</source>
         <translation>Размер потока страниц</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="64"/>
         <source>Choose</source>
         <translation>Выбрать</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="152"/>
         <source>Image options</source>
         <translation>Настройки изображения</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="142"/>
         <source>Contrast</source>
         <translation>Контраст</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="206"/>
         <source>Options</source>
         <translation>Настройки</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="213"/>
         <source>Comics directory</source>
         <translation>Папка комиксов</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="97"/>
         <source>Quick Navigation Mode</source>
         <translation>Ползунок для быстрой навигации по страницам</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="61"/>
         <source>Background color</source>
         <translation>Фоновый цвет</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="71"/>
+        <source>Scroll behaviour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="74"/>
+        <source>Do not turn page using scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="75"/>
+        <source>Use single scroll step to turn page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="98"/>
         <source>Disable mouse over activation</source>
         <translation>Отключить активацию потока при наведении мыши</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="190"/>
         <source>Page Flow</source>
         <translation>Поток Страниц</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="189"/>
         <source>General</source>
         <translation>Общие</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="141"/>
         <source>Brightness</source>
         <translation>Яркость</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="197"/>
         <source>Restart is needed</source>
         <translation> </translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="156"/>
         <source>Fit options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="158"/>
         <source>Enlarge images to fit width/height</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="169"/>
         <source>Double Page options</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="171"/>
         <source>Show covers as single page</source>
         <translation type="unfinished"></translation>
     </message>
@@ -610,34 +678,42 @@
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>7z lib not found</source>
         <translation>Библиотека распаковщика 7z не найдена</translation>
     </message>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>unable to load 7z lib from ./utils</source>
         <translation>не удается загрузить 7z lib из ./ utils</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41"/>
         <source>Trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45"/>
         <source>Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51"/>
         <source>Fatal</source>
         <translation type="unfinished"></translation>
     </message>
@@ -645,14 +721,17 @@
 <context>
     <name>QsLogging::LogWindowModel</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="141"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="143"/>
         <source>Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="145"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
@@ -660,18 +739,22 @@
 <context>
     <name>QsLogging::Window</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="236"/>
         <source>Save log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="237"/>
         <source>Log file (*.log)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -679,14 +762,17 @@
 <context>
     <name>ShortcutsDialog</name>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="23"/>
         <source>Close</source>
         <translation>Закрыть</translation>
     </message>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="19"/>
         <source>YACReader keyboard shortcuts</source>
         <translation>Клавиатурные комбинации YACReader</translation>
     </message>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="63"/>
         <source>Keyboard Shortcuts</source>
         <translation>Клавиатурные комбинации</translation>
     </message>
@@ -694,45 +780,537 @@
 <context>
     <name>Viewer</name>
     <message>
+        <location filename="viewer.cpp" line="937"/>
         <source>Page not available!</source>
         <translation>Страница недоступна!</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="51"/>
+        <location filename="viewer.cpp" line="915"/>
         <source>Press &apos;O&apos; to open comic.</source>
         <translation>Нажмите &quot;O&quot; чтобы открыть комикс.</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="240"/>
         <source>Error opening comic</source>
         <translation>Ошибка открытия комикса</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="1089"/>
         <source>Cover!</source>
         <translation>Начало!</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="246"/>
         <source>CRC Error</source>
         <translation>Ошибка CRC</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="234"/>
         <source>Comic not found</source>
         <translation>Комикс не найден</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="234"/>
         <source>Not found</source>
         <translation>Не найдено</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="1103"/>
         <source>Last page!</source>
         <translation>Конец!</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="927"/>
         <source>Loading...please wait!</source>
         <translation>Загрузка... Пожалуйста подождите!</translation>
     </message>
 </context>
 <context>
+    <name>YACReader::MainWindowViewer</name>
+    <message>
+        <location filename="main_window_viewer.cpp" line="219"/>
+        <source>&amp;Open</source>
+        <translation type="unfinished">&amp;Открыть</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="221"/>
+        <source>Open a comic</source>
+        <translation type="unfinished">Открыть комикс</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="227"/>
+        <source>New instance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="246"/>
+        <source>Open Folder</source>
+        <translation type="unfinished">Открыть папку</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="248"/>
+        <source>Open image folder</source>
+        <translation type="unfinished">Открыть папку с изображениями</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="253"/>
+        <source>Open latest comic</source>
+        <translation type="unfinished">Открыть последний комикс</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="254"/>
+        <source>Open the latest comic opened in the previous reading session</source>
+        <translation type="unfinished">Открыть комикс открытый в предыдущем сеансе чтения</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="266"/>
+        <source>Clear</source>
+        <translation type="unfinished">Очистить</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="267"/>
+        <source>Clear open recent list</source>
+        <translation type="unfinished">Очистить список недавно открытых файлов</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="270"/>
+        <source>Save</source>
+        <translation type="unfinished">Сохранить</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="272"/>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>Save current page</source>
+        <translation type="unfinished">Сохранить текущию страницу</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="277"/>
+        <source>Previous Comic</source>
+        <translation type="unfinished">Предыдущий комикс</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="279"/>
+        <location filename="main_window_viewer.cpp" line="1656"/>
+        <location filename="main_window_viewer.cpp" line="1660"/>
+        <source>Open previous comic</source>
+        <translation type="unfinished">Открыть предыдуший комикс</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="284"/>
+        <source>Next Comic</source>
+        <translation type="unfinished">Следующий комикс</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="286"/>
+        <location filename="main_window_viewer.cpp" line="1655"/>
+        <location filename="main_window_viewer.cpp" line="1661"/>
+        <source>Open next comic</source>
+        <translation type="unfinished">Открыть следующий комикс</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="291"/>
+        <source>&amp;Previous</source>
+        <translation type="unfinished">&amp;Предыдущий</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="294"/>
+        <location filename="main_window_viewer.cpp" line="1658"/>
+        <location filename="main_window_viewer.cpp" line="1662"/>
+        <source>Go to previous page</source>
+        <translation type="unfinished">Перейти к предыдущей странице</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="299"/>
+        <source>&amp;Next</source>
+        <translation type="unfinished">&amp;Следующий</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="302"/>
+        <location filename="main_window_viewer.cpp" line="1657"/>
+        <location filename="main_window_viewer.cpp" line="1663"/>
+        <source>Go to next page</source>
+        <translation type="unfinished">Перейти к следующей странице</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="307"/>
+        <source>Fit Height</source>
+        <translation type="unfinished">Подогнать по высоте</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="310"/>
+        <source>Fit image to height</source>
+        <translation type="unfinished">Подогнать по высоте</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="317"/>
+        <source>Fit Width</source>
+        <translation type="unfinished">Подогнать по ширине</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="320"/>
+        <source>Fit image to width</source>
+        <translation type="unfinished">Подогнать по ширине</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="327"/>
+        <source>Show full size</source>
+        <translation type="unfinished">Показать в полном размере</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="335"/>
+        <source>Fit to page</source>
+        <translation type="unfinished">Подогнать под размер страницы</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="366"/>
+        <source>Reset zoom</source>
+        <translation type="unfinished">Сбросить масштаб</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="371"/>
+        <source>Show zoom slider</source>
+        <translation type="unfinished">Показать ползунок масштабирования</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="374"/>
+        <source>Zoom+</source>
+        <translation type="unfinished">Увеличить масштаб</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="379"/>
+        <source>Zoom-</source>
+        <translation type="unfinished">Уменьшить масштаб</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="384"/>
+        <source>Rotate image to the left</source>
+        <translation type="unfinished">Повернуть изображение против часовой стрелки</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="390"/>
+        <source>Rotate image to the right</source>
+        <translation type="unfinished">Повернуть изображение по часовой стрелке</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="396"/>
+        <source>Double page mode</source>
+        <translation type="unfinished">Двухстраничный режим</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="397"/>
+        <source>Switch to double page mode</source>
+        <translation type="unfinished">Двухстраничный режим</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="406"/>
+        <source>Double page manga mode</source>
+        <translation type="unfinished">Двухстраничный режим манги</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="407"/>
+        <source>Reverse reading order in double page mode</source>
+        <translation type="unfinished">Двухстраничный режим манги</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="416"/>
+        <source>Go To</source>
+        <translation type="unfinished">Перейти к странице...</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="418"/>
+        <source>Go to page ...</source>
+        <translation type="unfinished">Перейти к странице...</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="423"/>
+        <source>Options</source>
+        <translation type="unfinished">Настройки</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="424"/>
+        <source>YACReader options</source>
+        <translation type="unfinished">Настройки</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="431"/>
+        <location filename="main_window_viewer.cpp" line="715"/>
+        <source>Help</source>
+        <translation type="unfinished">Справка</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="432"/>
+        <source>Help, About YACReader</source>
+        <translation type="unfinished">Справка</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="438"/>
+        <source>Magnifying glass</source>
+        <translation type="unfinished">Увеличительное стекло</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="439"/>
+        <source>Switch Magnifying glass</source>
+        <translation type="unfinished">Увеличительное стекло</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="446"/>
+        <source>Set bookmark</source>
+        <translation type="unfinished">Установить закладку</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="447"/>
+        <source>Set a bookmark on the current page</source>
+        <translation type="unfinished">Установить закладку на текущей странице</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="456"/>
+        <source>Show bookmarks</source>
+        <translation type="unfinished">Показать закладки</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="457"/>
+        <source>Show the bookmarks of the current comic</source>
+        <translation type="unfinished">Показать закладки в текущем комиксе</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="463"/>
+        <source>Show keyboard shortcuts</source>
+        <translation type="unfinished">Показать горячие клавиши</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="470"/>
+        <source>Show Info</source>
+        <translation type="unfinished">Показать/скрыть номер страницы и текущее время</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="476"/>
+        <source>Close</source>
+        <translation type="unfinished">Закрыть</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="482"/>
+        <source>Show Dictionary</source>
+        <translation type="unfinished">Переводчик YACreader</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="489"/>
+        <source>Show go to flow</source>
+        <translation type="unfinished">Показать поток страниц</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="495"/>
+        <source>Edit shortcuts</source>
+        <translation type="unfinished">Редактировать горячие клавиши</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="515"/>
+        <source>&amp;File</source>
+        <translation type="unfinished">&amp;Отображать панель инструментов</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="529"/>
+        <location filename="main_window_viewer.cpp" line="670"/>
+        <source>Open recent</source>
+        <translation type="unfinished">Открыть недавние</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="659"/>
+        <source>File</source>
+        <translation type="unfinished">Файл</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="680"/>
+        <source>Edit</source>
+        <translation type="unfinished">Редактировать</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="684"/>
+        <source>View</source>
+        <translation type="unfinished">Посмотреть</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="700"/>
+        <source>Go</source>
+        <translation type="unfinished">Перейти</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="708"/>
+        <source>Window</source>
+        <translation type="unfinished">Окно</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="809"/>
+        <location filename="main_window_viewer.cpp" line="811"/>
+        <source>Open Comic</source>
+        <translation type="unfinished">Открыть комикс</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="809"/>
+        <location filename="main_window_viewer.cpp" line="811"/>
+        <source>Comic files</source>
+        <translation type="unfinished">Файлы комикса </translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="898"/>
+        <source>Open folder</source>
+        <translation type="unfinished">Открыть папку</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>page_%1.jpg</source>
+        <translation type="unfinished">страница_%1.jpg</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>Image files (*.jpg)</source>
+        <translation type="unfinished">Файлы изображений (*.jpg)</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1159"/>
+        <source>Comics</source>
+        <translation type="unfinished">Комикс</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1169"/>
+        <source>Toggle fullscreen mode</source>
+        <translation type="unfinished">Полноэкранный режим включить/выключить</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1172"/>
+        <source>Hide/show toolbar</source>
+        <translation type="unfinished">Показать/скрыть панель инструментов</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1175"/>
+        <source>General</source>
+        <translation type="unfinished">Общие</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1194"/>
+        <source>Size up magnifying glass</source>
+        <translation type="unfinished">Увеличение размера окошка увеличительного стекла</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1197"/>
+        <source>Size down magnifying glass</source>
+        <translation type="unfinished">Уменьшение размера окошка увеличительного стекла</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1200"/>
+        <source>Zoom in magnifying glass</source>
+        <translation type="unfinished">Увеличить</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1203"/>
+        <source>Zoom out magnifying glass</source>
+        <translation type="unfinished">Уменьшить</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1209"/>
+        <source>Magnifiying glass</source>
+        <translation type="unfinished">Увеличительное стекло</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1216"/>
+        <source>Toggle between fit to width and fit to height</source>
+        <translation type="unfinished">Переключение режима подгонки страницы по ширине/высоте</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1220"/>
+        <source>Page adjustement</source>
+        <translation type="unfinished">Настройка страницы</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1237"/>
+        <source>Autoscroll down</source>
+        <translation type="unfinished">Автопрокрутка вниз</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1240"/>
+        <source>Autoscroll up</source>
+        <translation type="unfinished">Автопрокрутка вверх</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1243"/>
+        <source>Autoscroll forward, horizontal first</source>
+        <translation type="unfinished">Автопрокрутка вперед, горизонтальная</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1247"/>
+        <source>Autoscroll backward, horizontal first</source>
+        <translation type="unfinished">Автопрокрутка назад, горизонтальная</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1251"/>
+        <source>Autoscroll forward, vertical first</source>
+        <translation type="unfinished">Автопрокрутка вперед, вертикальная</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1255"/>
+        <source>Autoscroll backward, vertical first</source>
+        <translation type="unfinished">Автопрокрутка назад, вертикальная</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1259"/>
+        <source>Move down</source>
+        <translation type="unfinished">Переместить вниз</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1262"/>
+        <source>Move up</source>
+        <translation type="unfinished">Переместить вверх</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1265"/>
+        <source>Move left</source>
+        <translation type="unfinished">Переместить влево</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1268"/>
+        <source>Move right</source>
+        <translation type="unfinished">Переместить вправо</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1271"/>
+        <source>Go to the first page</source>
+        <translation type="unfinished">Перейти к первой странице</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1274"/>
+        <source>Go to the last page</source>
+        <translation type="unfinished">Перейти к последней странице</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1290"/>
+        <source>Reading</source>
+        <translation type="unfinished">Чтение</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1335"/>
+        <source>There is a new version available</source>
+        <translation type="unfinished">Доступна новая версия</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1336"/>
+        <source>Do you want to download the new version?</source>
+        <translation type="unfinished">Хотите загрузить новую версию ?</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1339"/>
+        <source>Remind me in 14 days</source>
+        <translation type="unfinished">Напомнить через 14 дней</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1340"/>
+        <source>Not now</source>
+        <translation type="unfinished">Не сейчас</translation>
+    </message>
+</context>
+<context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation type="unfinished">Закрыть</translation>
     </message>
@@ -740,10 +1318,13 @@
 <context>
     <name>YACReaderFieldEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11"/>
         <source>Restore to default</source>
         <translation>Восстановить значения по умолчанию</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28"/>
         <source>Click to overwrite</source>
         <translation>Изменить</translation>
     </message>
@@ -751,10 +1332,15 @@
 <context>
     <name>YACReaderFieldPlainTextEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10"/>
         <source>Restore to default</source>
         <translation>Вернуть начальные установки</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50"/>
         <source>Click to overwrite</source>
         <translation>Изменить</translation>
     </message>
@@ -762,18 +1348,22 @@
 <context>
     <name>YACReaderFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="15"/>
         <source>CoverFlow look</source>
         <translation>Вид рулеткой</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="13"/>
         <source>How to show covers:</source>
         <translation>Как отображать обложки:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="16"/>
         <source>Stripe look</source>
         <translation>Вид полосами</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="17"/>
         <source>Overlapped Stripe look</source>
         <translation>Вид перекрывающимися полосами</translation>
     </message>
@@ -781,94 +1371,117 @@
 <context>
     <name>YACReaderGLFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="112"/>
         <source>Zoom</source>
         <translation>Масштабировать</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="142"/>
         <source>Light</source>
         <translation>Осветить</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="76"/>
         <source>Show advanced settings</source>
         <translation>Показать дополнительные настройки</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="32"/>
         <source>Roulette look</source>
         <translation>Вид рулеткой</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="130"/>
         <source>Cover Angle</source>
         <translation>Охватить угол</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="23"/>
         <source>Stripe look</source>
         <translation>Вид полосами</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="94"/>
         <source>Position</source>
         <translation>Позиция</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="124"/>
         <source>Z offset</source>
         <translation>Смещение по Z</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="118"/>
         <source>Y offset</source>
         <translation>Смещение по Y</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="106"/>
         <source>Central gap</source>
         <translation>Сфокусировать разрыв</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="18"/>
         <source>Presets:</source>
         <translation>Предустановки:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="26"/>
         <source>Overlapped Stripe look</source>
         <translation>Вид перекрывающимися полосами</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="29"/>
         <source>Modern look</source>
         <translation>Современный вид</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="88"/>
         <source>View angle</source>
         <translation>Угол зрения</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="148"/>
         <source>Max angle</source>
         <translation>Максимальный угол</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="85"/>
         <source>Custom:</source>
         <translation>Пользовательский:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="20"/>
         <source>Classic look</source>
         <translation>Классический вид</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="100"/>
         <source>Cover gap</source>
         <translation>Осветить разрыв</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="182"/>
         <source>High Performance</source>
         <translation>Максимальная производительность</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="201"/>
         <source>Performance:</source>
         <translation>Производительность:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="193"/>
         <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
         <translation>Использовать VSync (повысить формат изображения в полноэкранном режиме , хуже производительность)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="136"/>
         <source>Visibility</source>
         <translation>Прозрачность</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="180"/>
         <source>Low Performance</source>
         <translation>Минимальная производительность</translation>
     </message>
@@ -876,22 +1489,27 @@
 <context>
     <name>YACReaderOptionsDialog</name>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="46"/>
         <source>Use hardware acceleration (restart needed)</source>
         <translation>Использовать аппаратное ускорение (Требуется перезагрузка)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="29"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="37"/>
         <source>Shortcuts</source>
         <translation>Горячие клавиши</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="34"/>
         <source>Edit shortcuts</source>
         <translation>Редактировать горячие клавиши</translation>
     </message>
@@ -899,6 +1517,7 @@
 <context>
     <name>YACReaderSlider</name>
     <message>
+        <location filename="width_slider.cpp" line="49"/>
         <source>Reset</source>
         <translation>Сброс мастштаба</translation>
     </message>
@@ -906,18 +1525,23 @@
 <context>
     <name>YACReaderTranslator</name>
     <message>
+        <location filename="translator.cpp" line="139"/>
         <source>clear</source>
         <translation>очистить</translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="216"/>
         <source>Service not available</source>
         <translation>Сервис недоступен</translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="116"/>
+        <location filename="translator.cpp" line="207"/>
         <source>Translation</source>
         <translation>Перевод</translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="62"/>
         <source>YACReader translator</source>
         <translation>Переводчик YACReader</translation>
     </message>

--- a/YACReader/yacreader_tr.ts
+++ b/YACReader/yacreader_tr.ts
@@ -4,6 +4,7 @@
 <context>
     <name>ActionsShortcutsModel</name>
     <message>
+        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="73"/>
         <source>None</source>
         <translation>Hiçbiri</translation>
     </message>
@@ -11,18 +12,23 @@
 <context>
     <name>BookmarksDialog</name>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="75"/>
         <source>Close</source>
         <translation>Kapat</translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="107"/>
+        <location filename="bookmarks_dialog.cpp" line="124"/>
         <source>Loading...</source>
         <translation>Yükleniyor...</translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="85"/>
         <source>Click on any image to go to the bookmark</source>
         <translation>Yer imine git</translation>
     </message>
     <message>
+        <location filename="bookmarks_dialog.cpp" line="25"/>
         <source>Lastest Page</source>
         <translation>Son Sayfa</translation>
     </message>
@@ -30,22 +36,27 @@
 <context>
     <name>EditShortcutsDialog</name>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="21"/>
         <source>Restore defaults</source>
         <translation>Varsayılarları geri yükle</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="22"/>
         <source>To change a shortcut, double click in the key combination and type the new keys.</source>
         <translation>Bir kısayolu değiştirmek için tuş kombinasyonuna çift tıklayın ve yeni tuşları girin.</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="69"/>
         <source>Shortcuts settings</source>
         <translation>Kısayol oyarları</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>Shortcut in use</source>
         <translation>Kısayol kullanımda</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>The shortcut &quot;%1&quot; is already assigned to other function</source>
         <translation>&quot;%1&quot; kısayolu bir başka işleve zaten atanmış</translation>
     </message>
@@ -53,18 +64,22 @@
 <context>
     <name>FileComic</name>
     <message>
+        <location filename="../common/comic.cpp" line="562"/>
         <source>7z not found</source>
         <translation>7z bulunamadı</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="454"/>
         <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
         <translation>(%1). sayfada CRC hatası : bazı sayfalar düzgün görüntülenmeyecek</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="461"/>
         <source>Unknown error opening the file</source>
         <translation>Dosya açılırken bilinmeyen hata</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="568"/>
         <source>Format not supported</source>
         <translation>Biçim desteklenmiyor</translation>
     </message>
@@ -72,22 +87,28 @@
 <context>
     <name>GoToDialog</name>
     <message>
+        <location filename="goto_dialog.cpp" line="23"/>
         <source>Go To</source>
         <translation>Git</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="53"/>
         <source>Go to...</source>
         <translation>Git...</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="39"/>
+        <location filename="goto_dialog.cpp" line="71"/>
         <source>Total pages : </source>
         <translation>Toplam sayfa: </translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="25"/>
         <source>Cancel</source>
         <translation>Vazgeç</translation>
     </message>
     <message>
+        <location filename="goto_dialog.cpp" line="15"/>
         <source>Page : </source>
         <translation>Sayfa : </translation>
     </message>
@@ -95,6 +116,7 @@
 <context>
     <name>GoToFlowToolBar</name>
     <message>
+        <location filename="goto_flow_toolbar.cpp" line="38"/>
         <source>Page : </source>
         <translation>Sayfa : </translation>
     </message>
@@ -102,10 +124,17 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Yardım</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
+        <source>System info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation>Hakkında</translation>
     </message>
@@ -113,30 +142,37 @@
 <context>
     <name>LogWindow</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="14"/>
         <source>Log window</source>
         <translation>Günlük penceresi</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="22"/>
         <source>&amp;Pause</source>
         <translation>&amp;Duraklat</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="39"/>
         <source>&amp;Save</source>
         <translation>&amp;Kaydet</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="56"/>
         <source>C&amp;lear</source>
         <translation>&amp;Temizle</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="73"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopyala</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="90"/>
         <source>Level:</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="136"/>
         <source>&amp;Auto scroll</source>
         <translation>&amp;Otomatik kaydır</translation>
     </message>
@@ -145,464 +181,500 @@
     <name>MainWindowViewer</name>
     <message>
         <source>Help</source>
-        <translation>Yardım</translation>
+        <translation type="vanished">Yardım</translation>
     </message>
     <message>
         <source>Save</source>
-        <translation>Kaydet</translation>
+        <translation type="vanished">Kaydet</translation>
     </message>
     <message>
         <source>&amp;File</source>
-        <translation>&amp;Dosya</translation>
+        <translation type="vanished">&amp;Dosya</translation>
     </message>
     <message>
         <source>&amp;Next</source>
-        <translation>&amp;İleri</translation>
+        <translation type="vanished">&amp;İleri</translation>
     </message>
     <message>
         <source>&amp;Open</source>
-        <translation>&amp;Aç</translation>
+        <translation type="vanished">&amp;Aç</translation>
     </message>
     <message>
         <source>Close</source>
-        <translation>Kapat</translation>
+        <translation type="vanished">Kapat</translation>
     </message>
     <message>
         <source>Open Comic</source>
-        <translation>Çizgi Romanı Aç</translation>
+        <translation type="vanished">Çizgi Romanı Aç</translation>
     </message>
     <message>
         <source>Go To</source>
-        <translation>Git</translation>
+        <translation type="vanished">Git</translation>
     </message>
     <message>
         <source>Open image folder</source>
-        <translation>Resim dosyasınıaç</translation>
+        <translation type="vanished">Resim dosyasınıaç</translation>
     </message>
     <message>
         <source>Set bookmark</source>
-        <translation>Yer imi yap</translation>
+        <translation type="vanished">Yer imi yap</translation>
     </message>
     <message>
         <source>page_%1.jpg</source>
-        <translation>sayfa_%1.jpg</translation>
+        <translation type="vanished">sayfa_%1.jpg</translation>
     </message>
     <message>
         <source>Switch to double page mode</source>
-        <translation>Çift sayfa moduna geç</translation>
+        <translation type="vanished">Çift sayfa moduna geç</translation>
     </message>
     <message>
         <source>Save current page</source>
-        <translation>Geçerli sayfayı kaydet</translation>
+        <translation type="vanished">Geçerli sayfayı kaydet</translation>
     </message>
     <message>
         <source>Double page mode</source>
-        <translation>Çift sayfa modu</translation>
+        <translation type="vanished">Çift sayfa modu</translation>
     </message>
     <message>
         <source>Switch Magnifying glass</source>
-        <translation>Büyüteç</translation>
+        <translation type="vanished">Büyüteç</translation>
     </message>
     <message>
         <source>Open Folder</source>
-        <translation>Dosyayı Aç</translation>
+        <translation type="vanished">Dosyayı Aç</translation>
     </message>
     <message>
         <source>Comic files</source>
-        <translation>Çizgi Roman Dosyaları</translation>
+        <translation type="vanished">Çizgi Roman Dosyaları</translation>
     </message>
     <message>
         <source>Go to previous page</source>
-        <translation>Önceki sayfaya dön</translation>
+        <translation type="vanished">Önceki sayfaya dön</translation>
     </message>
     <message>
         <source>Open a comic</source>
-        <translation>Çizgi romanı aç</translation>
+        <translation type="vanished">Çizgi romanı aç</translation>
     </message>
     <message>
         <source>Image files (*.jpg)</source>
-        <translation>Resim dosyaları (*.jpg)</translation>
+        <translation type="vanished">Resim dosyaları (*.jpg)</translation>
     </message>
     <message>
         <source>Next Comic</source>
-        <translation>Sırada ki çizgi roman</translation>
+        <translation type="vanished">Sırada ki çizgi roman</translation>
     </message>
     <message>
         <source>Fit Width</source>
-        <translation>Uygun Genişlik</translation>
+        <translation type="vanished">Uygun Genişlik</translation>
     </message>
     <message>
         <source>Options</source>
-        <translation>Ayarlar</translation>
+        <translation type="vanished">Ayarlar</translation>
     </message>
     <message>
         <source>Show Info</source>
-        <translation>Bilgiyi göster</translation>
+        <translation type="vanished">Bilgiyi göster</translation>
     </message>
     <message>
         <source>Open folder</source>
-        <translation>Dosyayı aç</translation>
+        <translation type="vanished">Dosyayı aç</translation>
     </message>
     <message>
         <source>Go to page ...</source>
-        <translation>Sayfata git...</translation>
+        <translation type="vanished">Sayfata git...</translation>
     </message>
     <message>
         <source>Fit image to width</source>
-        <translation>Görüntüyü sığdır</translation>
+        <translation type="vanished">Görüntüyü sığdır</translation>
     </message>
     <message>
         <source>&amp;Previous</source>
-        <translation>&amp;Geri</translation>
+        <translation type="vanished">&amp;Geri</translation>
     </message>
     <message>
         <source>Go to next page</source>
-        <translation>Sonra ki sayfaya geç</translation>
+        <translation type="vanished">Sonra ki sayfaya geç</translation>
     </message>
     <message>
         <source>Show keyboard shortcuts</source>
-        <translation>Klavye kısayollarını göster</translation>
+        <translation type="vanished">Klavye kısayollarını göster</translation>
     </message>
     <message>
         <source>There is a new version available</source>
-        <translation>Yeni versiyon mevcut</translation>
+        <translation type="vanished">Yeni versiyon mevcut</translation>
     </message>
     <message>
         <source>Open next comic</source>
-        <translation>Sıradaki çizgi romanı aç</translation>
+        <translation type="vanished">Sıradaki çizgi romanı aç</translation>
     </message>
     <message>
         <source>Show bookmarks</source>
-        <translation>Yer imlerini göster</translation>
+        <translation type="vanished">Yer imlerini göster</translation>
     </message>
     <message>
         <source>Open previous comic</source>
-        <translation>Önceki çizgi romanı aç</translation>
+        <translation type="vanished">Önceki çizgi romanı aç</translation>
     </message>
     <message>
         <source>Rotate image to the left</source>
-        <translation>Sayfayı sola yatır</translation>
+        <translation type="vanished">Sayfayı sola yatır</translation>
     </message>
     <message>
         <source>Fit image to height</source>
-        <translation>Uygun yüksekliğe getir</translation>
+        <translation type="vanished">Uygun yüksekliğe getir</translation>
     </message>
     <message>
         <source>Show the bookmarks of the current comic</source>
-        <translation>Bu çizgi romanın yer imlerini göster</translation>
+        <translation type="vanished">Bu çizgi romanın yer imlerini göster</translation>
     </message>
     <message>
         <source>Show Dictionary</source>
-        <translation>Sözlüğü göster</translation>
+        <translation type="vanished">Sözlüğü göster</translation>
     </message>
     <message>
         <source>YACReader options</source>
-        <translation>YACReader ayarları</translation>
+        <translation type="vanished">YACReader ayarları</translation>
     </message>
     <message>
         <source>Help, About YACReader</source>
-        <translation>YACReader hakkında yardım ve bilgi</translation>
+        <translation type="vanished">YACReader hakkında yardım ve bilgi</translation>
     </message>
     <message>
         <source>Show go to flow</source>
-        <translation>Akışı göster</translation>
+        <translation type="vanished">Akışı göster</translation>
     </message>
     <message>
         <source>Previous Comic</source>
-        <translation>Önce ki çizgi roman</translation>
+        <translation type="vanished">Önce ki çizgi roman</translation>
     </message>
     <message>
         <source>Show full size</source>
-        <translation>Tam erken</translation>
+        <translation type="vanished">Tam erken</translation>
     </message>
     <message>
         <source>Magnifying glass</source>
-        <translation>Büyüteç</translation>
+        <translation type="vanished">Büyüteç</translation>
     </message>
     <message>
         <source>General</source>
-        <translation>Genel</translation>
+        <translation type="vanished">Genel</translation>
     </message>
     <message>
         <source>Set a bookmark on the current page</source>
-        <translation>Sayfayı yer imi olarak ayarla</translation>
+        <translation type="vanished">Sayfayı yer imi olarak ayarla</translation>
     </message>
     <message>
         <source>Do you want to download the new version?</source>
-        <translation>Yeni versiyonu indirmek ister misin ?</translation>
+        <translation type="vanished">Yeni versiyonu indirmek ister misin ?</translation>
     </message>
     <message>
         <source>Rotate image to the right</source>
-        <translation>Sayfayı sağa yator</translation>
+        <translation type="vanished">Sayfayı sağa yator</translation>
     </message>
     <message>
         <source>Always on top</source>
-        <translation>Her zaman üstte</translation>
+        <translation type="vanished">Her zaman üstte</translation>
     </message>
     <message>
         <source>New instance</source>
-        <translation>Yeni örnek</translation>
+        <translation type="vanished">Yeni örnek</translation>
     </message>
     <message>
         <source>Open latest comic</source>
-        <translation>En son çizgi romanı aç</translation>
+        <translation type="vanished">En son çizgi romanı aç</translation>
     </message>
     <message>
         <source>Open the latest comic opened in the previous reading session</source>
-        <translation>Önceki okuma oturumunda açılan en son çizgi romanı aç</translation>
+        <translation type="vanished">Önceki okuma oturumunda açılan en son çizgi romanı aç</translation>
     </message>
     <message>
         <source>Clear</source>
-        <translation>Temizle</translation>
+        <translation type="vanished">Temizle</translation>
     </message>
     <message>
         <source>Clear open recent list</source>
-        <translation>Son açılanlar listesini temizle</translation>
+        <translation type="vanished">Son açılanlar listesini temizle</translation>
     </message>
     <message>
         <source>Fit Height</source>
-        <translation>Yüksekliğe Sığdır</translation>
+        <translation type="vanished">Yüksekliğe Sığdır</translation>
     </message>
     <message>
         <source>Fit to page</source>
-        <translation>Sayfaya sığdır</translation>
+        <translation type="vanished">Sayfaya sığdır</translation>
     </message>
     <message>
         <source>Reset zoom</source>
-        <translation>Yakınlaştırmayı sıfırla</translation>
+        <translation type="vanished">Yakınlaştırmayı sıfırla</translation>
     </message>
     <message>
         <source>Show zoom slider</source>
-        <translation>Yakınlaştırma çubuğunu göster</translation>
+        <translation type="vanished">Yakınlaştırma çubuğunu göster</translation>
     </message>
     <message>
         <source>Zoom+</source>
-        <translation>Yakınlaştır</translation>
+        <translation type="vanished">Yakınlaştır</translation>
     </message>
     <message>
         <source>Zoom-</source>
-        <translation>Uzaklaştır</translation>
+        <translation type="vanished">Uzaklaştır</translation>
     </message>
     <message>
         <source>Double page manga mode</source>
-        <translation>Çift sayfa manga kipi</translation>
+        <translation type="vanished">Çift sayfa manga kipi</translation>
     </message>
     <message>
         <source>Reverse reading order in double page mode</source>
-        <translation>Çift sayfa kipinde ters okuma sırası</translation>
+        <translation type="vanished">Çift sayfa kipinde ters okuma sırası</translation>
     </message>
     <message>
         <source>Edit shortcuts</source>
-        <translation>Kısayolları düzenle</translation>
+        <translation type="vanished">Kısayolları düzenle</translation>
     </message>
     <message>
         <source>Open recent</source>
-        <translation>Son dosyaları aç</translation>
+        <translation type="vanished">Son dosyaları aç</translation>
     </message>
     <message>
         <source>File</source>
-        <translation>Dosya</translation>
+        <translation type="vanished">Dosya</translation>
     </message>
     <message>
         <source>Edit</source>
-        <translation>Düzen</translation>
+        <translation type="vanished">Düzen</translation>
     </message>
     <message>
         <source>View</source>
-        <translation>Görünüm</translation>
+        <translation type="vanished">Görünüm</translation>
     </message>
     <message>
         <source>Go</source>
-        <translation>Git</translation>
+        <translation type="vanished">Git</translation>
     </message>
     <message>
         <source>Window</source>
-        <translation>Pencere</translation>
+        <translation type="vanished">Pencere</translation>
     </message>
     <message>
         <source>Comics</source>
-        <translation>Çizgi Roman</translation>
+        <translation type="vanished">Çizgi Roman</translation>
     </message>
     <message>
         <source>Toggle fullscreen mode</source>
-        <translation>Tam ekran kipini aç/kapat</translation>
+        <translation type="vanished">Tam ekran kipini aç/kapat</translation>
     </message>
     <message>
         <source>Hide/show toolbar</source>
-        <translation>Araç çubuğunu göster/gizle</translation>
+        <translation type="vanished">Araç çubuğunu göster/gizle</translation>
     </message>
     <message>
         <source>Size up magnifying glass</source>
-        <translation>Büyüteci büyüt</translation>
+        <translation type="vanished">Büyüteci büyüt</translation>
     </message>
     <message>
         <source>Size down magnifying glass</source>
-        <translation>Büyüteci küçült</translation>
+        <translation type="vanished">Büyüteci küçült</translation>
     </message>
     <message>
         <source>Zoom in magnifying glass</source>
-        <translation>Büyüteci yakınlaştır</translation>
+        <translation type="vanished">Büyüteci yakınlaştır</translation>
     </message>
     <message>
         <source>Zoom out magnifying glass</source>
-        <translation>Büyüteci uzaklaştır</translation>
+        <translation type="vanished">Büyüteci uzaklaştır</translation>
     </message>
     <message>
         <source>Magnifiying glass</source>
-        <translation>Büyüteç</translation>
+        <translation type="vanished">Büyüteç</translation>
     </message>
     <message>
         <source>Toggle between fit to width and fit to height</source>
-        <translation>Genişliğe sığdır ile yüksekliğe sığdır arasında geçiş yap</translation>
+        <translation type="vanished">Genişliğe sığdır ile yüksekliğe sığdır arasında geçiş yap</translation>
     </message>
     <message>
         <source>Page adjustement</source>
-        <translation>Sayfa ayarı</translation>
+        <translation type="vanished">Sayfa ayarı</translation>
     </message>
     <message>
         <source>Autoscroll down</source>
-        <translation>Otomatik aşağı kaydır</translation>
+        <translation type="vanished">Otomatik aşağı kaydır</translation>
     </message>
     <message>
         <source>Autoscroll up</source>
-        <translation>Otomatik yukarı kaydır</translation>
+        <translation type="vanished">Otomatik yukarı kaydır</translation>
     </message>
     <message>
         <source>Autoscroll forward, horizontal first</source>
-        <translation>Otomatik ileri kaydır, önce yatay</translation>
+        <translation type="vanished">Otomatik ileri kaydır, önce yatay</translation>
     </message>
     <message>
         <source>Autoscroll backward, horizontal first</source>
-        <translation>Otomatik geri kaydır, önce yatay</translation>
+        <translation type="vanished">Otomatik geri kaydır, önce yatay</translation>
     </message>
     <message>
         <source>Autoscroll forward, vertical first</source>
-        <translation>Otomatik ileri kaydır, önce dikey</translation>
+        <translation type="vanished">Otomatik ileri kaydır, önce dikey</translation>
     </message>
     <message>
         <source>Autoscroll backward, vertical first</source>
-        <translation>Otomatik geri kaydır, önce dikey</translation>
+        <translation type="vanished">Otomatik geri kaydır, önce dikey</translation>
     </message>
     <message>
         <source>Move down</source>
-        <translation>Aşağı git</translation>
+        <translation type="vanished">Aşağı git</translation>
     </message>
     <message>
         <source>Move up</source>
-        <translation>Yukarı git</translation>
+        <translation type="vanished">Yukarı git</translation>
     </message>
     <message>
         <source>Move left</source>
-        <translation>Sola git</translation>
+        <translation type="vanished">Sola git</translation>
     </message>
     <message>
         <source>Move right</source>
-        <translation>Sağa git</translation>
+        <translation type="vanished">Sağa git</translation>
     </message>
     <message>
         <source>Go to the first page</source>
-        <translation>İlk sayfaya git</translation>
+        <translation type="vanished">İlk sayfaya git</translation>
     </message>
     <message>
         <source>Go to the last page</source>
-        <translation>En son sayfaya git</translation>
+        <translation type="vanished">En son sayfaya git</translation>
     </message>
     <message>
         <source>Reading</source>
-        <translation>Okuma</translation>
+        <translation type="vanished">Okuma</translation>
     </message>
     <message>
         <source>Remind me in 14 days</source>
-        <translation>14 gün içinde hatırlat</translation>
+        <translation type="vanished">14 gün içinde hatırlat</translation>
     </message>
     <message>
         <source>Not now</source>
-        <translation>Şimdi değil</translation>
+        <translation type="vanished">Şimdi değil</translation>
     </message>
 </context>
 <context>
     <name>OptionsDialog</name>
     <message>
+        <location filename="options_dialog.cpp" line="143"/>
         <source>Gamma</source>
         <translation>Gama</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="147"/>
         <source>Reset</source>
         <translation>Yeniden başlat</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="34"/>
         <source>My comics path</source>
         <translation>Çizgi Romanlarım</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="191"/>
         <source>Image adjustment</source>
         <translation>Resim ayarları</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="43"/>
         <source>&quot;Go to flow&quot; size</source>
         <translation>Akış görünümüne git</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="64"/>
         <source>Choose</source>
         <translation>Seç</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="152"/>
         <source>Image options</source>
         <translation>Sayfa ayarları</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="142"/>
         <source>Contrast</source>
         <translation>Kontrast</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="206"/>
         <source>Options</source>
         <translation>Ayarlar</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="213"/>
         <source>Comics directory</source>
         <translation>Çizgi roman konumu</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="61"/>
         <source>Background color</source>
         <translation>Arka plan rengi</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="190"/>
         <source>Page Flow</source>
         <translation>Sayfa akışı</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="189"/>
         <source>General</source>
         <translation>Genel</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="141"/>
         <source>Brightness</source>
         <translation>Parlaklık</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="197"/>
         <source>Restart is needed</source>
         <translation>Yeniden başlatılmalı</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="97"/>
         <source>Quick Navigation Mode</source>
         <translation>Hızlı Gezinti Kipi</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="71"/>
+        <source>Scroll behaviour</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="74"/>
+        <source>Do not turn page using scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="75"/>
+        <source>Use single scroll step to turn page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="98"/>
         <source>Disable mouse over activation</source>
         <translation>Etkinleştirme üzerinde fareyi devre dışı bırak</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="156"/>
         <source>Fit options</source>
         <translation>Sığdırma seçenekleri</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="158"/>
         <source>Enlarge images to fit width/height</source>
         <translation>Genişliğe/yüksekliği sığmaları için resimleri genişlet</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="169"/>
         <source>Double Page options</source>
         <translation>Çift Sayfa seçenekleri</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="171"/>
         <source>Show covers as single page</source>
         <translation>Kapakları tek sayfa olarak göster</translation>
     </message>
@@ -610,34 +682,42 @@
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>7z lib not found</source>
         <translation>7z lib bulunamadı</translation>
     </message>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>unable to load 7z lib from ./utils</source>
         <translation>./utils içinden 7z lib yüklenemedi</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41"/>
         <source>Trace</source>
         <translation>İz</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43"/>
         <source>Debug</source>
         <translation>Hata ayıkla</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45"/>
         <source>Info</source>
         <translation>Bilgi</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47"/>
         <source>Warning</source>
         <translation>Uyarı</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49"/>
         <source>Error</source>
         <translation>Hata</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51"/>
         <source>Fatal</source>
         <translation>Ölümcül</translation>
     </message>
@@ -645,14 +725,17 @@
 <context>
     <name>QsLogging::LogWindowModel</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="141"/>
         <source>Time</source>
         <translation>Süre</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="143"/>
         <source>Level</source>
         <translation>Düzey</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="145"/>
         <source>Message</source>
         <translation>Mesaj</translation>
     </message>
@@ -660,18 +743,22 @@
 <context>
     <name>QsLogging::Window</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Pause</source>
         <translation>&amp;Duraklat</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Resume</source>
         <translation>&amp;Sürdür</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="236"/>
         <source>Save log</source>
         <translation>Günlük kaydet</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="237"/>
         <source>Log file (*.log)</source>
         <translation>Günlük dosyası (*.log)</translation>
     </message>
@@ -679,14 +766,17 @@
 <context>
     <name>ShortcutsDialog</name>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="23"/>
         <source>Close</source>
         <translation>Kapat</translation>
     </message>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="19"/>
         <source>YACReader keyboard shortcuts</source>
         <translation>YACReader klavye kısayolları</translation>
     </message>
     <message>
+        <location filename="shortcuts_dialog.cpp" line="63"/>
         <source>Keyboard Shortcuts</source>
         <translation>Klavye Kısayolları</translation>
     </message>
@@ -694,45 +784,537 @@
 <context>
     <name>Viewer</name>
     <message>
+        <location filename="viewer.cpp" line="51"/>
+        <location filename="viewer.cpp" line="915"/>
         <source>Press &apos;O&apos; to open comic.</source>
         <translation>&apos;O&apos;ya basarak aç.</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="1089"/>
         <source>Cover!</source>
         <translation>Kapak!</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="234"/>
         <source>Comic not found</source>
         <translation>Çizgi roman bulunamadı</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="234"/>
         <source>Not found</source>
         <translation>Bulunamadı</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="1103"/>
         <source>Last page!</source>
         <translation>Son sayfa!</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="927"/>
         <source>Loading...please wait!</source>
         <translation>Yükleniyor... lütfen bekleyin!</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="240"/>
         <source>Error opening comic</source>
         <translation>Çizgi roman açılırken hata</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="246"/>
         <source>CRC Error</source>
         <translation>CRC Hatası</translation>
     </message>
     <message>
+        <location filename="viewer.cpp" line="937"/>
         <source>Page not available!</source>
         <translation>Sayfa bulunamadı!</translation>
     </message>
 </context>
 <context>
+    <name>YACReader::MainWindowViewer</name>
+    <message>
+        <location filename="main_window_viewer.cpp" line="219"/>
+        <source>&amp;Open</source>
+        <translation type="unfinished">&amp;Aç</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="221"/>
+        <source>Open a comic</source>
+        <translation type="unfinished">Çizgi romanı aç</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="227"/>
+        <source>New instance</source>
+        <translation type="unfinished">Yeni örnek</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="246"/>
+        <source>Open Folder</source>
+        <translation type="unfinished">Dosyayı Aç</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="248"/>
+        <source>Open image folder</source>
+        <translation type="unfinished">Resim dosyasınıaç</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="253"/>
+        <source>Open latest comic</source>
+        <translation type="unfinished">En son çizgi romanı aç</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="254"/>
+        <source>Open the latest comic opened in the previous reading session</source>
+        <translation type="unfinished">Önceki okuma oturumunda açılan en son çizgi romanı aç</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="266"/>
+        <source>Clear</source>
+        <translation type="unfinished">Temizle</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="267"/>
+        <source>Clear open recent list</source>
+        <translation type="unfinished">Son açılanlar listesini temizle</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="270"/>
+        <source>Save</source>
+        <translation type="unfinished">Kaydet</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="272"/>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>Save current page</source>
+        <translation type="unfinished">Geçerli sayfayı kaydet</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="277"/>
+        <source>Previous Comic</source>
+        <translation type="unfinished">Önce ki çizgi roman</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="279"/>
+        <location filename="main_window_viewer.cpp" line="1656"/>
+        <location filename="main_window_viewer.cpp" line="1660"/>
+        <source>Open previous comic</source>
+        <translation type="unfinished">Önceki çizgi romanı aç</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="284"/>
+        <source>Next Comic</source>
+        <translation type="unfinished">Sırada ki çizgi roman</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="286"/>
+        <location filename="main_window_viewer.cpp" line="1655"/>
+        <location filename="main_window_viewer.cpp" line="1661"/>
+        <source>Open next comic</source>
+        <translation type="unfinished">Sıradaki çizgi romanı aç</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="291"/>
+        <source>&amp;Previous</source>
+        <translation type="unfinished">&amp;Geri</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="294"/>
+        <location filename="main_window_viewer.cpp" line="1658"/>
+        <location filename="main_window_viewer.cpp" line="1662"/>
+        <source>Go to previous page</source>
+        <translation type="unfinished">Önceki sayfaya dön</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="299"/>
+        <source>&amp;Next</source>
+        <translation type="unfinished">&amp;İleri</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="302"/>
+        <location filename="main_window_viewer.cpp" line="1657"/>
+        <location filename="main_window_viewer.cpp" line="1663"/>
+        <source>Go to next page</source>
+        <translation type="unfinished">Sonra ki sayfaya geç</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="307"/>
+        <source>Fit Height</source>
+        <translation type="unfinished">Yüksekliğe Sığdır</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="310"/>
+        <source>Fit image to height</source>
+        <translation type="unfinished">Uygun yüksekliğe getir</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="317"/>
+        <source>Fit Width</source>
+        <translation type="unfinished">Uygun Genişlik</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="320"/>
+        <source>Fit image to width</source>
+        <translation type="unfinished">Görüntüyü sığdır</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="327"/>
+        <source>Show full size</source>
+        <translation type="unfinished">Tam erken</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="335"/>
+        <source>Fit to page</source>
+        <translation type="unfinished">Sayfaya sığdır</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="366"/>
+        <source>Reset zoom</source>
+        <translation type="unfinished">Yakınlaştırmayı sıfırla</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="371"/>
+        <source>Show zoom slider</source>
+        <translation type="unfinished">Yakınlaştırma çubuğunu göster</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="374"/>
+        <source>Zoom+</source>
+        <translation type="unfinished">Yakınlaştır</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="379"/>
+        <source>Zoom-</source>
+        <translation type="unfinished">Uzaklaştır</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="384"/>
+        <source>Rotate image to the left</source>
+        <translation type="unfinished">Sayfayı sola yatır</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="390"/>
+        <source>Rotate image to the right</source>
+        <translation type="unfinished">Sayfayı sağa yator</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="396"/>
+        <source>Double page mode</source>
+        <translation type="unfinished">Çift sayfa modu</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="397"/>
+        <source>Switch to double page mode</source>
+        <translation type="unfinished">Çift sayfa moduna geç</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="406"/>
+        <source>Double page manga mode</source>
+        <translation type="unfinished">Çift sayfa manga kipi</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="407"/>
+        <source>Reverse reading order in double page mode</source>
+        <translation type="unfinished">Çift sayfa kipinde ters okuma sırası</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="416"/>
+        <source>Go To</source>
+        <translation type="unfinished">Git</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="418"/>
+        <source>Go to page ...</source>
+        <translation type="unfinished">Sayfata git...</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="423"/>
+        <source>Options</source>
+        <translation type="unfinished">Ayarlar</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="424"/>
+        <source>YACReader options</source>
+        <translation type="unfinished">YACReader ayarları</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="431"/>
+        <location filename="main_window_viewer.cpp" line="715"/>
+        <source>Help</source>
+        <translation type="unfinished">Yardım</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="432"/>
+        <source>Help, About YACReader</source>
+        <translation type="unfinished">YACReader hakkında yardım ve bilgi</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="438"/>
+        <source>Magnifying glass</source>
+        <translation type="unfinished">Büyüteç</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="439"/>
+        <source>Switch Magnifying glass</source>
+        <translation type="unfinished">Büyüteç</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="446"/>
+        <source>Set bookmark</source>
+        <translation type="unfinished">Yer imi yap</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="447"/>
+        <source>Set a bookmark on the current page</source>
+        <translation type="unfinished">Sayfayı yer imi olarak ayarla</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="456"/>
+        <source>Show bookmarks</source>
+        <translation type="unfinished">Yer imlerini göster</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="457"/>
+        <source>Show the bookmarks of the current comic</source>
+        <translation type="unfinished">Bu çizgi romanın yer imlerini göster</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="463"/>
+        <source>Show keyboard shortcuts</source>
+        <translation type="unfinished">Klavye kısayollarını göster</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="470"/>
+        <source>Show Info</source>
+        <translation type="unfinished">Bilgiyi göster</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="476"/>
+        <source>Close</source>
+        <translation type="unfinished">Kapat</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="482"/>
+        <source>Show Dictionary</source>
+        <translation type="unfinished">Sözlüğü göster</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="489"/>
+        <source>Show go to flow</source>
+        <translation type="unfinished">Akışı göster</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="495"/>
+        <source>Edit shortcuts</source>
+        <translation type="unfinished">Kısayolları düzenle</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="515"/>
+        <source>&amp;File</source>
+        <translation type="unfinished">&amp;Dosya</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="529"/>
+        <location filename="main_window_viewer.cpp" line="670"/>
+        <source>Open recent</source>
+        <translation type="unfinished">Son dosyaları aç</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="659"/>
+        <source>File</source>
+        <translation type="unfinished">Dosya</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="680"/>
+        <source>Edit</source>
+        <translation type="unfinished">Düzen</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="684"/>
+        <source>View</source>
+        <translation type="unfinished">Görünüm</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="700"/>
+        <source>Go</source>
+        <translation type="unfinished">Git</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="708"/>
+        <source>Window</source>
+        <translation type="unfinished">Pencere</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="809"/>
+        <location filename="main_window_viewer.cpp" line="811"/>
+        <source>Open Comic</source>
+        <translation type="unfinished">Çizgi Romanı Aç</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="809"/>
+        <location filename="main_window_viewer.cpp" line="811"/>
+        <source>Comic files</source>
+        <translation type="unfinished">Çizgi Roman Dosyaları</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="898"/>
+        <source>Open folder</source>
+        <translation type="unfinished">Dosyayı aç</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>page_%1.jpg</source>
+        <translation type="unfinished">sayfa_%1.jpg</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="954"/>
+        <source>Image files (*.jpg)</source>
+        <translation type="unfinished">Resim dosyaları (*.jpg)</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1159"/>
+        <source>Comics</source>
+        <translation type="unfinished">Çizgi Roman</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1169"/>
+        <source>Toggle fullscreen mode</source>
+        <translation type="unfinished">Tam ekran kipini aç/kapat</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1172"/>
+        <source>Hide/show toolbar</source>
+        <translation type="unfinished">Araç çubuğunu göster/gizle</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1175"/>
+        <source>General</source>
+        <translation type="unfinished">Genel</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1194"/>
+        <source>Size up magnifying glass</source>
+        <translation type="unfinished">Büyüteci büyüt</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1197"/>
+        <source>Size down magnifying glass</source>
+        <translation type="unfinished">Büyüteci küçült</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1200"/>
+        <source>Zoom in magnifying glass</source>
+        <translation type="unfinished">Büyüteci yakınlaştır</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1203"/>
+        <source>Zoom out magnifying glass</source>
+        <translation type="unfinished">Büyüteci uzaklaştır</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1209"/>
+        <source>Magnifiying glass</source>
+        <translation type="unfinished">Büyüteç</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1216"/>
+        <source>Toggle between fit to width and fit to height</source>
+        <translation type="unfinished">Genişliğe sığdır ile yüksekliğe sığdır arasında geçiş yap</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1220"/>
+        <source>Page adjustement</source>
+        <translation type="unfinished">Sayfa ayarı</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1237"/>
+        <source>Autoscroll down</source>
+        <translation type="unfinished">Otomatik aşağı kaydır</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1240"/>
+        <source>Autoscroll up</source>
+        <translation type="unfinished">Otomatik yukarı kaydır</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1243"/>
+        <source>Autoscroll forward, horizontal first</source>
+        <translation type="unfinished">Otomatik ileri kaydır, önce yatay</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1247"/>
+        <source>Autoscroll backward, horizontal first</source>
+        <translation type="unfinished">Otomatik geri kaydır, önce yatay</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1251"/>
+        <source>Autoscroll forward, vertical first</source>
+        <translation type="unfinished">Otomatik ileri kaydır, önce dikey</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1255"/>
+        <source>Autoscroll backward, vertical first</source>
+        <translation type="unfinished">Otomatik geri kaydır, önce dikey</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1259"/>
+        <source>Move down</source>
+        <translation type="unfinished">Aşağı git</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1262"/>
+        <source>Move up</source>
+        <translation type="unfinished">Yukarı git</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1265"/>
+        <source>Move left</source>
+        <translation type="unfinished">Sola git</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1268"/>
+        <source>Move right</source>
+        <translation type="unfinished">Sağa git</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1271"/>
+        <source>Go to the first page</source>
+        <translation type="unfinished">İlk sayfaya git</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1274"/>
+        <source>Go to the last page</source>
+        <translation type="unfinished">En son sayfaya git</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1290"/>
+        <source>Reading</source>
+        <translation type="unfinished">Okuma</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1335"/>
+        <source>There is a new version available</source>
+        <translation type="unfinished">Yeni versiyon mevcut</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1336"/>
+        <source>Do you want to download the new version?</source>
+        <translation type="unfinished">Yeni versiyonu indirmek ister misin ?</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1339"/>
+        <source>Remind me in 14 days</source>
+        <translation type="unfinished">14 gün içinde hatırlat</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1340"/>
+        <source>Not now</source>
+        <translation type="unfinished">Şimdi değil</translation>
+    </message>
+</context>
+<context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation>Kapat</translation>
     </message>
@@ -740,10 +1322,13 @@
 <context>
     <name>YACReaderFieldEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11"/>
         <source>Restore to default</source>
         <translation>Varsayılana ayarla</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28"/>
         <source>Click to overwrite</source>
         <translation>Üzerine yazmak için tıkla</translation>
     </message>
@@ -751,10 +1336,15 @@
 <context>
     <name>YACReaderFieldPlainTextEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10"/>
         <source>Restore to default</source>
         <translation>Varsayılana ayarla</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50"/>
         <source>Click to overwrite</source>
         <translation>Üstüne yazmak için tıkla</translation>
     </message>
@@ -762,18 +1352,22 @@
 <context>
     <name>YACReaderFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="15"/>
         <source>CoverFlow look</source>
         <translation>Kapak akışı görünümü</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="13"/>
         <source>How to show covers:</source>
         <translation>Kapaklar nasıl gözüksün:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="16"/>
         <source>Stripe look</source>
         <translation>Şerit görünüm</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="17"/>
         <source>Overlapped Stripe look</source>
         <translation>Çakışan şerit görünüm</translation>
     </message>
@@ -781,94 +1375,117 @@
 <context>
     <name>YACReaderGLFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="112"/>
         <source>Zoom</source>
         <translation>Yakınlaş</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="142"/>
         <source>Light</source>
         <translation>Işık</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="76"/>
         <source>Show advanced settings</source>
         <translation>Daha fazla ayar göster</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="32"/>
         <source>Roulette look</source>
         <translation>Rulet görünüm</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="130"/>
         <source>Cover Angle</source>
         <translation>Kapak Açısı</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="23"/>
         <source>Stripe look</source>
         <translation>Strip görünüm</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="94"/>
         <source>Position</source>
         <translation>Pozisyon</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="124"/>
         <source>Z offset</source>
         <translation>Z dengesi</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="118"/>
         <source>Y offset</source>
         <translation>Y dengesi</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="106"/>
         <source>Central gap</source>
         <translation>Boş merkaz</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="18"/>
         <source>Presets:</source>
         <translation>Hazırlayan:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="26"/>
         <source>Overlapped Stripe look</source>
         <translation>Çakışan şerit görünüm</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="29"/>
         <source>Modern look</source>
         <translation>Modern görünüm</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="88"/>
         <source>View angle</source>
         <translation>Bakış açısı</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="148"/>
         <source>Max angle</source>
         <translation>Maksimum açı</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="85"/>
         <source>Custom:</source>
         <translation>Kişisel:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="20"/>
         <source>Classic look</source>
         <translation>Klasik görünüm</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="100"/>
         <source>Cover gap</source>
         <translation>Kapak boşluğu</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="182"/>
         <source>High Performance</source>
         <translation>Yüksek performans</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="201"/>
         <source>Performance:</source>
         <translation>Performans:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="193"/>
         <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
         <translation>VSync kullan</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="136"/>
         <source>Visibility</source>
         <translation>Görünülebilirlik</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="180"/>
         <source>Low Performance</source>
         <translation>Düşük Performans</translation>
     </message>
@@ -876,22 +1493,27 @@
 <context>
     <name>YACReaderOptionsDialog</name>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28"/>
         <source>Save</source>
         <translation>Kaydet</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="46"/>
         <source>Use hardware acceleration (restart needed)</source>
         <translation>Yüksek donanımlı kullan (yeniden başlatmak gerekli)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="29"/>
         <source>Cancel</source>
         <translation>Vazgeç</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="34"/>
         <source>Edit shortcuts</source>
         <translation>Kısayolları düzenle</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="37"/>
         <source>Shortcuts</source>
         <translation>Kısayollar</translation>
     </message>
@@ -899,6 +1521,7 @@
 <context>
     <name>YACReaderSlider</name>
     <message>
+        <location filename="width_slider.cpp" line="49"/>
         <source>Reset</source>
         <translation>Yeniden başlat</translation>
     </message>
@@ -906,18 +1529,23 @@
 <context>
     <name>YACReaderTranslator</name>
     <message>
+        <location filename="translator.cpp" line="62"/>
         <source>YACReader translator</source>
         <translation>YACReader çevirmeni</translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="116"/>
+        <location filename="translator.cpp" line="207"/>
         <source>Translation</source>
         <translation>Çeviri</translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="139"/>
         <source>clear</source>
         <translation>temizle</translation>
     </message>
     <message>
+        <location filename="translator.cpp" line="216"/>
         <source>Service not available</source>
         <translation>Servis kullanılamıyor</translation>
     </message>

--- a/YACReader/yacreader_zh_CN.ts
+++ b/YACReader/yacreader_zh_CN.ts
@@ -124,17 +124,17 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
-        <location filename="../custom_widgets/help_about_dialog.cpp" line="25"/>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation>关于</translation>
     </message>
     <message>
-        <location filename="../custom_widgets/help_about_dialog.cpp" line="28"/>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
         <translation>帮助</translation>
     </message>
     <message>
-        <location filename="../custom_widgets/help_about_dialog.cpp" line="31"/>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
         <source>System info</source>
         <translation>系统信息</translation>
     </message>
@@ -190,112 +190,112 @@
         <translation>我的漫画路径</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="64"/>
+        <location filename="options_dialog.cpp" line="61"/>
         <source>Background color</source>
         <translation>背景颜色</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="67"/>
+        <location filename="options_dialog.cpp" line="64"/>
         <source>Choose</source>
         <translation>选择</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="100"/>
+        <location filename="options_dialog.cpp" line="97"/>
         <source>Quick Navigation Mode</source>
         <translation>快速导航模式</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="101"/>
+        <location filename="options_dialog.cpp" line="98"/>
         <source>Disable mouse over activation</source>
         <translation>禁用鼠标激活</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="200"/>
+        <location filename="options_dialog.cpp" line="197"/>
         <source>Restart is needed</source>
         <translation>需要重启</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="144"/>
+        <location filename="options_dialog.cpp" line="141"/>
         <source>Brightness</source>
         <translation>亮度</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="74"/>
+        <location filename="options_dialog.cpp" line="71"/>
         <source>Scroll behaviour</source>
         <translation>滚动效果</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="77"/>
+        <location filename="options_dialog.cpp" line="74"/>
         <source>Do not turn page using scroll</source>
         <translation>滚动时不翻页</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="78"/>
+        <location filename="options_dialog.cpp" line="75"/>
         <source>Use single scroll step to turn page</source>
         <translation>使用单滚动步骤翻页</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="145"/>
+        <location filename="options_dialog.cpp" line="142"/>
         <source>Contrast</source>
         <translation>对比度</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="146"/>
+        <location filename="options_dialog.cpp" line="143"/>
         <source>Gamma</source>
         <translation>Gamma值</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="150"/>
+        <location filename="options_dialog.cpp" line="147"/>
         <source>Reset</source>
         <translation>重置</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="155"/>
+        <location filename="options_dialog.cpp" line="152"/>
         <source>Image options</source>
         <translation>图片选项</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="159"/>
+        <location filename="options_dialog.cpp" line="156"/>
         <source>Fit options</source>
         <translation>适应项</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="161"/>
+        <location filename="options_dialog.cpp" line="158"/>
         <source>Enlarge images to fit width/height</source>
         <translation>放大图片以适应宽度/高度</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="172"/>
+        <location filename="options_dialog.cpp" line="169"/>
         <source>Double Page options</source>
         <translation>双页选项</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="174"/>
+        <location filename="options_dialog.cpp" line="171"/>
         <source>Show covers as single page</source>
         <translation>显示封面为单页</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="192"/>
+        <location filename="options_dialog.cpp" line="189"/>
         <source>General</source>
         <translation>常规</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="193"/>
+        <location filename="options_dialog.cpp" line="190"/>
         <source>Page Flow</source>
         <translation>页面流</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="194"/>
+        <location filename="options_dialog.cpp" line="191"/>
         <source>Image adjustment</source>
         <translation>图像调整</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="209"/>
+        <location filename="options_dialog.cpp" line="206"/>
         <source>Options</source>
         <translation>选项</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="216"/>
+        <location filename="options_dialog.cpp" line="213"/>
         <source>Comics directory</source>
         <translation>漫画目录</translation>
     </message>
@@ -935,7 +935,7 @@
 <context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
-        <location filename="../custom_widgets/whats_new_dialog.cpp" line="104"/>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>

--- a/YACReader/yacreader_zh_HK.ts
+++ b/YACReader/yacreader_zh_HK.ts
@@ -124,17 +124,17 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
-        <location filename="../custom_widgets/help_about_dialog.cpp" line="25"/>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation>關於</translation>
     </message>
     <message>
-        <location filename="../custom_widgets/help_about_dialog.cpp" line="28"/>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
         <translation>幫助</translation>
     </message>
     <message>
-        <location filename="../custom_widgets/help_about_dialog.cpp" line="31"/>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
         <source>System info</source>
         <translation>系統資訊</translation>
     </message>
@@ -190,112 +190,112 @@
         <translation>我的漫畫路徑</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="64"/>
+        <location filename="options_dialog.cpp" line="61"/>
         <source>Background color</source>
         <translation>背景顏色</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="67"/>
+        <location filename="options_dialog.cpp" line="64"/>
         <source>Choose</source>
         <translation>選擇</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="100"/>
+        <location filename="options_dialog.cpp" line="97"/>
         <source>Quick Navigation Mode</source>
         <translation>快速導航模式</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="101"/>
+        <location filename="options_dialog.cpp" line="98"/>
         <source>Disable mouse over activation</source>
         <translation>禁用滑鼠啟動</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="200"/>
+        <location filename="options_dialog.cpp" line="197"/>
         <source>Restart is needed</source>
         <translation>需要重啟</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="144"/>
+        <location filename="options_dialog.cpp" line="141"/>
         <source>Brightness</source>
         <translation>亮度</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="74"/>
+        <location filename="options_dialog.cpp" line="71"/>
         <source>Scroll behaviour</source>
         <translation>滾動效果</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="77"/>
+        <location filename="options_dialog.cpp" line="74"/>
         <source>Do not turn page using scroll</source>
         <translation>滾動時不翻頁</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="78"/>
+        <location filename="options_dialog.cpp" line="75"/>
         <source>Use single scroll step to turn page</source>
         <translation>使用單滾動步驟翻頁</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="145"/>
+        <location filename="options_dialog.cpp" line="142"/>
         <source>Contrast</source>
         <translation>對比度</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="146"/>
+        <location filename="options_dialog.cpp" line="143"/>
         <source>Gamma</source>
         <translation>Gamma值</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="150"/>
+        <location filename="options_dialog.cpp" line="147"/>
         <source>Reset</source>
         <translation>重置</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="155"/>
+        <location filename="options_dialog.cpp" line="152"/>
         <source>Image options</source>
         <translation>圖片選項</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="159"/>
+        <location filename="options_dialog.cpp" line="156"/>
         <source>Fit options</source>
         <translation>適應項</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="161"/>
+        <location filename="options_dialog.cpp" line="158"/>
         <source>Enlarge images to fit width/height</source>
         <translation>放大圖片以適應寬度/高度</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="172"/>
+        <location filename="options_dialog.cpp" line="169"/>
         <source>Double Page options</source>
         <translation>雙頁選項</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="174"/>
+        <location filename="options_dialog.cpp" line="171"/>
         <source>Show covers as single page</source>
         <translation>顯示封面為單頁</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="192"/>
+        <location filename="options_dialog.cpp" line="189"/>
         <source>General</source>
         <translation>常規</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="193"/>
+        <location filename="options_dialog.cpp" line="190"/>
         <source>Page Flow</source>
         <translation>頁面流</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="194"/>
+        <location filename="options_dialog.cpp" line="191"/>
         <source>Image adjustment</source>
         <translation>圖像調整</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="209"/>
+        <location filename="options_dialog.cpp" line="206"/>
         <source>Options</source>
         <translation>選項</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="216"/>
+        <location filename="options_dialog.cpp" line="213"/>
         <source>Comics directory</source>
         <translation>漫畫目錄</translation>
     </message>
@@ -935,7 +935,7 @@
 <context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
-        <location filename="../custom_widgets/whats_new_dialog.cpp" line="104"/>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation>關閉</translation>
     </message>

--- a/YACReader/yacreader_zh_TW.ts
+++ b/YACReader/yacreader_zh_TW.ts
@@ -124,17 +124,17 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
-        <location filename="../custom_widgets/help_about_dialog.cpp" line="25"/>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation>關於</translation>
     </message>
     <message>
-        <location filename="../custom_widgets/help_about_dialog.cpp" line="28"/>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
         <translation>幫助</translation>
     </message>
     <message>
-        <location filename="../custom_widgets/help_about_dialog.cpp" line="31"/>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
         <source>System info</source>
         <translation>系統資訊</translation>
     </message>
@@ -190,112 +190,112 @@
         <translation>我的漫畫路徑</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="64"/>
+        <location filename="options_dialog.cpp" line="61"/>
         <source>Background color</source>
         <translation>背景顏色</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="67"/>
+        <location filename="options_dialog.cpp" line="64"/>
         <source>Choose</source>
         <translation>選擇</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="100"/>
+        <location filename="options_dialog.cpp" line="97"/>
         <source>Quick Navigation Mode</source>
         <translation>快速導航模式</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="101"/>
+        <location filename="options_dialog.cpp" line="98"/>
         <source>Disable mouse over activation</source>
         <translation>禁用滑鼠啟動</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="200"/>
+        <location filename="options_dialog.cpp" line="197"/>
         <source>Restart is needed</source>
         <translation>需要重啟</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="144"/>
+        <location filename="options_dialog.cpp" line="141"/>
         <source>Brightness</source>
         <translation>亮度</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="74"/>
+        <location filename="options_dialog.cpp" line="71"/>
         <source>Scroll behaviour</source>
         <translation>滾動效果</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="77"/>
+        <location filename="options_dialog.cpp" line="74"/>
         <source>Do not turn page using scroll</source>
         <translation>滾動時不翻頁</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="78"/>
+        <location filename="options_dialog.cpp" line="75"/>
         <source>Use single scroll step to turn page</source>
         <translation>使用單滾動步驟翻頁</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="145"/>
+        <location filename="options_dialog.cpp" line="142"/>
         <source>Contrast</source>
         <translation>對比度</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="146"/>
+        <location filename="options_dialog.cpp" line="143"/>
         <source>Gamma</source>
         <translation>Gamma值</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="150"/>
+        <location filename="options_dialog.cpp" line="147"/>
         <source>Reset</source>
         <translation>重置</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="155"/>
+        <location filename="options_dialog.cpp" line="152"/>
         <source>Image options</source>
         <translation>圖片選項</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="159"/>
+        <location filename="options_dialog.cpp" line="156"/>
         <source>Fit options</source>
         <translation>適應項</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="161"/>
+        <location filename="options_dialog.cpp" line="158"/>
         <source>Enlarge images to fit width/height</source>
         <translation>放大圖片以適應寬度/高度</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="172"/>
+        <location filename="options_dialog.cpp" line="169"/>
         <source>Double Page options</source>
         <translation>雙頁選項</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="174"/>
+        <location filename="options_dialog.cpp" line="171"/>
         <source>Show covers as single page</source>
         <translation>顯示封面為單頁</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="192"/>
+        <location filename="options_dialog.cpp" line="189"/>
         <source>General</source>
         <translation>常規</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="193"/>
+        <location filename="options_dialog.cpp" line="190"/>
         <source>Page Flow</source>
         <translation>頁面流</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="194"/>
+        <location filename="options_dialog.cpp" line="191"/>
         <source>Image adjustment</source>
         <translation>圖像調整</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="209"/>
+        <location filename="options_dialog.cpp" line="206"/>
         <source>Options</source>
         <translation>選項</translation>
     </message>
     <message>
-        <location filename="options_dialog.cpp" line="216"/>
+        <location filename="options_dialog.cpp" line="213"/>
         <source>Comics directory</source>
         <translation>漫畫目錄</translation>
     </message>
@@ -935,7 +935,7 @@
 <context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
-        <location filename="../custom_widgets/whats_new_dialog.cpp" line="104"/>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation>關閉</translation>
     </message>

--- a/YACReaderLibrary/YACReaderLibrary.pro
+++ b/YACReaderLibrary/YACReaderLibrary.pro
@@ -285,8 +285,8 @@ TRANSLATIONS =   yacreaderlibrary_es.ts \
                 yacreaderlibrary_zh_CN.ts \
                 yacreaderlibrary_zh_TW.ts \
                 yacreaderlibrary_zh_HK.ts \
-                yacreaderlibrary_it.ts
-#                yacreaderlibrary_source.ts
+                yacreaderlibrary_it.ts \
+                yacreaderlibrary_en.ts
 
 CONFIG += lrelease
 

--- a/YACReaderLibrary/YACReaderLibrary.pro
+++ b/YACReaderLibrary/YACReaderLibrary.pro
@@ -291,6 +291,23 @@ TRANSLATIONS =   yacreaderlibrary_es.ts \
 LRELEASE_DIR = ../release/languages/
 CONFIG += lrelease
 
+win32 {
+    CONFIG(release, debug|release) {
+        SOURCE_QM_DIR = $$OUT_PWD/release/*.qm
+    }
+    CONFIG(debug, debug|release) {
+        SOURCE_QM_DIR = $$OUT_PWD/debug/*.qm
+    }
+
+    DEPLOYMENT_OUT_QM_DIR = ../release/languages/
+    OUT_QM_DIR = $${DESTDIR}/languages/
+
+    QMAKE_POST_LINK += $(MKDIR) $$shell_path($${OUT_QM_DIR}) 2> NULL & \
+                       $(COPY) $$shell_path($${SOURCE_QM_DIR}) $$shell_path($${OUT_QM_DIR}) & \
+                       $(MKDIR) $$shell_path($${DEPLOYMENT_OUT_QM_DIR}) 2> NULL & \
+                       $(COPY) $$shell_path($${SOURCE_QM_DIR}) $$shell_path($${DEPLOYMENT_OUT_QM_DIR})
+}
+
 #QML/GridView
 QT += quick qml quickwidgets
 

--- a/YACReaderLibrary/YACReaderLibrary.pro
+++ b/YACReaderLibrary/YACReaderLibrary.pro
@@ -288,7 +288,6 @@ TRANSLATIONS =   yacreaderlibrary_es.ts \
                 yacreaderlibrary_it.ts
 #                yacreaderlibrary_source.ts
 
-LRELEASE_DIR = ../release/languages/
 CONFIG += lrelease
 
 win32 {
@@ -306,6 +305,8 @@ win32 {
                        $(COPY) $$shell_path($${SOURCE_QM_DIR}) $$shell_path($${OUT_QM_DIR}) & \
                        $(MKDIR) $$shell_path($${DEPLOYMENT_OUT_QM_DIR}) 2> NULL & \
                        $(COPY) $$shell_path($${SOURCE_QM_DIR}) $$shell_path($${DEPLOYMENT_OUT_QM_DIR})
+} else {
+    LRELEASE_DIR = ../release/languages/
 }
 
 #QML/GridView

--- a/YACReaderLibrary/main.cpp
+++ b/YACReaderLibrary/main.cpp
@@ -171,13 +171,13 @@ int main(int argc, char **argv)
 #endif
     app.installTranslator(&translator);
 
-    QTranslator viewerTranslator;
-#if defined Q_OS_UNIX && !defined Q_OS_MAC
-    viewerTranslator.load(QString(DATADIR) + "/yacreader/languages/yacreader_" + sufix);
-#else
-    viewerTranslator.load(QCoreApplication::applicationDirPath() + "/languages/yacreader_" + sufix);
-#endif
-    app.installTranslator(&viewerTranslator);
+    /*QTranslator viewerTranslator;
+    #if defined Q_OS_UNIX && !defined Q_OS_MAC
+        viewerTranslator.load(QString(DATADIR) + "/yacreader/languages/yacreader_" + sufix);
+    #else
+        viewerTranslator.load(QCoreApplication::applicationDirPath() + "/languages/yacreader_" + sufix);
+    #endif
+        app.installTranslator(&viewerTranslator);*/
 
     qRegisterMetaType<ComicDB>("ComicDB");
 

--- a/YACReaderLibrary/main.cpp
+++ b/YACReaderLibrary/main.cpp
@@ -164,11 +164,10 @@ int main(int argc, char **argv)
     logger.addDestination(std::move(fileDestination));
 
     QTranslator translator;
-    QString sufix = QLocale::system().name();
 #if defined Q_OS_UNIX && !defined Q_OS_MAC
-    translator.load(QString(DATADIR) + "/yacreader/languages/yacreaderlibrary_" + sufix);
+    translator.load(QLocale(), "yacreaderlibrary", "_", QString(DATADIR) + "/yacreader/languages");
 #else
-    translator.load(QCoreApplication::applicationDirPath() + "/languages/yacreaderlibrary_" + sufix);
+    translator.load(QLocale(), "yacreaderlibrary", "_", "languages");
 #endif
     app.installTranslator(&translator);
 

--- a/YACReaderLibrary/yacreaderlibrary_de.ts
+++ b/YACReaderLibrary/yacreaderlibrary_de.ts
@@ -4,6 +4,7 @@
 <context>
     <name>ActionsShortcutsModel</name>
     <message>
+        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="73"/>
         <source>None</source>
         <translation>Keine</translation>
     </message>
@@ -11,66 +12,82 @@
 <context>
     <name>AddLabelDialog</name>
     <message>
+        <location filename="add_label_dialog.cpp" line="37"/>
         <source>cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="8"/>
         <source>Label name:</source>
         <translation>Label-Name:</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="11"/>
         <source>Choose a color:</source>
         <translation>Wähle eine Farbe:</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="14"/>
         <source>red</source>
         <translation>Rot</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="15"/>
         <source>orange</source>
         <translation>Orange</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="16"/>
         <source>yellow</source>
         <translation>Gelb</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="17"/>
         <source>green</source>
         <translation>Grün</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="18"/>
         <source>cyan</source>
         <translation>Kobalt</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="19"/>
         <source>blue</source>
         <translation>Blau</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="20"/>
         <source>violet</source>
         <translation>Violett</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="21"/>
         <source>purple</source>
         <translation>Lila</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="22"/>
         <source>pink</source>
         <translation>Pink</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="23"/>
         <source>white</source>
         <translation>Weiß</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="24"/>
         <source>light</source>
         <translation>Hell</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="25"/>
         <source>dark</source>
         <translation>Dunkel</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="36"/>
         <source>accept</source>
         <translation>Akzeptieren</translation>
     </message>
@@ -78,22 +95,27 @@
 <context>
     <name>AddLibraryDialog</name>
     <message>
+        <location filename="add_library_dialog.cpp" line="26"/>
         <source>Add</source>
         <translation>Hinzufügen</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="66"/>
         <source>Add an existing library</source>
         <translation>Eine vorhandene Bibliothek hinzufügen</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="30"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="16"/>
         <source>Comics folder : </source>
         <translation>Comics-Ordner :</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="21"/>
         <source>Library name : </source>
         <translation>Bibliothek-Name :</translation>
     </message>
@@ -101,18 +123,22 @@
 <context>
     <name>ApiKeyDialog</name>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="21"/>
         <source>Before you can connect to Comic Vine, you need your own API key. Please, get one free &lt;a href=&quot;http://www.comicvine.com/api/&quot;&gt;here&lt;/a&gt;</source>
         <translation>Bevor du dich mit Comic Vine verbindest, brauchst du deinen eigenen API-Schlüssel. Du kannst &lt;a href=&quot;http://www.comicvine.com/api/&quot;&gt;hier&lt;/a&gt; einen kostenlosen bekommen.</translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="25"/>
         <source>Paste here your Comic Vine API key</source>
         <translation>Füge hier deinen Comic Vine API-Schlüssel ein.</translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="28"/>
         <source>Accept</source>
         <translation>Akzeptieren</translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="32"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
@@ -120,6 +146,7 @@
 <context>
     <name>ClassicComicsView</name>
     <message>
+        <location filename="classic_comics_view.cpp" line="90"/>
         <source>Hide comic flow</source>
         <translation>Comic &quot;Flow&quot; verstecken</translation>
     </message>
@@ -127,46 +154,57 @@
 <context>
     <name>ComicInfoView</name>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="279"/>
         <source>Authors</source>
         <translation>Autoren</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="309"/>
         <source>writer</source>
         <translation>Schriftsteller</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="331"/>
         <source>penciller</source>
         <translation>Künstler (Bleistift)</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="353"/>
         <source>inker</source>
         <translation>Künstler (Tinte)</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="375"/>
         <source>colorist</source>
         <translation>Künstler (Farbe)</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="397"/>
         <source>letterer</source>
         <translation>Künstler (Lettering)</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="419"/>
         <source>cover artist</source>
         <translation>Künstler (Cover)</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="434"/>
         <source>Publisher</source>
         <translation>Herausgeber</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
         <source>color</source>
         <translation>Farbe</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
         <source>b/w</source>
         <translation>Schwarzweiß</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="502"/>
         <source>Characters</source>
         <translation>Charaktere</translation>
     </message>
@@ -174,38 +212,52 @@
 <context>
     <name>ComicModel</name>
     <message>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>no</source>
         <translation>Nein</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>yes</source>
         <translation>Ja</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="351"/>
         <source>Read</source>
         <translation>Lesen</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="349"/>
         <source>Size</source>
         <translation>Größe</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="347"/>
         <source>Pages</source>
         <translation>Seiten</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="343"/>
         <source>Title</source>
         <translation>Titel</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="353"/>
         <source>Current Page</source>
         <translation>Aktuelle Seite</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="345"/>
         <source>File Name</source>
         <translation>Dateiname</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="355"/>
+        <source>Publication Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="357"/>
         <source>Rating</source>
         <translation>Bewertung</translation>
     </message>
@@ -213,50 +265,67 @@
 <context>
     <name>ComicVineDialog</name>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="58"/>
         <source>back</source>
         <translation>zurück</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="59"/>
         <source>next</source>
         <translation>nächste</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="57"/>
         <source>skip</source>
         <translation>überspringen</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="61"/>
         <source>close</source>
         <translation>schließen</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="467"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="503"/>
         <source>Retrieving tags for : %1</source>
         <translation>Herunterladen von Tags für : %1</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="814"/>
         <source>Looking for comic...</source>
         <translation>Suche nach Comic...</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="60"/>
         <source>search</source>
         <translation>suche</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="143"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="257"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="773"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="807"/>
         <source>Looking for volume...</source>
         <translation>Suche nach Band....</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="141"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="735"/>
         <source>comic %1 of %2 - %3</source>
         <translation>Comic %1 von %2 - %3</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="262"/>
         <source>%1 comics selected</source>
         <translation>%1 Comic ausgewählt</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="295"/>
         <source>Error connecting to ComicVine</source>
         <translation>Fehler bei Verbindung zu ComicVine</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="788"/>
         <source>Retrieving volume info...</source>
         <translation>Herunterladen von Info zu Ausgabe...</translation>
     </message>
@@ -264,34 +333,42 @@
 <context>
     <name>CreateLibraryDialog</name>
     <message>
+        <location filename="create_library_dialog.cpp" line="75"/>
         <source>Create new library</source>
         <translation>Erstelle eine neue Bibliothek</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="31"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="27"/>
         <source>Create</source>
         <translation>Erstellen</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="53"/>
         <source>Create a library could take several minutes. You can stop the process and update the library later for completing the task.</source>
         <translation>Es kann einige Minuten dauern, eine neue Bibliothek zu erstellen. Sie können den Prozess abbrechen und die Bibliothek später aktualisieren, um den Vorgang abzuschließen.</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="95"/>
         <source>The selected path does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation>Der gewählte Pfad existiert nicht oder ist kein gültiger Pfad. Stellen Sie sicher, dass Sie Schreibzugriff zu dem Ordner haben</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="17"/>
         <source>Comics folder : </source>
         <translation>Comics-Ordner :</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="22"/>
         <source>Library Name : </source>
         <translation>Bibliothek-Name :</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="95"/>
         <source>Path not found</source>
         <translation>Pfad nicht gefunden</translation>
     </message>
@@ -299,22 +376,27 @@
 <context>
     <name>EditShortcutsDialog</name>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="21"/>
         <source>Restore defaults</source>
         <translation>Standard wiederherstellen</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="22"/>
         <source>To change a shortcut, double click in the key combination and type the new keys.</source>
         <translation>Um eine Tastenkombination zu ändern, doppelklicken Sie auf die Tastenkombination und geben Sie die neuen Tasten ein.</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="69"/>
         <source>Shortcuts settings</source>
         <translation>Kürzel-Einstellungen</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>Shortcut in use</source>
         <translation>Verwendete Kürzel</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>The shortcut &quot;%1&quot; is already assigned to other function</source>
         <translation>Das Kürzel &quot;%1&quot; ist bereits für eine andere Funktion in Verwendung</translation>
     </message>
@@ -322,14 +404,18 @@
 <context>
     <name>EmptyFolderWidget</name>
     <message>
+        <location filename="empty_folder_widget.cpp" line="75"/>
+        <location filename="empty_folder_widget.cpp" line="140"/>
         <source>Subfolders in this folder</source>
         <translation>Unterordner in diesem Ordner</translation>
     </message>
     <message>
+        <location filename="empty_folder_widget.cpp" line="138"/>
         <source>Empty folder</source>
         <translation>Leerer Ordner</translation>
     </message>
     <message>
+        <location filename="empty_folder_widget.cpp" line="138"/>
         <source>Drag and drop folders and comics here</source>
         <translation>Ziehen Sie Ordner und Comics hierher, um sie abzulegen</translation>
     </message>
@@ -337,6 +423,7 @@
 <context>
     <name>EmptyLabelWidget</name>
     <message>
+        <location filename="empty_label_widget.cpp" line="11"/>
         <source>This label doesn&apos;t contain comics yet</source>
         <translation>Dieses Label enthält noch keine Comics</translation>
     </message>
@@ -344,6 +431,7 @@
 <context>
     <name>EmptyReadingListWidget</name>
     <message>
+        <location filename="empty_reading_list_widget.cpp" line="8"/>
         <source>This reading list does not contain any comics yet</source>
         <translation>Diese Leseliste enthält noch keine Comics</translation>
     </message>
@@ -351,30 +439,37 @@
 <context>
     <name>ExportComicsInfoDialog</name>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="14"/>
         <source>Output file : </source>
         <translation>Zieldatei :</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="66"/>
         <source>Destination database name</source>
         <translation>Ziel-Datenbank Name</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="22"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="18"/>
         <source>Create</source>
         <translation>Erstellen</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="81"/>
         <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation>Der gewählte Pfad existiert nicht oder ist kein gültiger Pfad. Stellen Sie sicher, dass Sie Schreibzugriff zu dem Ordner haben</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="57"/>
         <source>Export comics info</source>
         <translation>Comicinfo exportieren</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="81"/>
         <source>Problem found while writing</source>
         <translation>Problem beim Schreiben</translation>
     </message>
@@ -382,30 +477,37 @@
 <context>
     <name>ExportLibraryDialog</name>
     <message>
+        <location filename="export_library_dialog.cpp" line="19"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="15"/>
         <source>Create</source>
         <translation>Erstellen</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="71"/>
         <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation>Der gewählte Pfad existiert nicht oder ist kein gültiger Pfad. Stellen Sie sicher, dass Sie Schreibzugriff zu dem Ordner haben</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="11"/>
         <source>Output folder : </source>
         <translation>Ziel-Ordner :</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="71"/>
         <source>Problem found while writing</source>
         <translation>Problem beim Schreiben</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="60"/>
         <source>Create covers package</source>
         <translation>Erzeuge Titelbild-Paket</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="76"/>
         <source>Destination directory</source>
         <translation>Ziel-Verzeichnis</translation>
     </message>
@@ -413,25 +515,46 @@
 <context>
     <name>FileComic</name>
     <message>
+        <location filename="../common/comic.cpp" line="568"/>
         <source>Format not supported</source>
         <translation>Format nicht unterstützt</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="562"/>
         <source>7z not found</source>
         <translation>7z nicht gefunden</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="461"/>
         <source>Unknown error opening the file</source>
         <translation>Unbekannter Fehler beim Öffnen der Datei</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="454"/>
         <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
         <translation>CRC Fehler auf Seite (%1): einige Seiten werden nicht korrekt dargestellt</translation>
     </message>
 </context>
 <context>
+    <name>FolderContentView</name>
+    <message>
+        <location filename="qml/FolderContentView.qml" line="238"/>
+        <source>Continue Reading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FolderContentView6</name>
+    <message>
+        <location filename="qml/FolderContentView6.qml" line="240"/>
+        <source>Continue Reading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GridComicsView</name>
     <message>
+        <location filename="grid_comics_view.cpp" line="147"/>
         <source>Show info</source>
         <translation>Info anzeigen</translation>
     </message>
@@ -439,10 +562,17 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Hilfe</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
+        <source>System info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation>Über</translation>
     </message>
@@ -450,22 +580,27 @@
 <context>
     <name>ImportComicsInfoDialog</name>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="24"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="20"/>
         <source>Import</source>
         <translation>Importieren</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="16"/>
         <source>Info database location : </source>
         <translation>Info-Datenbank Speicherort :</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="14"/>
         <source>Import comics info</source>
         <translation>Importiere Comic-Info</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="74"/>
         <source>Comics info file (*.ydb)</source>
         <translation>Comics Info File (*.ydb)</translation>
     </message>
@@ -473,30 +608,37 @@
 <context>
     <name>ImportLibraryDialog</name>
     <message>
+        <location filename="import_library_dialog.cpp" line="26"/>
         <source>Destination folder : </source>
         <translation>Zielordner :</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="34"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="30"/>
         <source>Unpack</source>
         <translation>Entpacken</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="108"/>
         <source>Compresed library covers (*.clc)</source>
         <translation>Komprimierte Bibliothek Cover (*.clc)</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="22"/>
         <source>Package location : </source>
         <translation>Paket Ort :</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="17"/>
         <source>Library Name : </source>
         <translation>Bibliothek-Name :</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="87"/>
         <source>Extract a catalog</source>
         <translation>Einen Katalog extrahieren</translation>
     </message>
@@ -504,489 +646,667 @@
 <context>
     <name>ImportWidget</name>
     <message>
+        <location filename="import_widget.cpp" line="150"/>
         <source>stop</source>
         <translation>Stop</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="334"/>
         <source>Importing comics</source>
         <translation>Comics werden importiert</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="335"/>
         <source>&lt;p&gt;YACReaderLibrary is now creating a new library.&lt;/p&gt;&lt;p&gt;Create a library could take several minutes. You can stop the process and update the library later for completing the task.&lt;/p&gt;</source>
         <translation>&lt;p&gt;YACReaderLibrary erstellt nun eine neue Bibliothek. &lt;/p&gt;&lt;p&gt;Es kann einige Minuten dauern, eine neue Bibliothek zu erstellen. Sie können den Prozess abbrechen und die Bibliothek später aktualisieren, um den Vorgang abzuschließen.&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="190"/>
         <source>Some of the comics being added...</source>
         <translation>Einige der Comics werden hinzugefügt...</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="346"/>
         <source>Updating the library</source>
         <translation>Aktualisierung der Bibliothek</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="347"/>
         <source>&lt;p&gt;The current library is being updated. For faster updates, please, update your libraries frequently.&lt;/p&gt;&lt;p&gt;You can stop the process and continue updating this library later.&lt;/p&gt;</source>
         <translation>&lt;p&gt;Die aktuelle Bibliothek wird gerade aktualisiert. Für eine schnellere Aktualisierung, aktualisieren Sie die Bibliothek bitte regelmäßig.&lt;/p&gt;&lt;p&gt;Sie können den Prozess abbrechen und mit der Aktualisierung später fortfahren.&lt;p&gt;</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="358"/>
         <source>Upgrading the library</source>
         <translation>Upgrade der Bibliothek</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="359"/>
         <source>&lt;p&gt;The current library is being upgraded, please wait.&lt;/p&gt;</source>
         <translation>Die aktuelle Bibliothek wird gerade upgegradet, bitte warten.</translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="370"/>
+        <source>Scanning the library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="371"/>
+        <source>&lt;p&gt;Current library is being scanned for legacy XML metadata information.&lt;/p&gt;&lt;p&gt;This is only needed once, and only if the library was crated with YACReaderLibrary 9.8.2 or earlier.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LibraryWindow</name>
     <message>
+        <location filename="library_window.cpp" line="730"/>
         <source>Edit</source>
         <translation>Bearbeiten</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2083"/>
         <source>The selected folder doesn&apos;t contain any library.</source>
         <translation>Der ausgewählte Ordner enthält keine Bibliothek.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1269"/>
         <source>This library was created with a previous version of YACReaderLibrary. It needs to be updated. Update now?</source>
         <translation>Diese Bibliothek wurde mit einer älteren Version von YACReader erzeugt. Sie muss geupdated werden. Jetzt updaten?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1060"/>
         <source>Comic</source>
         <translation>Comic</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2659"/>
         <source>Error opening the library</source>
         <translation>Fehler beim Öffnen der Bibliothek</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="585"/>
         <source>Show/Hide marks</source>
         <translation>Zeige/Verberge Markierungen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1993"/>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found</source>
         <translation>YACReader nicht gefunden</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="648"/>
         <source>Show comics server options dialog</source>
         <translation>Zeige Comic-Server-Optionen-Dialog</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="532"/>
         <source>Remove current library from your collection</source>
         <translation>Aktuelle Bibliothek aus der Sammlung entfernen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="554"/>
         <source>Set comic as read</source>
         <translation>Comic als gelesen markieren</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2139"/>
         <source>Remove and delete metadata</source>
         <translation>Entferne und lösche Metadaten</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Old library</source>
         <translation>Alte Bibliothek</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="742"/>
         <source>Update cover</source>
         <translation>Titelbild updaten</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="685"/>
+        <location filename="library_window.cpp" line="1797"/>
         <source>Set as completed</source>
         <translation>Als gelesen markieren</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1027"/>
         <source>Library</source>
         <translation>Bibliothek</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="526"/>
         <source>Rename current library</source>
         <translation>Aktuelle Bibliothek umbenennen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="593"/>
+        <location filename="library_window.cpp" line="594"/>
         <source>Fullscreen mode on/off</source>
         <translation>Vollbildmodus an/aus</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1336"/>
         <source>This library was created with a newer version of YACReaderLibrary. Download the new version now?</source>
         <translation>Die Bibliothek wurde mit einer neueren Version von YACReader erstellt. Die neue Version jetzt herunterladen?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="543"/>
         <source>Open current comic on YACReader</source>
         <translation>Aktuellen Comic mit YACReader öffnen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="520"/>
         <source>Update current library</source>
         <translation>Aktuelle Bibliothek updaten</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library &apos;%1&apos; is no longer available. Do you want to remove it?</source>
         <translation>Bibliothek &apos;%1&apos; ist nicht mehr verfügbar. Wollen Sie sie entfernen?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="519"/>
         <source>Update library</source>
         <translation>Bibliothek updaten</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="674"/>
+        <location filename="library_window.cpp" line="1787"/>
         <source>Open folder...</source>
         <translation>Öffne Ordner...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Do you want remove </source>
         <translation>Möchten Sie entfernen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="680"/>
+        <location filename="library_window.cpp" line="1794"/>
         <source>Set as uncompleted</source>
         <translation>Als nicht gelesen markieren</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="718"/>
         <source>Reset comic rating</source>
         <translation>Comic-Bewertung zurücksetzen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2654"/>
         <source>Error updating the library</source>
         <translation>Fehler beim Updaten der Bibliothek</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1046"/>
         <source>Folder</source>
         <translation>Ordner</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="628"/>
         <source>Expand all nodes</source>
         <translation>Alle Unterordner anzeigen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Library &apos;%1&apos; has been created with an older version of YACReaderLibrary. It must be created again. Do you want to create the library now?</source>
         <translation>Bibliothek &apos;%1&apos; wurde mit einer älteren Version von YACReader erstellt. Sie muss neu erzeugt werden. Wollen Sie die Bibliothek jetzt erzeugen?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="507"/>
         <source>Pack covers</source>
         <translation>Titelbild-Paket erzeugen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="553"/>
+        <location filename="library_window.cpp" line="690"/>
+        <location filename="library_window.cpp" line="1800"/>
         <source>Set as read</source>
         <translation>Als gelesen markieren</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="748"/>
         <source>Delete selected comics</source>
         <translation>Ausgewählte Comics löschen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="495"/>
+        <location filename="library_window.cpp" line="496"/>
         <source>Export comics info</source>
         <translation>Exportiere Comics-Info</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="640"/>
         <source>Show options dialog</source>
         <translation>Zeige den Optionen-Dialog</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="484"/>
         <source>Create a new library</source>
         <translation>Neue Bibliothek erstellen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library not available</source>
         <translation>Bibliothek nicht verfügbar</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="501"/>
+        <location filename="library_window.cpp" line="502"/>
         <source>Import comics info</source>
         <translation>Importiere Comics-Info</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2417"/>
         <source>There was an issue trying to delete the selected comics. Please, check for write permissions in the selected files or containing folder.</source>
         <translation>Es gab ein Problem beim Löschen der ausgewählten Comics. Überprüfen Sie bitte die Schreibberechtigung für die ausgewählten Dateien oder Ordner.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="542"/>
         <source>Open current comic</source>
         <translation>Aktuellen Comic öffnen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="188"/>
         <source>YACReader Library</source>
         <translation>YACReader Bibliothek</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2649"/>
         <source>Error creating the library</source>
         <translation>Fehler beim Erstellen der Bibliothek</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="513"/>
         <source>Unpack covers</source>
         <translation>Titelbilder entpacken</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1269"/>
         <source>Update needed</source>
         <translation>Update benötigt</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="490"/>
         <source>Open an existing library</source>
         <translation>Eine vorhandede Bibliothek öffnen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2805"/>
         <source>Library name already exists</source>
         <translation>Bibliothek-Name bereits vorhanden</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2805"/>
         <source>There is another library with the name &apos;%1&apos;.</source>
         <translation>Es gibt bereits eine Bibliothek mit dem Namen &apos;%1&apos;.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1336"/>
         <source>Download new version</source>
         <translation>Neue Version herunterladen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2694"/>
         <source>Delete comics</source>
         <translation>Comics löschen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="724"/>
         <source>Select all comics</source>
         <translation>Alle Comics auswählen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="508"/>
         <source>Pack the covers of the selected library</source>
         <translation>Packe die Titelbilder der ausgewählten Bibliothek in ein Paket</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="602"/>
         <source>Help, About YACReader</source>
         <translation>Hilfe, Über YACReader</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="560"/>
         <source>Set comic as unread</source>
         <translation>Comic als ungelesen markieren</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="624"/>
         <source>Select root node</source>
         <translation>Ursprungsordner auswählen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="514"/>
         <source>Unpack a catalog</source>
         <translation>Katalog entpacken</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2694"/>
         <source>All the selected comics will be deleted from your disk. Are you sure?</source>
         <translation>Alle ausgewählten Comics werden von Ihrer Festplatte gelöscht. Sind Sie sicher?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="756"/>
         <source>Download tags from Comic Vine</source>
         <translation>Tags von Comic Vine herunterladen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="559"/>
+        <location filename="library_window.cpp" line="695"/>
+        <location filename="library_window.cpp" line="1803"/>
         <source>Set as unread</source>
         <translation>Als ungelesen markieren</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2083"/>
         <source>Library not found</source>
         <translation>Bibliothek nicht gefunden</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="525"/>
         <source>Rename library</source>
         <translation>Bibliothek umbenennen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="531"/>
         <source>Remove library</source>
         <translation>Bibliothek entfernen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="712"/>
         <source>Open containing folder...</source>
         <translation>Öffne aktuellen Ordner...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1636"/>
+        <location filename="library_window.cpp" line="2417"/>
         <source>Unable to delete</source>
         <translation>Löschen nicht möglich</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source> library?</source>
         <translation> Bibliothek?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Are you sure?</source>
         <translation>Sind Sie sicher?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="548"/>
         <source>Save selected covers to...</source>
         <translation>Ausgewählte Titelbilder speichern in...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="537"/>
+        <source>Rescan library for XML info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="538"/>
+        <source>Tries to find XML info embedded in comic files. You only need to do this if the library was created with 9.8.2 or earlier versions or if you are using third party software to embed XML info in the files.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="549"/>
         <source>Save covers of the selected comics as JPG files</source>
         <translation>Titelbilder der ausgewählten Comics als JPG-Datei speichern</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="565"/>
+        <location filename="library_window.cpp" line="700"/>
+        <location filename="library_window.cpp" line="1806"/>
         <source>Set as manga</source>
         <translation>als Manga festlegen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="566"/>
         <source>Set issue as manga</source>
         <translation>Ausgabe als Manga festlegen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="571"/>
         <source>Set as normal</source>
         <translation>Als Normal festlegen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="572"/>
         <source>Set issue as normal</source>
         <translation>Ausgabe als normal festlegen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="586"/>
         <source>Show or hide read marks</source>
         <translation>Gelesen-Markierungen anzeigen oder verbergen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="609"/>
+        <location filename="library_window.cpp" line="1574"/>
         <source>Add new folder</source>
         <translation>Neuen Ordner erstellen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="612"/>
         <source>Add new folder to the current library</source>
         <translation>Neuen Ordner in der aktuellen Bibliothek erstellen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="615"/>
+        <location filename="library_window.cpp" line="1610"/>
         <source>Delete folder</source>
         <translation>Ordner löschen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="618"/>
         <source>Delete current folder from disk</source>
         <translation>Aktuellen Ordner von der Festplatte löschen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="634"/>
         <source>Collapse all nodes</source>
         <translation>Alle Unterordner einklappen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="655"/>
+        <location filename="library_window.cpp" line="656"/>
         <source>Change between comics views</source>
         <translation>Zwischen Comic-Anzeigemodi wechseln</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="705"/>
+        <location filename="library_window.cpp" line="1809"/>
         <source>Set as comic</source>
         <translation>Als Comic festlegen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="736"/>
         <source>Assign current order to comics</source>
         <translation>Aktuele Sortierung auf Comics anwenden</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="760"/>
+        <source>Focus search line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="766"/>
+        <source>Focus comics view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="771"/>
         <source>Edit shortcuts</source>
         <translation>Kürzel bearbeiten</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="777"/>
+        <source>&amp;Quit</source>
+        <translation type="unfinished">&amp;Schließen</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="784"/>
+        <location filename="library_window.cpp" line="1790"/>
         <source>Update folder</source>
         <translation>Ordner aktualisieren</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="787"/>
         <source>Update current folder</source>
         <translation>Aktuellen Ordner aktualisieren</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="792"/>
         <source>Add new reading list</source>
         <translation>Neue Leseliste hinzufügen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="795"/>
         <source>Add a new reading list to the current library</source>
         <translation>Neue Leseliste zur aktuellen Bibliothek hinzufügen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="798"/>
         <source>Remove reading list</source>
         <translation>Leseliste entfernen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="801"/>
         <source>Remove current reading list from the library</source>
         <translation>Aktuelle Leseliste von der Bibliothek entfernen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="804"/>
         <source>Add new label</source>
         <translation>Neues Label hinzufügen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="807"/>
         <source>Add a new label to this library</source>
         <translation>Neues Label zu dieser Bibliothek hinzufügen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="810"/>
         <source>Rename selected list</source>
         <translation>Ausgewählte Liste umbenennen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="813"/>
         <source>Rename any selected labels or lists</source>
         <translation>Ausgewählte Labels oder Listen umbenennen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="817"/>
         <source>Add to...</source>
         <translation>Hinzufügen zu...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="819"/>
         <source>Favorites</source>
         <translation>Favoriten</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="822"/>
         <source>Add selected comics to favorites list</source>
         <translation>Ausgewählte Comics zu Favoriten hinzufügen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1251"/>
         <source>Upgrade failed</source>
         <translation>Update gescheitert</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1251"/>
         <source>There were errors during library upgrade in: </source>
         <translation>Beim Upgrade der Bibliothek kam es zu Fehlern in: </translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1409"/>
+        <location filename="library_window.cpp" line="1445"/>
         <source>Copying comics...</source>
         <translation>Kopieren von Comics...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1426"/>
+        <location filename="library_window.cpp" line="1464"/>
         <source>Moving comics...</source>
         <translation>Verschieben von Comics...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1575"/>
         <source>Folder name:</source>
         <translation>Ordnername</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1604"/>
         <source>No folder selected</source>
         <translation>Kein Ordner ausgewählt</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1604"/>
         <source>Please, select a folder first</source>
         <translation>Bitte wählen Sie zuerst einen Ordner aus</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1608"/>
         <source>Error in path</source>
         <translation>Fehler im Pfad</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1608"/>
         <source>There was an error accessing the folder&apos;s path</source>
         <translation>Beim Aufrufen des Ordnerpfades kam es zu einem Fehler</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1610"/>
         <source>The selected folder and all its contents will be deleted from your disk. Are you sure?</source>
         <translation>Der ausgewählte Ordner und sein gesamter Inhalt wird von Ihrer Festplatte gelöscht. Sind Sie sicher?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1636"/>
         <source>There was an issue trying to delete the selected folders. Please, check for write permissions and be sure that any applications are using these folders or any of the contained files.</source>
         <translation>Beim Löschen des ausgewählten Ordners ist ein Problem aufgetreten. Bitte überprüfen Sie die Schreibrechte und stellen Sie sicher, dass keine Anwendung diese Ordner oder die darin enthaltenen Dateien verwendet.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1648"/>
         <source>Add new reading lists</source>
         <translation>Neue Leseliste hinzufügen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1649"/>
+        <location filename="library_window.cpp" line="1698"/>
         <source>List name:</source>
         <translation>Name der Liste</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1667"/>
         <source>Delete list/label</source>
         <translation>Ausgewählte/s Liste/Label löschen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1667"/>
         <source>The selected item will be deleted, your comics or folders will NOT be deleted from your disk. Are you sure?</source>
         <translation>Das ausgewählte Element wird gelöscht; Ihre Comics oder Ordner werden NICHT von Ihrer Festplatte gelöscht. Sind Sie sicher?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1697"/>
         <source>Rename list name</source>
         <translation>Listenname ändern</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1916"/>
         <source>Save covers</source>
         <translation>Titelbilder speichern</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.</source>
         <translation>Sie fügen zu viele Bibliotheken hinzu.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.
 
 You probably only need one library in your top level comics folder, you can browse any subfolders using the folders section in the left sidebar.
@@ -998,26 +1318,32 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 YACReaderLibrary wird Sie nicht daran hindern, weitere Bibliotheken zu erstellen, aber Sie sollten die Anzahl der Bibliotheken gering halten.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1993"/>
         <source>YACReader not found. YACReader should be installed in the same folder as YACReaderLibrary.</source>
         <translation>YACReader nicht gefunden. YACReader muss im gleichen Ordner installiert sein wie YACReaderLibrary.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found. There might be a problem with your YACReader installation.</source>
         <translation>YACReader nicht gefunden. Eventuell besteht ein Problem mit Ihrer YACReader-Installation.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2448"/>
         <source>Assign comics numbers</source>
         <translation>Comics Nummern zuweisen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2449"/>
         <source>Assign numbers starting in:</source>
         <translation>Nummern zuweisen, beginnend mit:</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Remove comics</source>
         <translation>Comics löschen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Comics will only be deleted from the current label/list. Are you sure?</source>
         <translation>Comics werden nur vom aktuellen Label/der aktuellen Liste gelöscht. Sind Sie sicher?</translation>
     </message>
@@ -1025,6 +1351,7 @@ YACReaderLibrary wird Sie nicht daran hindern, weitere Bibliotheken zu erstellen
 <context>
     <name>LocalComicListModel</name>
     <message>
+        <location filename="comic_vine/model/local_comic_list_model.cpp" line="72"/>
         <source>file name</source>
         <translation>Dateiname</translation>
     </message>
@@ -1032,30 +1359,37 @@ YACReaderLibrary wird Sie nicht daran hindern, weitere Bibliotheken zu erstellen
 <context>
     <name>LogWindow</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="14"/>
         <source>Log window</source>
         <translation>Protokollfenster</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="22"/>
         <source>&amp;Pause</source>
         <translation>&amp;Pause</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="39"/>
         <source>&amp;Save</source>
         <translation>&amp;Speichern</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="56"/>
         <source>C&amp;lear</source>
         <translation>L&amp;öschen</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="73"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopieren</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="90"/>
         <source>Level:</source>
         <translation>Level:</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="136"/>
         <source>&amp;Auto scroll</source>
         <translation>Automatisches Scrollen</translation>
     </message>
@@ -1063,18 +1397,22 @@ YACReaderLibrary wird Sie nicht daran hindern, weitere Bibliotheken zu erstellen
 <context>
     <name>NoLibrariesWidget</name>
     <message>
+        <location filename="no_libraries_widget.cpp" line="32"/>
         <source>create your first library</source>
         <translation>Erstellen Sie Ihre erste Bibliothek</translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="26"/>
         <source>You don&apos;t have any libraries yet</source>
         <translation>Sie haben aktuell noch keine Bibliothek</translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="28"/>
         <source>&lt;p&gt;You can create a library in any folder, YACReaderLibrary will import all comics and folders from this folder. If you have created any library in the past you can open them.&lt;/p&gt;&lt;p&gt;Don&apos;t forget that you can use YACReader as a stand alone application for reading the comics on your computer.&lt;/p&gt;</source>
         <translation>&lt;p&gt;Sie können eine Bibliothek in jedem beliebigen Ordner erstellen, YACReaderLibrary wird alle Comics und Unterordner von diesem Ordner importieren. Wenn Sie bereits eine Bibliothek erstellt haben, können Sie sie öffnen.&lt;/p&gt;&lt;p&gt;Vergessen Sie nicht, dass Sie YACReader als eigentsändige Anwendung nutzen können, um Comics auf Ihrem Computer zu lesen.&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="34"/>
         <source>add an existing one</source>
         <translation>Existierende hinzufügen</translation>
     </message>
@@ -1082,70 +1420,87 @@ YACReaderLibrary wird Sie nicht daran hindern, weitere Bibliotheken zu erstellen
 <context>
     <name>OptionsDialog</name>
     <message>
+        <location filename="options_dialog.cpp" line="156"/>
         <source>Options</source>
         <translation>Optionen</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="47"/>
         <source>Tray icon settings (experimental)</source>
         <translation>Taskleisten-Einstellungen (experimentell)</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="50"/>
         <source>Close to tray</source>
         <translation>In Taskleiste schließen</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="51"/>
         <source>Start into the system tray</source>
         <translation>In die Taskleiste starten</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="69"/>
         <source>Edit Comic Vine API key</source>
         <translation>Comic Vine API-Schlüssel ändern</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="72"/>
         <source>Comic Vine API key</source>
         <translation>Comic Vine API Schlüssel</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="78"/>
         <source>Enable background image</source>
         <translation>Hintergrundbild aktivieren</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="80"/>
         <source>Opacity level</source>
         <translation>Deckkraft-Stufe</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="85"/>
         <source>Blur level</source>
         <translation>Unschärfe-Stufe</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="90"/>
         <source>Use selected comic cover as background</source>
         <translation>Den ausgewählten Comic als Hintergrund verwenden</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="92"/>
         <source>Restore defautls</source>
         <translation>Standardwerte wiederherstellen</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="103"/>
         <source>Background</source>
         <translation>Hintergrund</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="106"/>
         <source>Display continue reading banner</source>
         <translation>Weiterlesen-Banner anzeigen</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="111"/>
         <source>Continue reading</source>
         <translation>Weiterlesen</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="144"/>
         <source>Comic Flow</source>
         <translation>Comic Flow</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="146"/>
         <source>Grid view</source>
         <translation>Rasteransicht</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="148"/>
         <source>General</source>
         <translation>Allgemein</translation>
     </message>
@@ -1153,142 +1508,178 @@ YACReaderLibrary wird Sie nicht daran hindern, weitere Bibliotheken zu erstellen
 <context>
     <name>PropertiesDialog</name>
     <message>
+        <location filename="properties_dialog.cpp" line="240"/>
         <source>Day:</source>
         <translation>Tag:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="85"/>
         <source>Plot</source>
         <translation>Inhalt</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="177"/>
         <source>Size:</source>
         <translation>Größe:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="248"/>
         <source>Year:</source>
         <translation>Jahr:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="207"/>
         <source>Inker(s):</source>
         <translation>Künstler(Tinte):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="84"/>
         <source>Publishing</source>
         <translation>Veröffentlichung</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="256"/>
         <source>Publisher:</source>
         <translation>Verlag:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="82"/>
         <source>General info</source>
         <translation>Allgemeine Info</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="258"/>
         <source>Color/BW:</source>
         <translation>Farbe/Schwarz-Weiß:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="501"/>
         <source>Edit selected comics information</source>
         <translation>Ausgewählte Comic-Informationen bearbeiten</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="200"/>
         <source>Penciller(s):</source>
         <translation>Künstler(Bleistift):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="210"/>
         <source>Colorist(s):</source>
         <translation>Künstler(Farbe):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="175"/>
         <source>Genre:</source>
         <translation>Genre:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="158"/>
         <source>Issue number:</source>
         <translation>Ausgabennummer:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="244"/>
         <source>Month:</source>
         <translation>Monat:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="275"/>
         <source>Notes:</source>
         <translation>Anmerkungen:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="273"/>
         <source>Synopsis:</source>
         <translation>Zusammenfassung:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="143"/>
         <source>Title:</source>
         <translation>Titel:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Not found</source>
         <translation>Nicht gefunden</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="274"/>
         <source>Characters:</source>
         <translation>Charaktere:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="83"/>
         <source>Authors</source>
         <translation>Autoren</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="259"/>
         <source>Age rating:</source>
         <translation>Altersangabe:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="173"/>
         <source>Story arc:</source>
         <translation>Handlung:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="197"/>
         <source>Writer(s):</source>
         <translation>Autor(en):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Comic not found. You should update your library.</source>
         <translation>Comic nicht gefunden. Sie sollten Ihre Bibliothek updaten.</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="467"/>
         <source>Edit comic information</source>
         <translation>Comic-Informationen bearbeiten</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="94"/>
         <source>Cover page</source>
         <translation>Titelbild</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="220"/>
         <source>Cover Artist(s):</source>
         <translation>Titelbild-Künstler:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="369"/>
         <source>Comic Vine link: &lt;a style=&apos;color: #FFCB00; text-decoration:none; font-weight:bold;&apos; href=&quot;http://www.comicvine.com/comic/4000-%1/&quot;&gt; view &lt;/a&gt;</source>
         <translation>Comic Vine Link: &lt;a style=&apos;color: #FFCB00; text-decoration:none; font-weight:bold;&apos; href=&quot;http://www.comicvine.com/comic/4000-%1/&quot;&gt; view &lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="160"/>
         <source>Volume:</source>
         <translation>Band:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="257"/>
         <source>Format:</source>
         <translation>Format:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="217"/>
         <source>Letterer(s):</source>
         <translation>Künstler(Schrift):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="151"/>
+        <location filename="properties_dialog.cpp" line="168"/>
         <source>of:</source>
         <translation>von</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="164"/>
         <source>Arc number:</source>
         <translation>Handlungsbogen Nummer:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="260"/>
         <source>Manga:</source>
         <translation>Manga:</translation>
     </message>
@@ -1296,34 +1687,42 @@ YACReaderLibrary wird Sie nicht daran hindern, weitere Bibliotheken zu erstellen
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>7z lib not found</source>
         <translation>7z Bibliothek nicht gefunden</translation>
     </message>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>unable to load 7z lib from ./utils</source>
         <translation>7z Bibliothek kann von ./utils nicht geladen werden</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41"/>
         <source>Trace</source>
         <translation>Verfolgen</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43"/>
         <source>Debug</source>
         <translation>Fehlersuche</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45"/>
         <source>Info</source>
         <translation>Info</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47"/>
         <source>Warning</source>
         <translation>Warnung</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49"/>
         <source>Error</source>
         <translation>Error</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51"/>
         <source>Fatal</source>
         <translation>Fatal</translation>
     </message>
@@ -1331,14 +1730,17 @@ YACReaderLibrary wird Sie nicht daran hindern, weitere Bibliotheken zu erstellen
 <context>
     <name>QsLogging::LogWindowModel</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="141"/>
         <source>Time</source>
         <translation>Zeit</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="143"/>
         <source>Level</source>
         <translation>Level</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="145"/>
         <source>Message</source>
         <translation>Nachricht</translation>
     </message>
@@ -1346,18 +1748,22 @@ YACReaderLibrary wird Sie nicht daran hindern, weitere Bibliotheken zu erstellen
 <context>
     <name>QsLogging::Window</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Pause</source>
         <translation>&amp;Pause</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Resume</source>
         <translation>&amp;Weiter</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="236"/>
         <source>Save log</source>
         <translation>Protokoll speichern</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="237"/>
         <source>Log file (*.log)</source>
         <translation>Protokolldatei (*.log)</translation>
     </message>
@@ -1365,18 +1771,22 @@ YACReaderLibrary wird Sie nicht daran hindern, weitere Bibliotheken zu erstellen
 <context>
     <name>RenameLibraryDialog</name>
     <message>
+        <location filename="rename_library_dialog.cpp" line="51"/>
         <source>Rename current library</source>
         <translation>Aktuelle Bibliothek umbenennen</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="24"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="20"/>
         <source>Rename</source>
         <translation>Umbenennen</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="15"/>
         <source>New Library Name : </source>
         <translation>Neuer Bibliotheksname :</translation>
     </message>
@@ -1384,14 +1794,18 @@ YACReaderLibrary wird Sie nicht daran hindern, weitere Bibliotheken zu erstellen
 <context>
     <name>ScraperResultsPaginator</name>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="54"/>
         <source>Number of %1 found : %2</source>
         <translation>Anzahl von %1 gefunden : %2</translation>
     </message>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="32"/>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="55"/>
         <source>page %1 of %2</source>
         <translation>Seite %1 von %2</translation>
     </message>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="30"/>
         <source>Number of volumes found : %1</source>
         <translation>Anzahl der gefundenen Bände: %1</translation>
     </message>
@@ -1399,10 +1813,12 @@ YACReaderLibrary wird Sie nicht daran hindern, weitere Bibliotheken zu erstellen
 <context>
     <name>SearchSingleComic</name>
     <message>
+        <location filename="comic_vine/search_single_comic.cpp" line="14"/>
         <source>Please provide some additional information.</source>
         <translation>Bitte stellen Sie weitere Informationen zur Verfügung.</translation>
     </message>
     <message>
+        <location filename="comic_vine/search_single_comic.cpp" line="19"/>
         <source>Series:</source>
         <translation>Serie:</translation>
     </message>
@@ -1410,10 +1826,12 @@ YACReaderLibrary wird Sie nicht daran hindern, weitere Bibliotheken zu erstellen
 <context>
     <name>SearchVolume</name>
     <message>
+        <location filename="comic_vine/search_volume.cpp" line="11"/>
         <source>Please provide some additional information.</source>
         <translation>Bitte stellen Sie weitere Informationen zur Verfügung.</translation>
     </message>
     <message>
+        <location filename="comic_vine/search_volume.cpp" line="14"/>
         <source>Series:</source>
         <translation>Serie:</translation>
     </message>
@@ -1421,22 +1839,27 @@ YACReaderLibrary wird Sie nicht daran hindern, weitere Bibliotheken zu erstellen
 <context>
     <name>SelectComic</name>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="95"/>
         <source>loading description</source>
         <translation>Beschreibung wird laden</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="38"/>
         <source>comics</source>
         <translation>Comics</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="94"/>
         <source>loading cover</source>
         <translation>Titelbild wird geladen</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="18"/>
         <source>Please, select the right comic info.</source>
         <translation>Bitte wählen Sie die korrekte Comic-Information aus.</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="135"/>
         <source>description unavailable</source>
         <translation>Beschreibung nicht verfügbar</translation>
     </message>
@@ -1444,22 +1867,37 @@ YACReaderLibrary wird Sie nicht daran hindern, weitere Bibliotheken zu erstellen
 <context>
     <name>SelectVolume</name>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="145"/>
         <source>loading description</source>
         <translation>Beschreibung wird geladen</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="35"/>
         <source>Please, select the right series for your comic.</source>
         <translation>Bitte wählen Sie die korrekte Serie für Ihre Comics aus.</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="56"/>
+        <source>Filter:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="138"/>
+        <source>Nothing found, clear the filter if any.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="144"/>
         <source>loading cover</source>
         <translation>Titelbild wird geladen</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="68"/>
         <source>volumes</source>
         <translation>Bände</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="185"/>
         <source>description unavailable</source>
         <translation>Beschreibung nicht verfügbar</translation>
     </message>
@@ -1467,14 +1905,17 @@ YACReaderLibrary wird Sie nicht daran hindern, weitere Bibliotheken zu erstellen
 <context>
     <name>SeriesQuestion</name>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="15"/>
         <source>no</source>
         <translation>Nein</translation>
     </message>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="14"/>
         <source>yes</source>
         <translation>Ja</translation>
     </message>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="12"/>
         <source>You are trying to get information for various comics at once, are they part of the same series?</source>
         <translation>Sie versuchen, Informationen zu mehreren Comics gleichzeitig zu laden, sind diese Teil einer Serie?</translation>
     </message>
@@ -1482,40 +1923,49 @@ YACReaderLibrary wird Sie nicht daran hindern, weitere Bibliotheken zu erstellen
 <context>
     <name>ServerConfigDialog</name>
     <message>
+        <location filename="server_config_dialog.cpp" line="115"/>
         <source>Port</source>
         <translation>Anschluss</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="147"/>
         <source>enable the server</source>
         <translation>Server aktivieren</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="86"/>
         <source>set port</source>
         <translation>Anschluss wählen</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="92"/>
         <source>Server connectivity information</source>
         <translation>Serveranschluss-Information</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="96"/>
         <source>Scan it!</source>
         <translation>Durchsuchen!</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="102"/>
         <source>YACReader is available for iOS devices. &lt;a href=&apos;http://ios.yacreader.com&apos; style=&apos;color:rgb(193, 148, 65)&apos;&gt; Discover it! &lt;/a&gt;</source>
         <translation>YACReader ist für iOS-Geräte verfügbar. &lt;a href=&apos;http://ios.yacreader.com&apos; style=&apos;color:rgb(193, 148, 65)&apos;&gt; Jetzt entdecken! &lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="111"/>
         <source>Choose an IP address</source>
         <translation>IP-Adresse auswählen</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="152"/>
         <source>display less information about folders in the browser
 to improve the performance</source>
         <translation>weniger Informationen zu Ordnern im Browser anzuzeigen,
 um die Leistung zu verbessern</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="268"/>
         <source>Could not load libqrencode.</source>
         <translation>libqrencode konnte nicht geladen werden</translation>
     </message>
@@ -1523,22 +1973,27 @@ um die Leistung zu verbessern</translation>
 <context>
     <name>SortVolumeComics</name>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="87"/>
         <source>remove selected comics</source>
         <translation>Ausgewählte Comics entfernen</translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="21"/>
         <source>sort comics to match comic information</source>
         <translation>Comics laut Comic-Information sortieren</translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="88"/>
         <source>restore all removed comics</source>
         <translation>Alle entfernten Comics wiederherstellen</translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="58"/>
         <source>issues</source>
         <translation>Ausgaben</translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="18"/>
         <source>Please, sort the list of comics on the left until it matches the comics&apos; information.</source>
         <translation>Sortieren Sie bitte die Comic-Informationen links, bis die Informationen mit den Comics übereinstimmen.</translation>
     </message>
@@ -1546,6 +2001,7 @@ um die Leistung zu verbessern</translation>
 <context>
     <name>TitleHeader</name>
     <message>
+        <location filename="comic_vine/title_header.cpp" line="30"/>
         <source>SEARCH</source>
         <translation>Suchen</translation>
     </message>
@@ -1553,14 +2009,17 @@ um die Leistung zu verbessern</translation>
 <context>
     <name>UpdateLibraryDialog</name>
     <message>
+        <location filename="create_library_dialog.cpp" line="180"/>
         <source>Update library</source>
         <translation>Bibliothek aktualisieren</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="161"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="155"/>
         <source>Updating....</source>
         <translation>Aktualisierung....</translation>
     </message>
@@ -1568,6 +2027,7 @@ um die Leistung zu verbessern</translation>
 <context>
     <name>VolumeComicsModel</name>
     <message>
+        <location filename="comic_vine/model/volume_comics_model.cpp" line="120"/>
         <source>title</source>
         <translation>Titel</translation>
     </message>
@@ -1575,14 +2035,17 @@ um die Leistung zu verbessern</translation>
 <context>
     <name>VolumesModel</name>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="118"/>
         <source>year</source>
         <translation>Jahr</translation>
     </message>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="120"/>
         <source>issues</source>
         <translation>Ausgaben</translation>
     </message>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="122"/>
         <source>publisher</source>
         <translation>Herausgeber</translation>
     </message>
@@ -1590,18 +2053,21 @@ um die Leistung zu verbessern</translation>
 <context>
     <name>YACReader::TrayIconController</name>
     <message>
+        <location filename="trayicon_controller.cpp" line="52"/>
         <source>&amp;Restore</source>
         <translation>&amp;Wiederherstellen</translation>
     </message>
     <message>
         <source>&amp;Quit</source>
-        <translation>&amp;Schließen</translation>
+        <translation type="vanished">&amp;Schließen</translation>
     </message>
     <message>
+        <location filename="trayicon_controller.cpp" line="79"/>
         <source>Systray</source>
         <translation>Taskleiste</translation>
     </message>
     <message>
+        <location filename="trayicon_controller.cpp" line="80"/>
         <source>YACReaderLibrary will keep running in the system tray. To terminate the program, choose &lt;b&gt;Quit&lt;/b&gt; in the context menu of the system tray icon.</source>
         <translation>YACReaderLibrary wird im Hintergrund weiterlaufen. Um das Programm zu schließen, wählen Sie &lt;b&gt;Schließen&lt;/b&gt; im Kontextmenü des Taskleisten-Symbols.</translation>
     </message>
@@ -1609,6 +2075,7 @@ um die Leistung zu verbessern</translation>
 <context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation>Schließen</translation>
     </message>
@@ -1616,10 +2083,12 @@ um die Leistung zu verbessern</translation>
 <context>
     <name>YACReaderDeletingProgress</name>
     <message>
+        <location filename="../custom_widgets/yacreader_deleting_progress.cpp" line="35"/>
         <source>cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_deleting_progress.cpp" line="20"/>
         <source>Please wait, deleting in progress...</source>
         <translation>Bitte warten, Löschvorgang läuft...</translation>
     </message>
@@ -1627,10 +2096,13 @@ um die Leistung zu verbessern</translation>
 <context>
     <name>YACReaderFieldEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11"/>
         <source>Restore to default</source>
         <translation>Standardeinstellungen wiederherstellen</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28"/>
         <source>Click to overwrite</source>
         <translation>Zum Überschreiben anklicken</translation>
     </message>
@@ -1638,10 +2110,15 @@ um die Leistung zu verbessern</translation>
 <context>
     <name>YACReaderFieldPlainTextEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10"/>
         <source>Restore to default</source>
         <translation>Standardeinstellungen wiederherstellen</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50"/>
         <source>Click to overwrite</source>
         <translation>Zum Überschreiben anklicken</translation>
     </message>
@@ -1649,18 +2126,22 @@ um die Leistung zu verbessern</translation>
 <context>
     <name>YACReaderFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="15"/>
         <source>CoverFlow look</source>
         <translation>CoverFlow-Ansicht</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="13"/>
         <source>How to show covers:</source>
         <translation>Wie Titelseiten angezeigt werden sollen:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="16"/>
         <source>Stripe look</source>
         <translation>Streifen-Ansicht</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="17"/>
         <source>Overlapped Stripe look</source>
         <translation>Überlappende Streifen-Ansicht</translation>
     </message>
@@ -1668,94 +2149,117 @@ um die Leistung zu verbessern</translation>
 <context>
     <name>YACReaderGLFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="112"/>
         <source>Zoom</source>
         <translation>Vergößern</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="142"/>
         <source>Light</source>
         <translation>Helligkeit</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="76"/>
         <source>Show advanced settings</source>
         <translation>Zeige erweiterte Einstellungen</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="32"/>
         <source>Roulette look</source>
         <translation>Zufällige Darstellung</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="130"/>
         <source>Cover Angle</source>
         <translation>Titelbild-Winkel</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="23"/>
         <source>Stripe look</source>
         <translation>Streifen-Ansicht</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="94"/>
         <source>Position</source>
         <translation>Position</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="124"/>
         <source>Z offset</source>
         <translation>Z Abstand</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="118"/>
         <source>Y offset</source>
         <translation>Y Abstand</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="106"/>
         <source>Central gap</source>
         <translation>Mittiger Abstand</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="18"/>
         <source>Presets:</source>
         <translation>Voreinstellungen:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="26"/>
         <source>Overlapped Stripe look</source>
         <translation>Überlappende Streifen-Ansicht</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="29"/>
         <source>Modern look</source>
         <translation>Moderne Ansicht</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="88"/>
         <source>View angle</source>
         <translation>Zeige Winkel</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="148"/>
         <source>Max angle</source>
         <translation>Maximaler Winkel</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="85"/>
         <source>Custom:</source>
         <translation>Benutzerdefiniert:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="20"/>
         <source>Classic look</source>
         <translation>Klassische Ansicht</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="100"/>
         <source>Cover gap</source>
         <translation>Titelbild Abstand</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="182"/>
         <source>High Performance</source>
         <translation>Hohe Leistung</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="201"/>
         <source>Performance:</source>
         <translation>Leistung:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="193"/>
         <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
         <translation>VSync nutzen (verbessert die Bilddarstellung im Vollbild, schlechtere Leistung)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="136"/>
         <source>Visibility</source>
         <translation>Sichtbarkeit</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="180"/>
         <source>Low Performance</source>
         <translation>Niedrige Leistung</translation>
     </message>
@@ -1763,10 +2267,12 @@ um die Leistung zu verbessern</translation>
 <context>
     <name>YACReaderNavigationController</name>
     <message>
+        <location filename="yacreader_navigation_controller.cpp" line="123"/>
         <source>No favorites</source>
         <translation>Keine Favoriten</translation>
     </message>
     <message>
+        <location filename="yacreader_navigation_controller.cpp" line="127"/>
         <source>You are not reading anything yet, come on!!</source>
         <translation>Sie lesen noch nichts, starten Sie!!</translation>
     </message>
@@ -1774,22 +2280,27 @@ um die Leistung zu verbessern</translation>
 <context>
     <name>YACReaderOptionsDialog</name>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28"/>
         <source>Save</source>
         <translation>Speichern</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="46"/>
         <source>Use hardware acceleration (restart needed)</source>
         <translation>Hardwarebeschleunigung nutzen (Neustart erforderlich)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="29"/>
         <source>Cancel</source>
         <translation>Abbrechen</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="34"/>
         <source>Edit shortcuts</source>
         <translation>Kürzel bearbeiten</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="37"/>
         <source>Shortcuts</source>
         <translation>Kürzel</translation>
     </message>
@@ -1797,6 +2308,7 @@ um die Leistung zu verbessern</translation>
 <context>
     <name>YACReaderSearchLineEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_search_line_edit.cpp" line="68"/>
         <source>type to search</source>
         <translation>tippen, um zu suchen</translation>
     </message>
@@ -1804,26 +2316,32 @@ um die Leistung zu verbessern</translation>
 <context>
     <name>YACReaderSideBar</name>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="31"/>
         <source>LIBRARIES</source>
         <translation>BIBLIOTHEKEN</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="32"/>
         <source>FOLDERS</source>
         <translation>ORDNER</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="27"/>
         <source>Libraries</source>
         <translation>Bibliotheken</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="28"/>
         <source>Folders</source>
         <translation>Ordner</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="29"/>
         <source>Reading Lists</source>
         <translation>Leselisten</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="33"/>
         <source>READING LISTS</source>
         <translation>LESELISTEN</translation>
     </message>

--- a/YACReaderLibrary/yacreaderlibrary_en.ts
+++ b/YACReaderLibrary/yacreaderlibrary_en.ts
@@ -1,0 +1,2272 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>ActionsShortcutsModel</name>
+    <message>
+        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="72"/>
+        <source>None</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AddLabelDialog</name>
+    <message>
+        <location filename="add_label_dialog.cpp" line="8"/>
+        <source>Label name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="add_label_dialog.cpp" line="11"/>
+        <source>Choose a color:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="add_label_dialog.cpp" line="14"/>
+        <source>red</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="add_label_dialog.cpp" line="15"/>
+        <source>orange</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="add_label_dialog.cpp" line="16"/>
+        <source>yellow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="add_label_dialog.cpp" line="17"/>
+        <source>green</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="add_label_dialog.cpp" line="18"/>
+        <source>cyan</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="add_label_dialog.cpp" line="19"/>
+        <source>blue</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="add_label_dialog.cpp" line="20"/>
+        <source>violet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="add_label_dialog.cpp" line="21"/>
+        <source>purple</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="add_label_dialog.cpp" line="22"/>
+        <source>pink</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="add_label_dialog.cpp" line="23"/>
+        <source>white</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="add_label_dialog.cpp" line="24"/>
+        <source>light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="add_label_dialog.cpp" line="25"/>
+        <source>dark</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="add_label_dialog.cpp" line="36"/>
+        <source>accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="add_label_dialog.cpp" line="37"/>
+        <source>cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>AddLibraryDialog</name>
+    <message>
+        <location filename="add_library_dialog.cpp" line="16"/>
+        <source>Comics folder : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="add_library_dialog.cpp" line="21"/>
+        <source>Library name : </source>
+        <oldsource>Library Name : </oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="add_library_dialog.cpp" line="26"/>
+        <source>Add</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="add_library_dialog.cpp" line="30"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="add_library_dialog.cpp" line="66"/>
+        <source>Add an existing library</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ApiKeyDialog</name>
+    <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="21"/>
+        <source>Before you can connect to Comic Vine, you need your own API key. Please, get one free &lt;a href=&quot;http://www.comicvine.com/api/&quot;&gt;here&lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="25"/>
+        <source>Paste here your Comic Vine API key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="28"/>
+        <source>Accept</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="32"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ClassicComicsView</name>
+    <message>
+        <location filename="classic_comics_view.cpp" line="90"/>
+        <source>Hide comic flow</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ComicInfoView</name>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="281"/>
+        <source>Authors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="311"/>
+        <source>writer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="333"/>
+        <source>penciller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="355"/>
+        <source>inker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="377"/>
+        <source>colorist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="399"/>
+        <source>letterer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="421"/>
+        <source>cover artist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="436"/>
+        <source>Publisher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="476"/>
+        <source>color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="476"/>
+        <source>b/w</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="504"/>
+        <source>Characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ComicModel</name>
+    <message>
+        <location filename="db/comic_model.cpp" line="307"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="307"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="335"/>
+        <source>Title</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="337"/>
+        <source>File Name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="339"/>
+        <source>Pages</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="341"/>
+        <source>Size</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="343"/>
+        <source>Read</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="345"/>
+        <source>Current Page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="347"/>
+        <source>Rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ComicVineDialog</name>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="54"/>
+        <source>skip</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="55"/>
+        <source>back</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="56"/>
+        <source>next</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="57"/>
+        <source>search</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="58"/>
+        <source>close</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="134"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="144"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="240"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="747"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="781"/>
+        <source>Looking for volume...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="142"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="714"/>
+        <source>comic %1 of %2 - %3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="245"/>
+        <source>%1 comics selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="278"/>
+        <source>Error connecting to ComicVine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="448"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="484"/>
+        <source>Retrieving tags for : %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="762"/>
+        <source>Retrieving volume info...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="788"/>
+        <source>Looking for comic...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>CreateLibraryDialog</name>
+    <message>
+        <location filename="create_library_dialog.cpp" line="17"/>
+        <source>Comics folder : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="create_library_dialog.cpp" line="22"/>
+        <source>Library Name : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="create_library_dialog.cpp" line="27"/>
+        <source>Create</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="create_library_dialog.cpp" line="31"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="create_library_dialog.cpp" line="53"/>
+        <source>Create a library could take several minutes. You can stop the process and update the library later for completing the task.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="create_library_dialog.cpp" line="75"/>
+        <source>Create new library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="create_library_dialog.cpp" line="95"/>
+        <source>Path not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="create_library_dialog.cpp" line="95"/>
+        <source>The selected path does not exist or is not a valid path. Be sure that you have write access to this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EditShortcutsDialog</name>
+    <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="21"/>
+        <source>Restore defaults</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="22"/>
+        <source>To change a shortcut, double click in the key combination and type the new keys.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="69"/>
+        <source>Shortcuts settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
+        <source>Shortcut in use</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
+        <source>The shortcut &quot;%1&quot; is already assigned to other function</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EmptyFolderWidget</name>
+    <message>
+        <location filename="empty_folder_widget.cpp" line="75"/>
+        <location filename="empty_folder_widget.cpp" line="140"/>
+        <source>Subfolders in this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="empty_folder_widget.cpp" line="138"/>
+        <source>Empty folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="empty_folder_widget.cpp" line="138"/>
+        <source>Drag and drop folders and comics here</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EmptyLabelWidget</name>
+    <message>
+        <location filename="empty_label_widget.cpp" line="11"/>
+        <source>This label doesn&apos;t contain comics yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>EmptyReadingListWidget</name>
+    <message>
+        <location filename="empty_reading_list_widget.cpp" line="8"/>
+        <source>This reading list does not contain any comics yet</source>
+        <oldsource>This reading list doesn&apos;t contain any comics yet</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ExportComicsInfoDialog</name>
+    <message>
+        <location filename="export_comics_info_dialog.cpp" line="14"/>
+        <source>Output file : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="export_comics_info_dialog.cpp" line="18"/>
+        <source>Create</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="export_comics_info_dialog.cpp" line="22"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="export_comics_info_dialog.cpp" line="57"/>
+        <source>Export comics info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="export_comics_info_dialog.cpp" line="66"/>
+        <source>Destination database name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="export_comics_info_dialog.cpp" line="81"/>
+        <source>Problem found while writing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="export_comics_info_dialog.cpp" line="81"/>
+        <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ExportLibraryDialog</name>
+    <message>
+        <location filename="export_library_dialog.cpp" line="11"/>
+        <source>Output folder : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="export_library_dialog.cpp" line="15"/>
+        <source>Create</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="export_library_dialog.cpp" line="19"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="export_library_dialog.cpp" line="60"/>
+        <source>Create covers package</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="export_library_dialog.cpp" line="71"/>
+        <source>Problem found while writing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="export_library_dialog.cpp" line="71"/>
+        <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="export_library_dialog.cpp" line="76"/>
+        <source>Destination directory</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FileComic</name>
+    <message>
+        <location filename="../common/comic.cpp" line="454"/>
+        <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/comic.cpp" line="461"/>
+        <source>Unknown error opening the file</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/comic.cpp" line="562"/>
+        <source>7z not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/comic.cpp" line="568"/>
+        <source>Format not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>GridComicsView</name>
+    <message>
+        <location filename="grid_comics_view.cpp" line="169"/>
+        <source>Show info</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>HelpAboutDialog</name>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="21"/>
+        <source>About</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="24"/>
+        <source>Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImportComicsInfoDialog</name>
+    <message>
+        <location filename="import_comics_info_dialog.cpp" line="14"/>
+        <source>Import comics info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_comics_info_dialog.cpp" line="16"/>
+        <source>Info database location : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_comics_info_dialog.cpp" line="20"/>
+        <source>Import</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_comics_info_dialog.cpp" line="24"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_comics_info_dialog.cpp" line="74"/>
+        <source>Comics info file (*.ydb)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImportLibraryDialog</name>
+    <message>
+        <location filename="import_library_dialog.cpp" line="17"/>
+        <source>Library Name : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_library_dialog.cpp" line="22"/>
+        <source>Package location : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_library_dialog.cpp" line="26"/>
+        <source>Destination folder : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_library_dialog.cpp" line="30"/>
+        <source>Unpack</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_library_dialog.cpp" line="34"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_library_dialog.cpp" line="87"/>
+        <source>Extract a catalog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_library_dialog.cpp" line="108"/>
+        <source>Compresed library covers (*.clc)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ImportWidget</name>
+    <message>
+        <location filename="import_widget.cpp" line="150"/>
+        <source>stop</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="190"/>
+        <source>Some of the comics being added...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="334"/>
+        <source>Importing comics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="335"/>
+        <source>&lt;p&gt;YACReaderLibrary is now creating a new library.&lt;/p&gt;&lt;p&gt;Create a library could take several minutes. You can stop the process and update the library later for completing the task.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="346"/>
+        <source>Updating the library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="347"/>
+        <source>&lt;p&gt;The current library is being updated. For faster updates, please, update your libraries frequently.&lt;/p&gt;&lt;p&gt;You can stop the process and continue updating this library later.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="358"/>
+        <source>Upgrading the library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="359"/>
+        <source>&lt;p&gt;The current library is being upgraded, please wait.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LibraryWindow</name>
+    <message>
+        <location filename="library_window.cpp" line="144"/>
+        <source>YACReader Library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="968"/>
+        <source>Library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="450"/>
+        <source>Create a new library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="456"/>
+        <source>Open an existing library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="461"/>
+        <location filename="library_window.cpp" line="462"/>
+        <source>Export comics info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="467"/>
+        <location filename="library_window.cpp" line="468"/>
+        <source>Import comics info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="473"/>
+        <source>Pack covers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="474"/>
+        <source>Pack the covers of the selected library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="479"/>
+        <source>Unpack covers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="480"/>
+        <source>Unpack a catalog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="485"/>
+        <source>Update library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="486"/>
+        <source>Update current library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="491"/>
+        <source>Rename library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="492"/>
+        <source>Rename current library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="497"/>
+        <source>Remove library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="498"/>
+        <source>Remove current library from your collection</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="503"/>
+        <source>Open current comic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="504"/>
+        <source>Open current comic on YACReader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="509"/>
+        <source>Save selected covers to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="510"/>
+        <source>Save covers of the selected comics as JPG files</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="514"/>
+        <location filename="library_window.cpp" line="651"/>
+        <source>Set as read</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="515"/>
+        <source>Set comic as read</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="520"/>
+        <location filename="library_window.cpp" line="656"/>
+        <source>Set as unread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="521"/>
+        <source>Set comic as unread</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="546"/>
+        <source>Show/Hide marks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="595"/>
+        <source>Collapse all nodes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="697"/>
+        <source>Assign current order to comics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1283"/>
+        <source>Library not available</source>
+        <oldsource>Library &apos;</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="554"/>
+        <location filename="library_window.cpp" line="555"/>
+        <source>Fullscreen mode on/off</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="526"/>
+        <location filename="library_window.cpp" line="661"/>
+        <source>Set as manga</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="527"/>
+        <source>Set issue as manga</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="532"/>
+        <source>Set as normal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="533"/>
+        <source>Set issue as normal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="563"/>
+        <source>Help, About YACReader</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="576"/>
+        <location filename="library_window.cpp" line="1527"/>
+        <source>Delete folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="585"/>
+        <source>Select root node</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="589"/>
+        <source>Expand all nodes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="601"/>
+        <source>Show options dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="609"/>
+        <source>Show comics server options dialog</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="635"/>
+        <source>Open folder...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="641"/>
+        <source>Set as uncompleted</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="646"/>
+        <source>Set as completed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="666"/>
+        <source>Set as comic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="673"/>
+        <source>Open containing folder...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="679"/>
+        <source>Reset comic rating</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="685"/>
+        <source>Select all comics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="691"/>
+        <source>Edit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="703"/>
+        <source>Update cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="709"/>
+        <source>Delete selected comics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="717"/>
+        <source>Download tags from Comic Vine</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="721"/>
+        <source>Edit shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="727"/>
+        <source>Update folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="730"/>
+        <source>Update current folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="735"/>
+        <source>Add new reading list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="738"/>
+        <source>Add a new reading list to the current library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="741"/>
+        <source>Remove reading list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="744"/>
+        <source>Remove current reading list from the library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="747"/>
+        <source>Add new label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="750"/>
+        <source>Add a new label to this library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="753"/>
+        <source>Rename selected list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="756"/>
+        <source>Rename any selected labels or lists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="760"/>
+        <source>Add to...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="762"/>
+        <source>Favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="765"/>
+        <source>Add selected comics to favorites list</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="984"/>
+        <source>Folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="998"/>
+        <source>Comic</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1178"/>
+        <source>Upgrade failed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1178"/>
+        <source>There were errors during library upgrade in: </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1196"/>
+        <source>Update needed</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1196"/>
+        <source>This library was created with a previous version of YACReaderLibrary. It needs to be updated. Update now?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1262"/>
+        <source>Download new version</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1262"/>
+        <source>This library was created with a newer version of YACReaderLibrary. Download the new version now?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1283"/>
+        <source>Library &apos;%1&apos; is no longer available. Do you want to remove it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1302"/>
+        <source>Old library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1302"/>
+        <source>Library &apos;%1&apos; has been created with an older version of YACReaderLibrary. It must be created again. Do you want to create the library now?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1335"/>
+        <location filename="library_window.cpp" line="1371"/>
+        <source>Copying comics...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1352"/>
+        <location filename="library_window.cpp" line="1390"/>
+        <source>Moving comics...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1492"/>
+        <source>Folder name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1521"/>
+        <source>No folder selected</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1521"/>
+        <source>Please, select a folder first</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1525"/>
+        <source>Error in path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1525"/>
+        <source>There was an error accessing the folder&apos;s path</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1527"/>
+        <source>The selected folder and all its contents will be deleted from your disk. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1561"/>
+        <source>There was an issue trying to delete the selected folders. Please, check for write permissions and be sure that any applications are using these folders or any of the contained files.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1573"/>
+        <source>Add new reading lists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1574"/>
+        <location filename="library_window.cpp" line="1623"/>
+        <source>List name:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1592"/>
+        <source>Delete list/label</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1592"/>
+        <source>The selected item will be deleted, your comics or folders will NOT be deleted from your disk. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1622"/>
+        <source>Rename list name</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1752"/>
+        <source>Save covers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1771"/>
+        <source>You are adding too many libraries.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1771"/>
+        <source>You are adding too many libraries.
+
+You probably only need one library in your top level comics folder, you can browse any subfolders using the folders section in the left sidebar.
+
+YACReaderLibrary will not stop you from creating more libraries but you should keep the number of libraries low.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1832"/>
+        <location filename="library_window.cpp" line="1834"/>
+        <source>YACReader not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1931"/>
+        <source>Library not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1931"/>
+        <source>The selected folder doesn&apos;t contain any library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1986"/>
+        <source>Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1986"/>
+        <source>Do you want remove </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1986"/>
+        <source> library?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1987"/>
+        <source>Remove and delete metadata</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2271"/>
+        <source>Assign comics numbers</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2272"/>
+        <source>Assign numbers starting in:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1561"/>
+        <location filename="library_window.cpp" line="2240"/>
+        <source>Unable to delete</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="547"/>
+        <source>Show or hide read marks</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="570"/>
+        <location filename="library_window.cpp" line="1491"/>
+        <source>Add new folder</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="573"/>
+        <source>Add new folder to the current library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="579"/>
+        <source>Delete current folder from disk</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="616"/>
+        <location filename="library_window.cpp" line="617"/>
+        <source>Change between comics views</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1832"/>
+        <source>YACReader not found. YACReader should be installed in the same folder as YACReaderLibrary.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1834"/>
+        <source>YACReader not found. There might be a problem with your YACReader installation.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2240"/>
+        <source>There was an issue trying to delete the selected comics. Please, check for write permissions in the selected files or containing folder.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2473"/>
+        <source>Error creating the library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2478"/>
+        <source>Error updating the library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2483"/>
+        <source>Error opening the library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2518"/>
+        <source>Delete comics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2518"/>
+        <source>All the selected comics will be deleted from your disk. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2563"/>
+        <source>Remove comics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2563"/>
+        <source>Comics will only be deleted from the current label/list. Are you sure?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2638"/>
+        <source>Library name already exists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2638"/>
+        <source>There is another library with the name &apos;%1&apos;.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LocalComicListModel</name>
+    <message>
+        <location filename="comic_vine/model/local_comic_list_model.cpp" line="72"/>
+        <source>file name</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>LogWindow</name>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="14"/>
+        <source>Log window</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="22"/>
+        <source>&amp;Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="39"/>
+        <source>&amp;Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="56"/>
+        <source>C&amp;lear</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="73"/>
+        <source>&amp;Copy</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="90"/>
+        <source>Level:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="136"/>
+        <source>&amp;Auto scroll</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>NoLibrariesWidget</name>
+    <message>
+        <location filename="no_libraries_widget.cpp" line="26"/>
+        <source>You don&apos;t have any libraries yet</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="no_libraries_widget.cpp" line="28"/>
+        <source>&lt;p&gt;You can create a library in any folder, YACReaderLibrary will import all comics and folders from this folder. If you have created any library in the past you can open them.&lt;/p&gt;&lt;p&gt;Don&apos;t forget that you can use YACReader as a stand alone application for reading the comics on your computer.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="no_libraries_widget.cpp" line="32"/>
+        <source>create your first library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="no_libraries_widget.cpp" line="34"/>
+        <source>add an existing one</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>OptionsDialog</name>
+    <message>
+        <location filename="options_dialog.cpp" line="47"/>
+        <source>Tray icon settings (experimental)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="50"/>
+        <source>Close to tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="51"/>
+        <source>Start into the system tray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="69"/>
+        <source>Edit Comic Vine API key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="72"/>
+        <source>Comic Vine API key</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="78"/>
+        <source>Enable background image</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="80"/>
+        <source>Opacity level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="85"/>
+        <source>Blur level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="90"/>
+        <source>Use selected comic cover as background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="92"/>
+        <source>Restore defautls</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="103"/>
+        <source>Background</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="106"/>
+        <source>Display continue reading banner</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="111"/>
+        <source>Continue reading</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="144"/>
+        <source>Comic Flow</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="146"/>
+        <source>Grid view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="148"/>
+        <source>General</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="156"/>
+        <source>Options</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>PropertiesDialog</name>
+    <message>
+        <location filename="properties_dialog.cpp" line="74"/>
+        <source>General info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="75"/>
+        <source>Authors</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="76"/>
+        <source>Publishing</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="77"/>
+        <source>Plot</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="86"/>
+        <source>Cover page</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="146"/>
+        <source>Title:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="154"/>
+        <location filename="properties_dialog.cpp" line="171"/>
+        <source>of:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="161"/>
+        <source>Issue number:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="163"/>
+        <source>Volume:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="167"/>
+        <source>Arc number:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="176"/>
+        <source>Story arc:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="178"/>
+        <source>Genre:</source>
+        <oldsource>Genere:</oldsource>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="180"/>
+        <source>Size:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="204"/>
+        <source>Writer(s):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="207"/>
+        <source>Penciller(s):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="215"/>
+        <source>Inker(s):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="218"/>
+        <source>Colorist(s):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="228"/>
+        <source>Letterer(s):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="231"/>
+        <source>Cover Artist(s):</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="253"/>
+        <source>Day:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="257"/>
+        <source>Month:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="261"/>
+        <source>Year:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="269"/>
+        <source>Publisher:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="270"/>
+        <source>Format:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="271"/>
+        <source>Color/BW:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="272"/>
+        <source>Age rating:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="273"/>
+        <source>Manga:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="286"/>
+        <source>Synopsis:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="287"/>
+        <source>Characters:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="288"/>
+        <source>Notes:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="384"/>
+        <source>Comic Vine link: &lt;a style=&apos;color: #FFCB00; text-decoration:none; font-weight:bold;&apos; href=&quot;http://www.comicvine.com/comic/4000-%1/&quot;&gt; view &lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="409"/>
+        <source>Not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="409"/>
+        <source>Comic not found. You should update your library.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="486"/>
+        <source>Edit selected comics information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="553"/>
+        <source>Edit comic information</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
+        <source>7z lib not found</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
+        <source>unable to load 7z lib from ./utils</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41"/>
+        <source>Trace</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43"/>
+        <source>Debug</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45"/>
+        <source>Info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47"/>
+        <source>Warning</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49"/>
+        <source>Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51"/>
+        <source>Fatal</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QsLogging::LogWindowModel</name>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="141"/>
+        <source>Time</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="143"/>
+        <source>Level</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="145"/>
+        <source>Message</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>QsLogging::Window</name>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
+        <source>&amp;Pause</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
+        <source>&amp;Resume</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="236"/>
+        <source>Save log</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="237"/>
+        <source>Log file (*.log)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>RenameLibraryDialog</name>
+    <message>
+        <location filename="rename_library_dialog.cpp" line="15"/>
+        <source>New Library Name : </source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="rename_library_dialog.cpp" line="20"/>
+        <source>Rename</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="rename_library_dialog.cpp" line="24"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="rename_library_dialog.cpp" line="52"/>
+        <source>Rename current library</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ScraperResultsPaginator</name>
+    <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="30"/>
+        <source>Number of volumes found : %1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="32"/>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="55"/>
+        <source>page %1 of %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="54"/>
+        <source>Number of %1 found : %2</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SearchSingleComic</name>
+    <message>
+        <location filename="comic_vine/search_single_comic.cpp" line="14"/>
+        <source>Please provide some additional information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/search_single_comic.cpp" line="19"/>
+        <source>Series:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SearchVolume</name>
+    <message>
+        <location filename="comic_vine/search_volume.cpp" line="11"/>
+        <source>Please provide some additional information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/search_volume.cpp" line="14"/>
+        <source>Series:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SelectComic</name>
+    <message>
+        <location filename="comic_vine/select_comic.cpp" line="18"/>
+        <source>Please, select the right comic info.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_comic.cpp" line="38"/>
+        <source>comics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_comic.cpp" line="94"/>
+        <source>loading cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_comic.cpp" line="95"/>
+        <source>loading description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_comic.cpp" line="135"/>
+        <source>description unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SelectVolume</name>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="32"/>
+        <source>Please, select the right series for your comic.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="60"/>
+        <source>volumes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="121"/>
+        <source>loading cover</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="122"/>
+        <source>loading description</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="162"/>
+        <source>description unavailable</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SeriesQuestion</name>
+    <message>
+        <location filename="comic_vine/series_question.cpp" line="12"/>
+        <source>You are trying to get information for various comics at once, are they part of the same series?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/series_question.cpp" line="14"/>
+        <source>yes</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/series_question.cpp" line="15"/>
+        <source>no</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>ServerConfigDialog</name>
+    <message>
+        <location filename="server_config_dialog.cpp" line="86"/>
+        <source>set port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="server_config_dialog.cpp" line="92"/>
+        <source>Server connectivity information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="server_config_dialog.cpp" line="96"/>
+        <source>Scan it!</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="server_config_dialog.cpp" line="102"/>
+        <source>YACReader is available for iOS devices. &lt;a href=&apos;http://ios.yacreader.com&apos; style=&apos;color:rgb(193, 148, 65)&apos;&gt; Discover it! &lt;/a&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="server_config_dialog.cpp" line="111"/>
+        <source>Choose an IP address</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="server_config_dialog.cpp" line="115"/>
+        <source>Port</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="server_config_dialog.cpp" line="147"/>
+        <source>enable the server</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="server_config_dialog.cpp" line="152"/>
+        <source>display less information about folders in the browser
+to improve the performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="server_config_dialog.cpp" line="268"/>
+        <source>Could not load libqrencode.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>SortVolumeComics</name>
+    <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="18"/>
+        <source>Please, sort the list of comics on the left until it matches the comics&apos; information.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="21"/>
+        <source>sort comics to match comic information</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="58"/>
+        <source>issues</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="87"/>
+        <source>remove selected comics</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="88"/>
+        <source>restore all removed comics</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>TitleHeader</name>
+    <message>
+        <location filename="comic_vine/title_header.cpp" line="30"/>
+        <source>SEARCH</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>UpdateLibraryDialog</name>
+    <message>
+        <location filename="create_library_dialog.cpp" line="155"/>
+        <source>Updating....</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="create_library_dialog.cpp" line="161"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="create_library_dialog.cpp" line="180"/>
+        <source>Update library</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>VolumeComicsModel</name>
+    <message>
+        <location filename="comic_vine/model/volume_comics_model.cpp" line="120"/>
+        <source>title</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>VolumesModel</name>
+    <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="118"/>
+        <source>year</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="120"/>
+        <source>issues</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="122"/>
+        <source>publisher</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReader::TrayIconController</name>
+    <message>
+        <location filename="trayicon_controller.cpp" line="52"/>
+        <source>&amp;Restore</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="trayicon_controller.cpp" line="55"/>
+        <source>&amp;Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="trayicon_controller.cpp" line="82"/>
+        <source>Systray</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="trayicon_controller.cpp" line="83"/>
+        <source>YACReaderLibrary will keep running in the system tray. To terminate the program, choose &lt;b&gt;Quit&lt;/b&gt; in the context menu of the system tray icon.</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReader::WhatsNewDialog</name>
+    <message>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="99"/>
+        <source>Close</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderDeletingProgress</name>
+    <message>
+        <location filename="../custom_widgets/yacreader_deleting_progress.cpp" line="20"/>
+        <source>Please wait, deleting in progress...</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_deleting_progress.cpp" line="35"/>
+        <source>cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderFieldEdit</name>
+    <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28"/>
+        <source>Click to overwrite</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11"/>
+        <source>Restore to default</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderFieldPlainTextEdit</name>
+    <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50"/>
+        <source>Click to overwrite</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10"/>
+        <source>Restore to default</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderFlowConfigWidget</name>
+    <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="13"/>
+        <source>How to show covers:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="15"/>
+        <source>CoverFlow look</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="16"/>
+        <source>Stripe look</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="17"/>
+        <source>Overlapped Stripe look</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderGLFlowConfigWidget</name>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="18"/>
+        <source>Presets:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="20"/>
+        <source>Classic look</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="23"/>
+        <source>Stripe look</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="26"/>
+        <source>Overlapped Stripe look</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="29"/>
+        <source>Modern look</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="32"/>
+        <source>Roulette look</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="76"/>
+        <source>Show advanced settings</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="85"/>
+        <source>Custom:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="88"/>
+        <source>View angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="94"/>
+        <source>Position</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="100"/>
+        <source>Cover gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="106"/>
+        <source>Central gap</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="112"/>
+        <source>Zoom</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="118"/>
+        <source>Y offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="124"/>
+        <source>Z offset</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="130"/>
+        <source>Cover Angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="136"/>
+        <source>Visibility</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="142"/>
+        <source>Light</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="148"/>
+        <source>Max angle</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="180"/>
+        <source>Low Performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="182"/>
+        <source>High Performance</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="193"/>
+        <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="201"/>
+        <source>Performance:</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderNavigationController</name>
+    <message>
+        <location filename="yacreader_navigation_controller.cpp" line="125"/>
+        <source>No favorites</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="yacreader_navigation_controller.cpp" line="129"/>
+        <source>You are not reading anything yet, come on!!</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderOptionsDialog</name>
+    <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28"/>
+        <source>Save</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="29"/>
+        <source>Cancel</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="34"/>
+        <source>Edit shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="37"/>
+        <source>Shortcuts</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="46"/>
+        <source>Use hardware acceleration (restart needed)</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderSearchLineEdit</name>
+    <message>
+        <location filename="../custom_widgets/yacreader_search_line_edit.cpp" line="48"/>
+        <source>type to search</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderSideBar</name>
+    <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="27"/>
+        <source>Libraries</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="28"/>
+        <source>Folders</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="29"/>
+        <source>Reading Lists</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="31"/>
+        <source>LIBRARIES</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="32"/>
+        <source>FOLDERS</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="33"/>
+        <source>READING LISTS</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+</TS>

--- a/YACReaderLibrary/yacreaderlibrary_en.ts
+++ b/YACReaderLibrary/yacreaderlibrary_en.ts
@@ -4,7 +4,7 @@
 <context>
     <name>ActionsShortcutsModel</name>
     <message>
-        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="72"/>
+        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="73"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
@@ -155,57 +155,57 @@
 <context>
     <name>ComicInfoView</name>
     <message>
-        <location filename="qml/ComicInfoView.qml" line="281"/>
+        <location filename="qml/ComicInfoView.qml" line="279"/>
         <source>Authors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qml/ComicInfoView.qml" line="311"/>
+        <location filename="qml/ComicInfoView.qml" line="309"/>
         <source>writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qml/ComicInfoView.qml" line="333"/>
+        <location filename="qml/ComicInfoView.qml" line="331"/>
         <source>penciller</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qml/ComicInfoView.qml" line="355"/>
+        <location filename="qml/ComicInfoView.qml" line="353"/>
         <source>inker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qml/ComicInfoView.qml" line="377"/>
+        <location filename="qml/ComicInfoView.qml" line="375"/>
         <source>colorist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qml/ComicInfoView.qml" line="399"/>
+        <location filename="qml/ComicInfoView.qml" line="397"/>
         <source>letterer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qml/ComicInfoView.qml" line="421"/>
+        <location filename="qml/ComicInfoView.qml" line="419"/>
         <source>cover artist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qml/ComicInfoView.qml" line="436"/>
+        <location filename="qml/ComicInfoView.qml" line="434"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qml/ComicInfoView.qml" line="476"/>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
         <source>color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qml/ComicInfoView.qml" line="476"/>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
         <source>b/w</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="qml/ComicInfoView.qml" line="504"/>
+        <location filename="qml/ComicInfoView.qml" line="502"/>
         <source>Characters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -213,47 +213,52 @@
 <context>
     <name>ComicModel</name>
     <message>
-        <location filename="db/comic_model.cpp" line="307"/>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="307"/>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="335"/>
+        <location filename="db/comic_model.cpp" line="343"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="337"/>
+        <location filename="db/comic_model.cpp" line="345"/>
         <source>File Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="339"/>
+        <location filename="db/comic_model.cpp" line="347"/>
         <source>Pages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="341"/>
+        <location filename="db/comic_model.cpp" line="349"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="343"/>
+        <location filename="db/comic_model.cpp" line="351"/>
         <source>Read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="345"/>
+        <location filename="db/comic_model.cpp" line="353"/>
         <source>Current Page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="347"/>
+        <location filename="db/comic_model.cpp" line="355"/>
+        <source>Publication Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="357"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
@@ -261,68 +266,67 @@
 <context>
     <name>ComicVineDialog</name>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="54"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="57"/>
         <source>skip</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="55"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="58"/>
         <source>back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="56"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="59"/>
         <source>next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="57"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="60"/>
         <source>search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="58"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="61"/>
         <source>close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="134"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="144"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="240"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="747"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="781"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="143"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="257"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="773"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="807"/>
         <source>Looking for volume...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="142"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="714"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="141"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="735"/>
         <source>comic %1 of %2 - %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="245"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="262"/>
         <source>%1 comics selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="278"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="295"/>
         <source>Error connecting to ComicVine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="448"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="484"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="467"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="503"/>
         <source>Retrieving tags for : %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="762"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="788"/>
         <source>Retrieving volume info...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="788"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="814"/>
         <source>Looking for comic...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -534,9 +538,25 @@
     </message>
 </context>
 <context>
+    <name>FolderContentView</name>
+    <message>
+        <location filename="qml/FolderContentView.qml" line="238"/>
+        <source>Continue Reading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FolderContentView6</name>
+    <message>
+        <location filename="qml/FolderContentView6.qml" line="240"/>
+        <source>Continue Reading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GridComicsView</name>
     <message>
-        <location filename="grid_comics_view.cpp" line="169"/>
+        <location filename="grid_comics_view.cpp" line="147"/>
         <source>Show info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -544,13 +564,18 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
-        <location filename="../custom_widgets/help_about_dialog.cpp" line="21"/>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../custom_widgets/help_about_dialog.cpp" line="24"/>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
+        <source>System info</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
@@ -662,477 +687,520 @@
         <source>&lt;p&gt;The current library is being upgraded, please wait.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
+    <message>
+        <location filename="import_widget.cpp" line="370"/>
+        <source>Scanning the library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="371"/>
+        <source>&lt;p&gt;Current library is being scanned for legacy XML metadata information.&lt;/p&gt;&lt;p&gt;This is only needed once, and only if the library was crated with YACReaderLibrary 9.8.2 or earlier.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
 </context>
 <context>
     <name>LibraryWindow</name>
     <message>
-        <location filename="library_window.cpp" line="144"/>
+        <location filename="library_window.cpp" line="188"/>
         <source>YACReader Library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="968"/>
+        <location filename="library_window.cpp" line="1027"/>
         <source>Library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="450"/>
+        <location filename="library_window.cpp" line="484"/>
         <source>Create a new library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="456"/>
+        <location filename="library_window.cpp" line="490"/>
         <source>Open an existing library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="461"/>
-        <location filename="library_window.cpp" line="462"/>
+        <location filename="library_window.cpp" line="495"/>
+        <location filename="library_window.cpp" line="496"/>
         <source>Export comics info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="467"/>
-        <location filename="library_window.cpp" line="468"/>
+        <location filename="library_window.cpp" line="501"/>
+        <location filename="library_window.cpp" line="502"/>
         <source>Import comics info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="473"/>
+        <location filename="library_window.cpp" line="507"/>
         <source>Pack covers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="474"/>
+        <location filename="library_window.cpp" line="508"/>
         <source>Pack the covers of the selected library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="479"/>
+        <location filename="library_window.cpp" line="513"/>
         <source>Unpack covers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="480"/>
+        <location filename="library_window.cpp" line="514"/>
         <source>Unpack a catalog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="485"/>
+        <location filename="library_window.cpp" line="519"/>
         <source>Update library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="486"/>
+        <location filename="library_window.cpp" line="520"/>
         <source>Update current library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="491"/>
+        <location filename="library_window.cpp" line="525"/>
         <source>Rename library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="492"/>
+        <location filename="library_window.cpp" line="526"/>
         <source>Rename current library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="497"/>
+        <location filename="library_window.cpp" line="531"/>
         <source>Remove library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="498"/>
+        <location filename="library_window.cpp" line="532"/>
         <source>Remove current library from your collection</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="503"/>
+        <location filename="library_window.cpp" line="542"/>
         <source>Open current comic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="504"/>
+        <location filename="library_window.cpp" line="543"/>
         <source>Open current comic on YACReader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="509"/>
+        <location filename="library_window.cpp" line="548"/>
         <source>Save selected covers to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="510"/>
+        <location filename="library_window.cpp" line="549"/>
         <source>Save covers of the selected comics as JPG files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="514"/>
-        <location filename="library_window.cpp" line="651"/>
+        <location filename="library_window.cpp" line="553"/>
+        <location filename="library_window.cpp" line="690"/>
+        <location filename="library_window.cpp" line="1800"/>
         <source>Set as read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="515"/>
+        <location filename="library_window.cpp" line="554"/>
         <source>Set comic as read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="520"/>
-        <location filename="library_window.cpp" line="656"/>
+        <location filename="library_window.cpp" line="559"/>
+        <location filename="library_window.cpp" line="695"/>
+        <location filename="library_window.cpp" line="1803"/>
         <source>Set as unread</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="521"/>
+        <location filename="library_window.cpp" line="560"/>
         <source>Set comic as unread</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="546"/>
+        <location filename="library_window.cpp" line="585"/>
         <source>Show/Hide marks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="595"/>
+        <location filename="library_window.cpp" line="634"/>
         <source>Collapse all nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="697"/>
+        <location filename="library_window.cpp" line="736"/>
         <source>Assign current order to comics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1283"/>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library not available</source>
         <oldsource>Library &apos;</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="554"/>
-        <location filename="library_window.cpp" line="555"/>
+        <location filename="library_window.cpp" line="593"/>
+        <location filename="library_window.cpp" line="594"/>
         <source>Fullscreen mode on/off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="526"/>
-        <location filename="library_window.cpp" line="661"/>
+        <location filename="library_window.cpp" line="537"/>
+        <source>Rescan library for XML info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="538"/>
+        <source>Tries to find XML info embedded in comic files. You only need to do this if the library was created with 9.8.2 or earlier versions or if you are using third party software to embed XML info in the files.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="565"/>
+        <location filename="library_window.cpp" line="700"/>
+        <location filename="library_window.cpp" line="1806"/>
         <source>Set as manga</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="527"/>
+        <location filename="library_window.cpp" line="566"/>
         <source>Set issue as manga</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="532"/>
+        <location filename="library_window.cpp" line="571"/>
         <source>Set as normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="533"/>
+        <location filename="library_window.cpp" line="572"/>
         <source>Set issue as normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="563"/>
+        <location filename="library_window.cpp" line="602"/>
         <source>Help, About YACReader</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="576"/>
-        <location filename="library_window.cpp" line="1527"/>
+        <location filename="library_window.cpp" line="615"/>
+        <location filename="library_window.cpp" line="1610"/>
         <source>Delete folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="585"/>
+        <location filename="library_window.cpp" line="624"/>
         <source>Select root node</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="589"/>
+        <location filename="library_window.cpp" line="628"/>
         <source>Expand all nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="601"/>
+        <location filename="library_window.cpp" line="640"/>
         <source>Show options dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="609"/>
+        <location filename="library_window.cpp" line="648"/>
         <source>Show comics server options dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="635"/>
+        <location filename="library_window.cpp" line="674"/>
+        <location filename="library_window.cpp" line="1787"/>
         <source>Open folder...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="641"/>
+        <location filename="library_window.cpp" line="680"/>
+        <location filename="library_window.cpp" line="1794"/>
         <source>Set as uncompleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="646"/>
+        <location filename="library_window.cpp" line="685"/>
+        <location filename="library_window.cpp" line="1797"/>
         <source>Set as completed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="666"/>
+        <location filename="library_window.cpp" line="705"/>
+        <location filename="library_window.cpp" line="1809"/>
         <source>Set as comic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="673"/>
+        <location filename="library_window.cpp" line="712"/>
         <source>Open containing folder...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="679"/>
+        <location filename="library_window.cpp" line="718"/>
         <source>Reset comic rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="685"/>
+        <location filename="library_window.cpp" line="724"/>
         <source>Select all comics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="691"/>
+        <location filename="library_window.cpp" line="730"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="703"/>
+        <location filename="library_window.cpp" line="742"/>
         <source>Update cover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="709"/>
+        <location filename="library_window.cpp" line="748"/>
         <source>Delete selected comics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="717"/>
+        <location filename="library_window.cpp" line="756"/>
         <source>Download tags from Comic Vine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="721"/>
+        <location filename="library_window.cpp" line="760"/>
+        <source>Focus search line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="766"/>
+        <source>Focus comics view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="771"/>
         <source>Edit shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="727"/>
+        <location filename="library_window.cpp" line="777"/>
+        <source>&amp;Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="784"/>
+        <location filename="library_window.cpp" line="1790"/>
         <source>Update folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="730"/>
+        <location filename="library_window.cpp" line="787"/>
         <source>Update current folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="735"/>
+        <location filename="library_window.cpp" line="792"/>
         <source>Add new reading list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="738"/>
+        <location filename="library_window.cpp" line="795"/>
         <source>Add a new reading list to the current library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="741"/>
+        <location filename="library_window.cpp" line="798"/>
         <source>Remove reading list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="744"/>
+        <location filename="library_window.cpp" line="801"/>
         <source>Remove current reading list from the library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="747"/>
+        <location filename="library_window.cpp" line="804"/>
         <source>Add new label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="750"/>
+        <location filename="library_window.cpp" line="807"/>
         <source>Add a new label to this library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="753"/>
+        <location filename="library_window.cpp" line="810"/>
         <source>Rename selected list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="756"/>
+        <location filename="library_window.cpp" line="813"/>
         <source>Rename any selected labels or lists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="760"/>
+        <location filename="library_window.cpp" line="817"/>
         <source>Add to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="762"/>
+        <location filename="library_window.cpp" line="819"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="765"/>
+        <location filename="library_window.cpp" line="822"/>
         <source>Add selected comics to favorites list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="984"/>
+        <location filename="library_window.cpp" line="1046"/>
         <source>Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="998"/>
+        <location filename="library_window.cpp" line="1060"/>
         <source>Comic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1178"/>
+        <location filename="library_window.cpp" line="1251"/>
         <source>Upgrade failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1178"/>
+        <location filename="library_window.cpp" line="1251"/>
         <source>There were errors during library upgrade in: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1196"/>
+        <location filename="library_window.cpp" line="1269"/>
         <source>Update needed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1196"/>
+        <location filename="library_window.cpp" line="1269"/>
         <source>This library was created with a previous version of YACReaderLibrary. It needs to be updated. Update now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1262"/>
+        <location filename="library_window.cpp" line="1336"/>
         <source>Download new version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1262"/>
+        <location filename="library_window.cpp" line="1336"/>
         <source>This library was created with a newer version of YACReaderLibrary. Download the new version now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1283"/>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library &apos;%1&apos; is no longer available. Do you want to remove it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1302"/>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Old library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1302"/>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Library &apos;%1&apos; has been created with an older version of YACReaderLibrary. It must be created again. Do you want to create the library now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1335"/>
-        <location filename="library_window.cpp" line="1371"/>
+        <location filename="library_window.cpp" line="1409"/>
+        <location filename="library_window.cpp" line="1445"/>
         <source>Copying comics...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1352"/>
-        <location filename="library_window.cpp" line="1390"/>
+        <location filename="library_window.cpp" line="1426"/>
+        <location filename="library_window.cpp" line="1464"/>
         <source>Moving comics...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1492"/>
+        <location filename="library_window.cpp" line="1575"/>
         <source>Folder name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1521"/>
+        <location filename="library_window.cpp" line="1604"/>
         <source>No folder selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1521"/>
+        <location filename="library_window.cpp" line="1604"/>
         <source>Please, select a folder first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1525"/>
+        <location filename="library_window.cpp" line="1608"/>
         <source>Error in path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1525"/>
+        <location filename="library_window.cpp" line="1608"/>
         <source>There was an error accessing the folder&apos;s path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1527"/>
+        <location filename="library_window.cpp" line="1610"/>
         <source>The selected folder and all its contents will be deleted from your disk. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1561"/>
+        <location filename="library_window.cpp" line="1636"/>
         <source>There was an issue trying to delete the selected folders. Please, check for write permissions and be sure that any applications are using these folders or any of the contained files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1573"/>
+        <location filename="library_window.cpp" line="1648"/>
         <source>Add new reading lists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1574"/>
-        <location filename="library_window.cpp" line="1623"/>
+        <location filename="library_window.cpp" line="1649"/>
+        <location filename="library_window.cpp" line="1698"/>
         <source>List name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1592"/>
+        <location filename="library_window.cpp" line="1667"/>
         <source>Delete list/label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1592"/>
+        <location filename="library_window.cpp" line="1667"/>
         <source>The selected item will be deleted, your comics or folders will NOT be deleted from your disk. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1622"/>
+        <location filename="library_window.cpp" line="1697"/>
         <source>Rename list name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1752"/>
+        <location filename="library_window.cpp" line="1916"/>
         <source>Save covers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1771"/>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1771"/>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.
 
 You probably only need one library in your top level comics folder, you can browse any subfolders using the folders section in the left sidebar.
@@ -1141,141 +1209,141 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1832"/>
-        <location filename="library_window.cpp" line="1834"/>
+        <location filename="library_window.cpp" line="1993"/>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1931"/>
+        <location filename="library_window.cpp" line="2083"/>
         <source>Library not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1931"/>
+        <location filename="library_window.cpp" line="2083"/>
         <source>The selected folder doesn&apos;t contain any library.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1986"/>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1986"/>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Do you want remove </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1986"/>
+        <location filename="library_window.cpp" line="2138"/>
         <source> library?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1987"/>
+        <location filename="library_window.cpp" line="2139"/>
         <source>Remove and delete metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2271"/>
+        <location filename="library_window.cpp" line="2448"/>
         <source>Assign comics numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2272"/>
+        <location filename="library_window.cpp" line="2449"/>
         <source>Assign numbers starting in:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1561"/>
-        <location filename="library_window.cpp" line="2240"/>
+        <location filename="library_window.cpp" line="1636"/>
+        <location filename="library_window.cpp" line="2417"/>
         <source>Unable to delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="547"/>
+        <location filename="library_window.cpp" line="586"/>
         <source>Show or hide read marks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="570"/>
-        <location filename="library_window.cpp" line="1491"/>
+        <location filename="library_window.cpp" line="609"/>
+        <location filename="library_window.cpp" line="1574"/>
         <source>Add new folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="573"/>
+        <location filename="library_window.cpp" line="612"/>
         <source>Add new folder to the current library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="579"/>
+        <location filename="library_window.cpp" line="618"/>
         <source>Delete current folder from disk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="616"/>
-        <location filename="library_window.cpp" line="617"/>
+        <location filename="library_window.cpp" line="655"/>
+        <location filename="library_window.cpp" line="656"/>
         <source>Change between comics views</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1832"/>
+        <location filename="library_window.cpp" line="1993"/>
         <source>YACReader not found. YACReader should be installed in the same folder as YACReaderLibrary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1834"/>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found. There might be a problem with your YACReader installation.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2240"/>
+        <location filename="library_window.cpp" line="2417"/>
         <source>There was an issue trying to delete the selected comics. Please, check for write permissions in the selected files or containing folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2473"/>
+        <location filename="library_window.cpp" line="2649"/>
         <source>Error creating the library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2478"/>
+        <location filename="library_window.cpp" line="2654"/>
         <source>Error updating the library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2483"/>
+        <location filename="library_window.cpp" line="2659"/>
         <source>Error opening the library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2518"/>
+        <location filename="library_window.cpp" line="2694"/>
         <source>Delete comics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2518"/>
+        <location filename="library_window.cpp" line="2694"/>
         <source>All the selected comics will be deleted from your disk. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2563"/>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Remove comics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2563"/>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Comics will only be deleted from the current label/list. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2638"/>
+        <location filename="library_window.cpp" line="2805"/>
         <source>Library name already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2638"/>
+        <location filename="library_window.cpp" line="2805"/>
         <source>There is another library with the name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1440,179 +1508,179 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>PropertiesDialog</name>
     <message>
-        <location filename="properties_dialog.cpp" line="74"/>
+        <location filename="properties_dialog.cpp" line="82"/>
         <source>General info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="75"/>
+        <location filename="properties_dialog.cpp" line="83"/>
         <source>Authors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="76"/>
+        <location filename="properties_dialog.cpp" line="84"/>
         <source>Publishing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="77"/>
+        <location filename="properties_dialog.cpp" line="85"/>
         <source>Plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="86"/>
+        <location filename="properties_dialog.cpp" line="94"/>
         <source>Cover page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="146"/>
+        <location filename="properties_dialog.cpp" line="143"/>
         <source>Title:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="154"/>
-        <location filename="properties_dialog.cpp" line="171"/>
+        <location filename="properties_dialog.cpp" line="151"/>
+        <location filename="properties_dialog.cpp" line="168"/>
         <source>of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="161"/>
+        <location filename="properties_dialog.cpp" line="158"/>
         <source>Issue number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="163"/>
+        <location filename="properties_dialog.cpp" line="160"/>
         <source>Volume:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="167"/>
+        <location filename="properties_dialog.cpp" line="164"/>
         <source>Arc number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="176"/>
+        <location filename="properties_dialog.cpp" line="173"/>
         <source>Story arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="178"/>
+        <location filename="properties_dialog.cpp" line="175"/>
         <source>Genre:</source>
         <oldsource>Genere:</oldsource>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="180"/>
+        <location filename="properties_dialog.cpp" line="177"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="204"/>
+        <location filename="properties_dialog.cpp" line="197"/>
         <source>Writer(s):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="207"/>
+        <location filename="properties_dialog.cpp" line="200"/>
         <source>Penciller(s):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="215"/>
+        <location filename="properties_dialog.cpp" line="207"/>
         <source>Inker(s):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="218"/>
+        <location filename="properties_dialog.cpp" line="210"/>
         <source>Colorist(s):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="228"/>
+        <location filename="properties_dialog.cpp" line="217"/>
         <source>Letterer(s):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="231"/>
+        <location filename="properties_dialog.cpp" line="220"/>
         <source>Cover Artist(s):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="253"/>
+        <location filename="properties_dialog.cpp" line="240"/>
         <source>Day:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="257"/>
+        <location filename="properties_dialog.cpp" line="244"/>
         <source>Month:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="261"/>
+        <location filename="properties_dialog.cpp" line="248"/>
         <source>Year:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="269"/>
+        <location filename="properties_dialog.cpp" line="256"/>
         <source>Publisher:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="270"/>
+        <location filename="properties_dialog.cpp" line="257"/>
         <source>Format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="271"/>
+        <location filename="properties_dialog.cpp" line="258"/>
         <source>Color/BW:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="272"/>
+        <location filename="properties_dialog.cpp" line="259"/>
         <source>Age rating:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="273"/>
+        <location filename="properties_dialog.cpp" line="260"/>
         <source>Manga:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="286"/>
+        <location filename="properties_dialog.cpp" line="273"/>
         <source>Synopsis:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="287"/>
+        <location filename="properties_dialog.cpp" line="274"/>
         <source>Characters:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="288"/>
+        <location filename="properties_dialog.cpp" line="275"/>
         <source>Notes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="384"/>
+        <location filename="properties_dialog.cpp" line="369"/>
         <source>Comic Vine link: &lt;a style=&apos;color: #FFCB00; text-decoration:none; font-weight:bold;&apos; href=&quot;http://www.comicvine.com/comic/4000-%1/&quot;&gt; view &lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="409"/>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="409"/>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Comic not found. You should update your library.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="486"/>
+        <location filename="properties_dialog.cpp" line="501"/>
         <source>Edit selected comics information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="553"/>
+        <location filename="properties_dialog.cpp" line="467"/>
         <source>Edit comic information</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1719,7 +1787,7 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="rename_library_dialog.cpp" line="52"/>
+        <location filename="rename_library_dialog.cpp" line="51"/>
         <source>Rename current library</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1800,27 +1868,37 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>SelectVolume</name>
     <message>
-        <location filename="comic_vine/select_volume.cpp" line="32"/>
+        <location filename="comic_vine/select_volume.cpp" line="35"/>
         <source>Please, select the right series for your comic.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="comic_vine/select_volume.cpp" line="60"/>
+        <location filename="comic_vine/select_volume.cpp" line="56"/>
+        <source>Filter:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="68"/>
         <source>volumes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="comic_vine/select_volume.cpp" line="121"/>
+        <location filename="comic_vine/select_volume.cpp" line="138"/>
+        <source>Nothing found, clear the filter if any.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="144"/>
         <source>loading cover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="comic_vine/select_volume.cpp" line="122"/>
+        <location filename="comic_vine/select_volume.cpp" line="145"/>
         <source>loading description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="comic_vine/select_volume.cpp" line="162"/>
+        <location filename="comic_vine/select_volume.cpp" line="185"/>
         <source>description unavailable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1980,17 +2058,12 @@ to improve the performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="trayicon_controller.cpp" line="55"/>
-        <source>&amp;Quit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="trayicon_controller.cpp" line="82"/>
+        <location filename="trayicon_controller.cpp" line="79"/>
         <source>Systray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="trayicon_controller.cpp" line="83"/>
+        <location filename="trayicon_controller.cpp" line="80"/>
         <source>YACReaderLibrary will keep running in the system tray. To terminate the program, choose &lt;b&gt;Quit&lt;/b&gt; in the context menu of the system tray icon.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1998,7 +2071,7 @@ to improve the performance</source>
 <context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
-        <location filename="../custom_widgets/whats_new_dialog.cpp" line="99"/>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2190,12 +2263,12 @@ to improve the performance</source>
 <context>
     <name>YACReaderNavigationController</name>
     <message>
-        <location filename="yacreader_navigation_controller.cpp" line="125"/>
+        <location filename="yacreader_navigation_controller.cpp" line="123"/>
         <source>No favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="yacreader_navigation_controller.cpp" line="129"/>
+        <location filename="yacreader_navigation_controller.cpp" line="127"/>
         <source>You are not reading anything yet, come on!!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -2231,7 +2304,7 @@ to improve the performance</source>
 <context>
     <name>YACReaderSearchLineEdit</name>
     <message>
-        <location filename="../custom_widgets/yacreader_search_line_edit.cpp" line="48"/>
+        <location filename="../custom_widgets/yacreader_search_line_edit.cpp" line="68"/>
         <source>type to search</source>
         <translation type="unfinished"></translation>
     </message>

--- a/YACReaderLibrary/yacreaderlibrary_es.ts
+++ b/YACReaderLibrary/yacreaderlibrary_es.ts
@@ -4,6 +4,7 @@
 <context>
     <name>ActionsShortcutsModel</name>
     <message>
+        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="73"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11,66 +12,82 @@
 <context>
     <name>AddLabelDialog</name>
     <message>
+        <location filename="add_label_dialog.cpp" line="37"/>
         <source>cancel</source>
         <translation>cancelar</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="8"/>
         <source>Label name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="11"/>
         <source>Choose a color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="14"/>
         <source>red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="15"/>
         <source>orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="16"/>
         <source>yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="17"/>
         <source>green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="18"/>
         <source>cyan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="19"/>
         <source>blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="20"/>
         <source>violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="21"/>
         <source>purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="22"/>
         <source>pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="23"/>
         <source>white</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="24"/>
         <source>light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="25"/>
         <source>dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="36"/>
         <source>accept</source>
         <translation type="unfinished"></translation>
     </message>
@@ -78,22 +95,27 @@
 <context>
     <name>AddLibraryDialog</name>
     <message>
+        <location filename="add_library_dialog.cpp" line="26"/>
         <source>Add</source>
         <translation>Añadir</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="66"/>
         <source>Add an existing library</source>
         <translation>Añadir una biblioteca existente</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="30"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="16"/>
         <source>Comics folder : </source>
         <translation>Carpeta de cómics:</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="21"/>
         <source>Library name : </source>
         <translation>Nombre de la biblioteca:</translation>
     </message>
@@ -101,18 +123,22 @@
 <context>
     <name>ApiKeyDialog</name>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="32"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="21"/>
         <source>Before you can connect to Comic Vine, you need your own API key. Please, get one free &lt;a href=&quot;http://www.comicvine.com/api/&quot;&gt;here&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="25"/>
         <source>Paste here your Comic Vine API key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="28"/>
         <source>Accept</source>
         <translation type="unfinished"></translation>
     </message>
@@ -120,6 +146,7 @@
 <context>
     <name>ClassicComicsView</name>
     <message>
+        <location filename="classic_comics_view.cpp" line="90"/>
         <source>Hide comic flow</source>
         <translation>Ocultar cómic flow</translation>
     </message>
@@ -127,46 +154,57 @@
 <context>
     <name>ComicInfoView</name>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="279"/>
         <source>Authors</source>
         <translation>Autores</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="309"/>
         <source>writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="331"/>
         <source>penciller</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="353"/>
         <source>inker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="375"/>
         <source>colorist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="397"/>
         <source>letterer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="419"/>
         <source>cover artist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="434"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
         <source>color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
         <source>b/w</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="502"/>
         <source>Characters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,38 +212,52 @@
 <context>
     <name>ComicModel</name>
     <message>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>no</source>
         <translation>no</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>yes</source>
         <translation>sí</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="351"/>
         <source>Read</source>
         <translation>Leído</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="349"/>
         <source>Size</source>
         <translation>Tamaño</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="347"/>
         <source>Pages</source>
         <translation>Páginas</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="343"/>
         <source>Title</source>
         <translation>Título</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="353"/>
         <source>Current Page</source>
         <translation>Página Actual</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="345"/>
         <source>File Name</source>
         <translation>Nombre de archivo</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="355"/>
+        <source>Publication Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="357"/>
         <source>Rating</source>
         <translation>Nota</translation>
     </message>
@@ -213,50 +265,67 @@
 <context>
     <name>ComicVineDialog</name>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="58"/>
         <source>back</source>
         <translation>atrás</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="59"/>
         <source>next</source>
         <translation>siguiente</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="57"/>
         <source>skip</source>
         <translation>omitir</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="61"/>
         <source>close</source>
         <translation>cerrar</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="467"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="503"/>
         <source>Retrieving tags for : %1</source>
         <translation>Recuperando etiquetas para : %1</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="814"/>
         <source>Looking for comic...</source>
         <translation>Buscando cómic...</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="60"/>
         <source>search</source>
         <translation>buscar</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="143"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="257"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="773"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="807"/>
         <source>Looking for volume...</source>
         <translation>Buscando volumen...</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="141"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="735"/>
         <source>comic %1 of %2 - %3</source>
         <translation>cómic %1 de %2 - %3</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="262"/>
         <source>%1 comics selected</source>
         <translation>%1 comics seleccionados</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="295"/>
         <source>Error connecting to ComicVine</source>
         <translation>Error conectando a ComicVine</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="788"/>
         <source>Retrieving volume info...</source>
         <translation>Recuperando imformación del volumen...</translation>
     </message>
@@ -264,34 +333,42 @@
 <context>
     <name>CreateLibraryDialog</name>
     <message>
+        <location filename="create_library_dialog.cpp" line="75"/>
         <source>Create new library</source>
         <translation>Crear la nueva biblioteca</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="31"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="27"/>
         <source>Create</source>
         <translation>Crear</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="53"/>
         <source>Create a library could take several minutes. You can stop the process and update the library later for completing the task.</source>
         <translation>Crear una biblioteca puede llevar varios minutos. Puedes parar el proceso en cualquier momento y completar la tarea más tarde.</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="95"/>
         <source>The selected path does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation>La ruta seleccionada no existe o no es válida. Asegúrate de que tienes privilegios de escritura en esta carpeta</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="17"/>
         <source>Comics folder : </source>
         <translation>Carpeta de cómics:</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="22"/>
         <source>Library Name : </source>
         <translation>Nombre de la biblioteca:</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="95"/>
         <source>Path not found</source>
         <translation>Ruta no encontrada</translation>
     </message>
@@ -299,22 +376,27 @@
 <context>
     <name>EditShortcutsDialog</name>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="21"/>
         <source>Restore defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="22"/>
         <source>To change a shortcut, double click in the key combination and type the new keys.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="69"/>
         <source>Shortcuts settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>Shortcut in use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>The shortcut &quot;%1&quot; is already assigned to other function</source>
         <translation type="unfinished"></translation>
     </message>
@@ -322,14 +404,18 @@
 <context>
     <name>EmptyFolderWidget</name>
     <message>
+        <location filename="empty_folder_widget.cpp" line="75"/>
+        <location filename="empty_folder_widget.cpp" line="140"/>
         <source>Subfolders in this folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="empty_folder_widget.cpp" line="138"/>
         <source>Empty folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="empty_folder_widget.cpp" line="138"/>
         <source>Drag and drop folders and comics here</source>
         <translation type="unfinished"></translation>
     </message>
@@ -337,6 +423,7 @@
 <context>
     <name>EmptyLabelWidget</name>
     <message>
+        <location filename="empty_label_widget.cpp" line="11"/>
         <source>This label doesn&apos;t contain comics yet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -344,6 +431,7 @@
 <context>
     <name>EmptyReadingListWidget</name>
     <message>
+        <location filename="empty_reading_list_widget.cpp" line="8"/>
         <source>This reading list does not contain any comics yet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -351,30 +439,37 @@
 <context>
     <name>ExportComicsInfoDialog</name>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="14"/>
         <source>Output file : </source>
         <translation>Archivo de salida : </translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="66"/>
         <source>Destination database name</source>
         <translation>Nombre de la base de datos de destino</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="22"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="18"/>
         <source>Create</source>
         <translation>Crear</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="81"/>
         <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation>La ruta seleccionada para el archivo de salida no existe o no es una ruta válida. Asegúrate de que tienes permisos de escritura en esta carpeta</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="57"/>
         <source>Export comics info</source>
         <translation>Exportar información de los cómics</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="81"/>
         <source>Problem found while writing</source>
         <translation>Problema encontrado mientras se escribía</translation>
     </message>
@@ -382,30 +477,37 @@
 <context>
     <name>ExportLibraryDialog</name>
     <message>
+        <location filename="export_library_dialog.cpp" line="19"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="15"/>
         <source>Create</source>
         <translation>Crear</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="71"/>
         <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation>La ruta seleccionada para el archivo de salida no existe o no es una ruta válida. Asegúrate de que tienes permisos de escritura en esta carpeta</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="11"/>
         <source>Output folder : </source>
         <translation>Carpeta de destino:</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="71"/>
         <source>Problem found while writing</source>
         <translation>Problema encontrado mientras se escribía</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="60"/>
         <source>Create covers package</source>
         <translation>Crear paquete de portadas</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="76"/>
         <source>Destination directory</source>
         <translation>Carpeta de destino</translation>
     </message>
@@ -413,25 +515,46 @@
 <context>
     <name>FileComic</name>
     <message>
+        <location filename="../common/comic.cpp" line="568"/>
         <source>Format not supported</source>
         <translation>Formato no soportado</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="562"/>
         <source>7z not found</source>
         <translation>7z no encontrado</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="461"/>
         <source>Unknown error opening the file</source>
         <translation>Error desconocido abriendo el archivo</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="454"/>
         <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
         <translation>Error CRC en la página (%1): algunas de las páginas no se mostrarán correctamente</translation>
     </message>
 </context>
 <context>
+    <name>FolderContentView</name>
+    <message>
+        <location filename="qml/FolderContentView.qml" line="238"/>
+        <source>Continue Reading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FolderContentView6</name>
+    <message>
+        <location filename="qml/FolderContentView6.qml" line="240"/>
+        <source>Continue Reading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GridComicsView</name>
     <message>
+        <location filename="grid_comics_view.cpp" line="147"/>
         <source>Show info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -439,10 +562,17 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Ayuda</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
+        <source>System info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation>Acerca de</translation>
     </message>
@@ -450,22 +580,27 @@
 <context>
     <name>ImportComicsInfoDialog</name>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="24"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="20"/>
         <source>Import</source>
         <translation>Importar</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="16"/>
         <source>Info database location : </source>
         <translation>Ubicación de la base de datos de información : </translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="14"/>
         <source>Import comics info</source>
         <translation>Importar información de cómics</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="74"/>
         <source>Comics info file (*.ydb)</source>
         <translation>Archivo de información de cómics (*.ydb)</translation>
     </message>
@@ -473,30 +608,37 @@
 <context>
     <name>ImportLibraryDialog</name>
     <message>
+        <location filename="import_library_dialog.cpp" line="26"/>
         <source>Destination folder : </source>
         <translation>Directorio de destino:</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="34"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="30"/>
         <source>Unpack</source>
         <translation>Desempaquetar</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="108"/>
         <source>Compresed library covers (*.clc)</source>
         <translation>Compresed library covers (*.clc)</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="22"/>
         <source>Package location : </source>
         <translation>Ubicación del paquete:</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="17"/>
         <source>Library Name : </source>
         <translation>Nombre de la biblioteca :</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="87"/>
         <source>Extract a catalog</source>
         <translation>Extraer un catálogo</translation>
     </message>
@@ -504,489 +646,667 @@
 <context>
     <name>ImportWidget</name>
     <message>
+        <location filename="import_widget.cpp" line="150"/>
         <source>stop</source>
         <translation>parar</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="334"/>
         <source>Importing comics</source>
         <translation>Importando cómics</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="335"/>
         <source>&lt;p&gt;YACReaderLibrary is now creating a new library.&lt;/p&gt;&lt;p&gt;Create a library could take several minutes. You can stop the process and update the library later for completing the task.&lt;/p&gt;</source>
         <translation>&lt;p&gt;YACReaderLibrary está creando una nueva biblioteca.&lt;/p&gt;&lt;p&gt;Crear una biblioteca puede llevar varios minutos. Puedes parar el proceso en cualquier momento y actualizar la biblioteca más tarde para completar el proceso.&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="190"/>
         <source>Some of the comics being added...</source>
         <translation>Algunos de los cómics que estan siendo añadidos....</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="346"/>
         <source>Updating the library</source>
         <translation>Actualizando la biblioteca</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="347"/>
         <source>&lt;p&gt;The current library is being updated. For faster updates, please, update your libraries frequently.&lt;/p&gt;&lt;p&gt;You can stop the process and continue updating this library later.&lt;/p&gt;</source>
         <translation>&lt;p&gt;La biblioteca actual está siendo actualizada. Para actualizaciones más rápidas, por favor, actualiza tus bibliotecas frecuentemente.&lt;/p&gt;&lt;p&gt;Puedes parar el proceso y continunar la actualización más tarde.&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="358"/>
         <source>Upgrading the library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="359"/>
         <source>&lt;p&gt;The current library is being upgraded, please wait.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="370"/>
+        <source>Scanning the library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="371"/>
+        <source>&lt;p&gt;Current library is being scanned for legacy XML metadata information.&lt;/p&gt;&lt;p&gt;This is only needed once, and only if the library was crated with YACReaderLibrary 9.8.2 or earlier.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LibraryWindow</name>
     <message>
+        <location filename="library_window.cpp" line="730"/>
         <source>Edit</source>
         <translation>Editar</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2083"/>
         <source>The selected folder doesn&apos;t contain any library.</source>
         <translation>La carpeta seleccionada no contiene ninguna biblioteca.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1269"/>
         <source>This library was created with a previous version of YACReaderLibrary. It needs to be updated. Update now?</source>
         <translation>Esta biblioteca fue creada con una versión anterior de YACReaderLibrary. Es necesario que se actualice. ¿Deseas hacerlo ahora?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1060"/>
         <source>Comic</source>
         <translation>Cómic</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2659"/>
         <source>Error opening the library</source>
         <translation>Error abriendo la biblioteca</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="585"/>
         <source>Show/Hide marks</source>
         <translation>Mostrar/Ocultar marcas</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1993"/>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found</source>
         <translation>YACReader no encontrado</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="648"/>
         <source>Show comics server options dialog</source>
         <translation></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="532"/>
         <source>Remove current library from your collection</source>
         <translation>Eliminar biblioteca de la colección</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="554"/>
         <source>Set comic as read</source>
         <translation>Marcar cómic como leído</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2139"/>
         <source>Remove and delete metadata</source>
         <translation>Eliminar y borrar metadatos</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Old library</source>
         <translation>Biblioteca antigua</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="742"/>
         <source>Update cover</source>
         <translation>Actualizar portada</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="685"/>
+        <location filename="library_window.cpp" line="1797"/>
         <source>Set as completed</source>
         <translation>Marcar como completo</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1027"/>
         <source>Library</source>
         <translation>Librería</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="526"/>
         <source>Rename current library</source>
         <translation>Renombrar la biblioteca seleccionada</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="593"/>
+        <location filename="library_window.cpp" line="594"/>
         <source>Fullscreen mode on/off</source>
         <translation>Modo a pantalla completa on/off</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1336"/>
         <source>This library was created with a newer version of YACReaderLibrary. Download the new version now?</source>
         <translation>Esta biblioteca fue creada con una versión más nueva de YACReaderLibrary. ¿Deseas descargar la nueva versión ahora?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="543"/>
         <source>Open current comic on YACReader</source>
         <translation>Abrir el cómic actual en YACReader</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="520"/>
         <source>Update current library</source>
         <translation>Actualizar la biblioteca seleccionada</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library &apos;%1&apos; is no longer available. Do you want to remove it?</source>
         <translation>La biblioteca &apos;%1&apos; no está disponible. ¿Deseas eliminarla?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="519"/>
         <source>Update library</source>
         <translation>Actualizar biblioteca</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="674"/>
+        <location filename="library_window.cpp" line="1787"/>
         <source>Open folder...</source>
         <translation>Abrir carpeta...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Do you want remove </source>
         <translation>¿Deseas eliminar la biblioteca  </translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="680"/>
+        <location filename="library_window.cpp" line="1794"/>
         <source>Set as uncompleted</source>
         <translation>Marcar como incompleto</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="718"/>
         <source>Reset comic rating</source>
         <translation>Reseteal cómic rating</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2654"/>
         <source>Error updating the library</source>
         <translation>Error actualizando la biblioteca</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1046"/>
         <source>Folder</source>
         <translation>Carpeta</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="628"/>
         <source>Expand all nodes</source>
         <translation>Expandir todos los nodos</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Library &apos;%1&apos; has been created with an older version of YACReaderLibrary. It must be created again. Do you want to create the library now?</source>
         <translation>La biblioteca &apos;%1&apos; ha sido creada con una versión más antigua de YACReaderLibrary y debe ser creada de nuevo. ¿Deseas crear la biblioteca ahora?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="507"/>
         <source>Pack covers</source>
         <translation>Empaquetar portadas</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="553"/>
+        <location filename="library_window.cpp" line="690"/>
+        <location filename="library_window.cpp" line="1800"/>
         <source>Set as read</source>
         <translation>Marcar como leído</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="748"/>
         <source>Delete selected comics</source>
         <translation>Borrar los cómics seleccionados</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="495"/>
+        <location filename="library_window.cpp" line="496"/>
         <source>Export comics info</source>
         <translation>Exportar información de los cómics</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="640"/>
         <source>Show options dialog</source>
         <translation>Mostrar opciones</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="484"/>
         <source>Create a new library</source>
         <translation>Crear una nueva biblioteca</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library not available</source>
         <translation>Biblioteca no disponible</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="501"/>
+        <location filename="library_window.cpp" line="502"/>
         <source>Import comics info</source>
         <translation>Importar información de cómics</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2417"/>
         <source>There was an issue trying to delete the selected comics. Please, check for write permissions in the selected files or containing folder.</source>
         <translation>Ha habido algún problema intentando borrar los cómics selecionados. Por favor, verifica los permisos de escritura en los arhicovs seleccionados o los directorios que los conienen.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="542"/>
         <source>Open current comic</source>
         <translation>Abrir cómic actual</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="188"/>
         <source>YACReader Library</source>
         <translation>YACReader Library</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2649"/>
         <source>Error creating the library</source>
         <translation>Errar creando la biblioteca</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="513"/>
         <source>Unpack covers</source>
         <translation>Desempaquetar portadas</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1269"/>
         <source>Update needed</source>
         <translation>Se necesita actualizar</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="490"/>
         <source>Open an existing library</source>
         <translation>Abrir una biblioteca  existente</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2805"/>
         <source>Library name already exists</source>
         <translation>Ya existe el nombre de la biblioteca</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2805"/>
         <source>There is another library with the name &apos;%1&apos;.</source>
         <translation>Hay otra biblioteca con el nombre &apos;%1&apos;.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1336"/>
         <source>Download new version</source>
         <translation>Descargar la nueva versión</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2694"/>
         <source>Delete comics</source>
         <translation>Borrar cómics</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="724"/>
         <source>Select all comics</source>
         <translation>Seleccionar todos los cómics</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="508"/>
         <source>Pack the covers of the selected library</source>
         <translation>Empaquetar las portadas de la biblioteca seleccionada</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="602"/>
         <source>Help, About YACReader</source>
         <translation>Ayuda, A cerca de... YACReader</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="560"/>
         <source>Set comic as unread</source>
         <translation>Marcar cómic como no leído</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="624"/>
         <source>Select root node</source>
         <translation>Seleccionar el nodo raíz</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="514"/>
         <source>Unpack a catalog</source>
         <translation>Desempaquetar un catálogo</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2694"/>
         <source>All the selected comics will be deleted from your disk. Are you sure?</source>
         <translation>Todos los cómics seleccionados serán borrados de tu disco. ¿Estás seguro?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="756"/>
         <source>Download tags from Comic Vine</source>
         <translation>Descargar etiquetas de Comic Vine</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="559"/>
+        <location filename="library_window.cpp" line="695"/>
+        <location filename="library_window.cpp" line="1803"/>
         <source>Set as unread</source>
         <translation>Marcar como no leído</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2083"/>
         <source>Library not found</source>
         <translation>Biblioteca no encontrada</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="525"/>
         <source>Rename library</source>
         <translation>Renombrar biblioteca</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="531"/>
         <source>Remove library</source>
         <translation>Eliminar biblioteca</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="712"/>
         <source>Open containing folder...</source>
         <translation>Abrir carpeta contenedora...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1636"/>
+        <location filename="library_window.cpp" line="2417"/>
         <source>Unable to delete</source>
         <translation>No se ha podido borrar</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source> library?</source>
         <translation>?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Are you sure?</source>
         <translation>¿Estás seguro?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="548"/>
         <source>Save selected covers to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="537"/>
+        <source>Rescan library for XML info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="538"/>
+        <source>Tries to find XML info embedded in comic files. You only need to do this if the library was created with 9.8.2 or earlier versions or if you are using third party software to embed XML info in the files.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="549"/>
         <source>Save covers of the selected comics as JPG files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="565"/>
+        <location filename="library_window.cpp" line="700"/>
+        <location filename="library_window.cpp" line="1806"/>
         <source>Set as manga</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="566"/>
         <source>Set issue as manga</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="571"/>
         <source>Set as normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="572"/>
         <source>Set issue as normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="586"/>
         <source>Show or hide read marks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="609"/>
+        <location filename="library_window.cpp" line="1574"/>
         <source>Add new folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="612"/>
         <source>Add new folder to the current library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="615"/>
+        <location filename="library_window.cpp" line="1610"/>
         <source>Delete folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="618"/>
         <source>Delete current folder from disk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="634"/>
         <source>Collapse all nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="655"/>
+        <location filename="library_window.cpp" line="656"/>
         <source>Change between comics views</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="705"/>
+        <location filename="library_window.cpp" line="1809"/>
         <source>Set as comic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="736"/>
         <source>Assign current order to comics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="760"/>
+        <source>Focus search line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="766"/>
+        <source>Focus comics view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="771"/>
         <source>Edit shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="777"/>
+        <source>&amp;Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="784"/>
+        <location filename="library_window.cpp" line="1790"/>
         <source>Update folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="787"/>
         <source>Update current folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="792"/>
         <source>Add new reading list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="795"/>
         <source>Add a new reading list to the current library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="798"/>
         <source>Remove reading list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="801"/>
         <source>Remove current reading list from the library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="804"/>
         <source>Add new label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="807"/>
         <source>Add a new label to this library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="810"/>
         <source>Rename selected list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="813"/>
         <source>Rename any selected labels or lists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="817"/>
         <source>Add to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="819"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="822"/>
         <source>Add selected comics to favorites list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1251"/>
         <source>Upgrade failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1251"/>
         <source>There were errors during library upgrade in: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1409"/>
+        <location filename="library_window.cpp" line="1445"/>
         <source>Copying comics...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1426"/>
+        <location filename="library_window.cpp" line="1464"/>
         <source>Moving comics...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1575"/>
         <source>Folder name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1604"/>
         <source>No folder selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1604"/>
         <source>Please, select a folder first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1608"/>
         <source>Error in path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1608"/>
         <source>There was an error accessing the folder&apos;s path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1610"/>
         <source>The selected folder and all its contents will be deleted from your disk. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1636"/>
         <source>There was an issue trying to delete the selected folders. Please, check for write permissions and be sure that any applications are using these folders or any of the contained files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1648"/>
         <source>Add new reading lists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1649"/>
+        <location filename="library_window.cpp" line="1698"/>
         <source>List name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1667"/>
         <source>Delete list/label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1667"/>
         <source>The selected item will be deleted, your comics or folders will NOT be deleted from your disk. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1697"/>
         <source>Rename list name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1916"/>
         <source>Save covers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.
 
 You probably only need one library in your top level comics folder, you can browse any subfolders using the folders section in the left sidebar.
@@ -995,26 +1315,32 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1993"/>
         <source>YACReader not found. YACReader should be installed in the same folder as YACReaderLibrary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found. There might be a problem with your YACReader installation.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2448"/>
         <source>Assign comics numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2449"/>
         <source>Assign numbers starting in:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Remove comics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Comics will only be deleted from the current label/list. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1022,6 +1348,7 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>LocalComicListModel</name>
     <message>
+        <location filename="comic_vine/model/local_comic_list_model.cpp" line="72"/>
         <source>file name</source>
         <translation>nombre de archivo</translation>
     </message>
@@ -1029,30 +1356,37 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>LogWindow</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="14"/>
         <source>Log window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="22"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="39"/>
         <source>&amp;Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="56"/>
         <source>C&amp;lear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="73"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="90"/>
         <source>Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="136"/>
         <source>&amp;Auto scroll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1060,18 +1394,22 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>NoLibrariesWidget</name>
     <message>
+        <location filename="no_libraries_widget.cpp" line="32"/>
         <source>create your first library</source>
         <translation>crea tu primera biblioteca</translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="26"/>
         <source>You don&apos;t have any libraries yet</source>
         <translation>Aún no tienes ninguna biblioteca</translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="28"/>
         <source>&lt;p&gt;You can create a library in any folder, YACReaderLibrary will import all comics and folders from this folder. If you have created any library in the past you can open them.&lt;/p&gt;&lt;p&gt;Don&apos;t forget that you can use YACReader as a stand alone application for reading the comics on your computer.&lt;/p&gt;</source>
         <translation>&lt;p&gt;Puedes crear una biblioteca en cualquier carpeta, YACReaderLibrary importará todos las carpetas y cómics de esa carpeta. Si has creado alguna biblioteca anteriormente, puedes abrirla sin volver a crearla.&lt;/p&gt;&lt;p&gt;No olvides que puedes usar YACReader como una aplicación independiente para leer los cómics en tu ordenador.&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="34"/>
         <source>add an existing one</source>
         <translation>añade una existente</translation>
     </message>
@@ -1079,70 +1417,87 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>OptionsDialog</name>
     <message>
+        <location filename="options_dialog.cpp" line="156"/>
         <source>Options</source>
         <translation>Opciones</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="47"/>
         <source>Tray icon settings (experimental)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="50"/>
         <source>Close to tray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="51"/>
         <source>Start into the system tray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="69"/>
         <source>Edit Comic Vine API key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="72"/>
         <source>Comic Vine API key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="78"/>
         <source>Enable background image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="80"/>
         <source>Opacity level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="85"/>
         <source>Blur level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="90"/>
         <source>Use selected comic cover as background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="92"/>
         <source>Restore defautls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="103"/>
         <source>Background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="106"/>
         <source>Display continue reading banner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="111"/>
         <source>Continue reading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="144"/>
         <source>Comic Flow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="146"/>
         <source>Grid view</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="148"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1150,142 +1505,178 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>PropertiesDialog</name>
     <message>
+        <location filename="properties_dialog.cpp" line="240"/>
         <source>Day:</source>
         <translation>Día:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="85"/>
         <source>Plot</source>
         <translation>Argumento</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="177"/>
         <source>Size:</source>
         <translation>Tamaño:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="248"/>
         <source>Year:</source>
         <translation>Año:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="207"/>
         <source>Inker(s):</source>
         <translation>Entintador(es):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="84"/>
         <source>Publishing</source>
         <translation>Publicación</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="256"/>
         <source>Publisher:</source>
         <translation>Editorial:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="82"/>
         <source>General info</source>
         <translation>Información general</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="258"/>
         <source>Color/BW:</source>
         <translation>Color/BN:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="501"/>
         <source>Edit selected comics information</source>
         <translation>Editar la información de los cómics seleccionados</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="200"/>
         <source>Penciller(s):</source>
         <translation>Dibujant(es):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="210"/>
         <source>Colorist(s):</source>
         <translation>Color:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="175"/>
         <source>Genre:</source>
         <translation>Género:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="158"/>
         <source>Issue number:</source>
         <translation>Número:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="244"/>
         <source>Month:</source>
         <translation>Mes:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="275"/>
         <source>Notes:</source>
         <translation>Notas:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="273"/>
         <source>Synopsis:</source>
         <translation>Sinopsis:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="143"/>
         <source>Title:</source>
         <translation>Título:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Not found</source>
         <translation>No encontrado</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="274"/>
         <source>Characters:</source>
         <translation>Personajes:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="83"/>
         <source>Authors</source>
         <translation>Autores</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="259"/>
         <source>Age rating:</source>
         <translation>Casificación edades:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="173"/>
         <source>Story arc:</source>
         <translation>Arco argumental:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="197"/>
         <source>Writer(s):</source>
         <translation>Guionista(s):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Comic not found. You should update your library.</source>
         <translation>Cómic no encontrado. Deberias actualizar tu biblioteca.</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="467"/>
         <source>Edit comic information</source>
         <translation>Editar la información del cócmic</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="94"/>
         <source>Cover page</source>
         <translation>Página de portada</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="220"/>
         <source>Cover Artist(s):</source>
         <translation>Artista(s) portada:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="369"/>
         <source>Comic Vine link: &lt;a style=&apos;color: #FFCB00; text-decoration:none; font-weight:bold;&apos; href=&quot;http://www.comicvine.com/comic/4000-%1/&quot;&gt; view &lt;/a&gt;</source>
         <translation>Comic Vine link: &lt;a style=&apos;color: #FFCB00; text-decoration:none; font-weight:bold;&apos; href=&quot;http://www.comicvine.com/comic/4000-%1/&quot;&gt; ver &lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="160"/>
         <source>Volume:</source>
         <translation>Volumen:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="257"/>
         <source>Format:</source>
         <translation>Formato:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="217"/>
         <source>Letterer(s):</source>
         <translation>Rotulista(s):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="151"/>
+        <location filename="properties_dialog.cpp" line="168"/>
         <source>of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="164"/>
         <source>Arc number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="260"/>
         <source>Manga:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1293,34 +1684,42 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>7z lib not found</source>
         <translation>7z lib no encontrado</translation>
     </message>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>unable to load 7z lib from ./utils</source>
         <translation>imposible cargar 7z lib de ./utils</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41"/>
         <source>Trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45"/>
         <source>Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51"/>
         <source>Fatal</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1328,14 +1727,17 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>QsLogging::LogWindowModel</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="141"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="143"/>
         <source>Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="145"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1343,18 +1745,22 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>QsLogging::Window</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="236"/>
         <source>Save log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="237"/>
         <source>Log file (*.log)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1362,18 +1768,22 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>RenameLibraryDialog</name>
     <message>
+        <location filename="rename_library_dialog.cpp" line="51"/>
         <source>Rename current library</source>
         <translation>Renombrar la biblioteca seleccionada</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="24"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="20"/>
         <source>Rename</source>
         <translation>Renombrar</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="15"/>
         <source>New Library Name : </source>
         <translation>Nuevo nombre de la biblioteca :</translation>
     </message>
@@ -1381,14 +1791,18 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>ScraperResultsPaginator</name>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="54"/>
         <source>Number of %1 found : %2</source>
         <translation>Número de %1 encontrados : %2</translation>
     </message>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="32"/>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="55"/>
         <source>page %1 of %2</source>
         <translation>página %1 de %2</translation>
     </message>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="30"/>
         <source>Number of volumes found : %1</source>
         <translation>Número de volúmenes encontrados : %1</translation>
     </message>
@@ -1396,10 +1810,12 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>SearchSingleComic</name>
     <message>
+        <location filename="comic_vine/search_single_comic.cpp" line="14"/>
         <source>Please provide some additional information.</source>
         <translation>Por favor, proporciona alguna información adicional.</translation>
     </message>
     <message>
+        <location filename="comic_vine/search_single_comic.cpp" line="19"/>
         <source>Series:</source>
         <translation>Series:</translation>
     </message>
@@ -1407,10 +1823,12 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>SearchVolume</name>
     <message>
+        <location filename="comic_vine/search_volume.cpp" line="11"/>
         <source>Please provide some additional information.</source>
         <translation>Por favor, proporciona alguna informacion adicional.</translation>
     </message>
     <message>
+        <location filename="comic_vine/search_volume.cpp" line="14"/>
         <source>Series:</source>
         <translation>Series:</translation>
     </message>
@@ -1418,22 +1836,27 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>SelectComic</name>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="95"/>
         <source>loading description</source>
         <translation>cargando descripción</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="38"/>
         <source>comics</source>
         <translation>cómics</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="94"/>
         <source>loading cover</source>
         <translation>cargando portada</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="18"/>
         <source>Please, select the right comic info.</source>
         <translation>Por favor, selecciona la información correcta.</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="135"/>
         <source>description unavailable</source>
         <translation>descripción no disponible</translation>
     </message>
@@ -1441,22 +1864,37 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>SelectVolume</name>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="145"/>
         <source>loading description</source>
         <translation>cargando descripción</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="35"/>
         <source>Please, select the right series for your comic.</source>
         <translation>Por favor, seleciona la serie correcta para tu cómic.</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="56"/>
+        <source>Filter:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="138"/>
+        <source>Nothing found, clear the filter if any.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="144"/>
         <source>loading cover</source>
         <translation>cargando portada</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="68"/>
         <source>volumes</source>
         <translation>volúmenes</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="185"/>
         <source>description unavailable</source>
         <translation>descripción no disponible</translation>
     </message>
@@ -1464,14 +1902,17 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>SeriesQuestion</name>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="15"/>
         <source>no</source>
         <translation>no</translation>
     </message>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="14"/>
         <source>yes</source>
         <translation>sí</translation>
     </message>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="12"/>
         <source>You are trying to get information for various comics at once, are they part of the same series?</source>
         <translation>Estás intentando obtener información de varios cómics a la vez, ¿son parte de la misma serie?</translation>
     </message>
@@ -1479,39 +1920,48 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>ServerConfigDialog</name>
     <message>
+        <location filename="server_config_dialog.cpp" line="115"/>
         <source>Port</source>
         <translation>Puerto</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="147"/>
         <source>enable the server</source>
         <translation>activar el servidor</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="86"/>
         <source>set port</source>
         <translation>fijar puerto</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="92"/>
         <source>Server connectivity information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="96"/>
         <source>Scan it!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="102"/>
         <source>YACReader is available for iOS devices. &lt;a href=&apos;http://ios.yacreader.com&apos; style=&apos;color:rgb(193, 148, 65)&apos;&gt; Discover it! &lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="111"/>
         <source>Choose an IP address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="152"/>
         <source>display less information about folders in the browser
 to improve the performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="268"/>
         <source>Could not load libqrencode.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1519,22 +1969,27 @@ to improve the performance</source>
 <context>
     <name>SortVolumeComics</name>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="87"/>
         <source>remove selected comics</source>
         <translation>eliminar cómics seleccionados</translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="21"/>
         <source>sort comics to match comic information</source>
         <translation>ordena los cómics para coincidir con la información</translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="88"/>
         <source>restore all removed comics</source>
         <translation>restaurar todos los cómics eliminados</translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="58"/>
         <source>issues</source>
         <translation>números</translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="18"/>
         <source>Please, sort the list of comics on the left until it matches the comics&apos; information.</source>
         <translation>Por favor, ordena la lista de cómics en la izquiera hasta que coincida con la información adecuada.</translation>
     </message>
@@ -1542,6 +1997,7 @@ to improve the performance</source>
 <context>
     <name>TitleHeader</name>
     <message>
+        <location filename="comic_vine/title_header.cpp" line="30"/>
         <source>SEARCH</source>
         <translation>BUSCAR</translation>
     </message>
@@ -1549,14 +2005,17 @@ to improve the performance</source>
 <context>
     <name>UpdateLibraryDialog</name>
     <message>
+        <location filename="create_library_dialog.cpp" line="180"/>
         <source>Update library</source>
         <translation>Actualizar biblioteca</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="161"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="155"/>
         <source>Updating....</source>
         <translation>Actualizado...</translation>
     </message>
@@ -1564,6 +2023,7 @@ to improve the performance</source>
 <context>
     <name>VolumeComicsModel</name>
     <message>
+        <location filename="comic_vine/model/volume_comics_model.cpp" line="120"/>
         <source>title</source>
         <translation>título</translation>
     </message>
@@ -1571,14 +2031,17 @@ to improve the performance</source>
 <context>
     <name>VolumesModel</name>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="118"/>
         <source>year</source>
         <translation>año</translation>
     </message>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="120"/>
         <source>issues</source>
         <translation>números</translation>
     </message>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="122"/>
         <source>publisher</source>
         <translation>editor</translation>
     </message>
@@ -1586,18 +2049,17 @@ to improve the performance</source>
 <context>
     <name>YACReader::TrayIconController</name>
     <message>
+        <location filename="trayicon_controller.cpp" line="52"/>
         <source>&amp;Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Quit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="trayicon_controller.cpp" line="79"/>
         <source>Systray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="trayicon_controller.cpp" line="80"/>
         <source>YACReaderLibrary will keep running in the system tray. To terminate the program, choose &lt;b&gt;Quit&lt;/b&gt; in the context menu of the system tray icon.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1605,6 +2067,7 @@ to improve the performance</source>
 <context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1612,10 +2075,12 @@ to improve the performance</source>
 <context>
     <name>YACReaderDeletingProgress</name>
     <message>
+        <location filename="../custom_widgets/yacreader_deleting_progress.cpp" line="35"/>
         <source>cancel</source>
         <translation>cancelar</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_deleting_progress.cpp" line="20"/>
         <source>Please wait, deleting in progress...</source>
         <translation>Borrando, por favor espera...</translation>
     </message>
@@ -1623,10 +2088,13 @@ to improve the performance</source>
 <context>
     <name>YACReaderFieldEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11"/>
         <source>Restore to default</source>
         <translation>Restaurar valor por defecto</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28"/>
         <source>Click to overwrite</source>
         <translation>Click para sobreescribir</translation>
     </message>
@@ -1634,10 +2102,15 @@ to improve the performance</source>
 <context>
     <name>YACReaderFieldPlainTextEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10"/>
         <source>Restore to default</source>
         <translation>Restaurar valor por defecto</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50"/>
         <source>Click to overwrite</source>
         <translation>Click para sobreescribir</translation>
     </message>
@@ -1645,18 +2118,22 @@ to improve the performance</source>
 <context>
     <name>YACReaderFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="15"/>
         <source>CoverFlow look</source>
         <translation>Tipo CoverFlow</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="13"/>
         <source>How to show covers:</source>
         <translation>Cómo mostrar las portadas:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="16"/>
         <source>Stripe look</source>
         <translation>Tipo tira</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="17"/>
         <source>Overlapped Stripe look</source>
         <translation>Tipo tira solapada</translation>
     </message>
@@ -1664,94 +2141,117 @@ to improve the performance</source>
 <context>
     <name>YACReaderGLFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="112"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="142"/>
         <source>Light</source>
         <translation>Luz</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="76"/>
         <source>Show advanced settings</source>
         <translation>Opciones avanzadas</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="32"/>
         <source>Roulette look</source>
         <translation>Tipo ruleta</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="130"/>
         <source>Cover Angle</source>
         <translation>Ángulo de las portadas </translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="23"/>
         <source>Stripe look</source>
         <translation>Tipo tira</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="94"/>
         <source>Position</source>
         <translation>Posición</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="124"/>
         <source>Z offset</source>
         <translation>Desplazamiento en Z</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="118"/>
         <source>Y offset</source>
         <translation>Desplazamiento en Y</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="106"/>
         <source>Central gap</source>
         <translation>Hueco central</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="18"/>
         <source>Presets:</source>
         <translation>Predeterminados:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="26"/>
         <source>Overlapped Stripe look</source>
         <translation>Tipo tira solapada</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="29"/>
         <source>Modern look</source>
         <translation>Tipo moderno</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="88"/>
         <source>View angle</source>
         <translation>Ángulo de vista</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="148"/>
         <source>Max angle</source>
         <translation>Ángulo máximo</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="85"/>
         <source>Custom:</source>
         <translation>Personalizado:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="20"/>
         <source>Classic look</source>
         <translation>Tipo clásico</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="100"/>
         <source>Cover gap</source>
         <translation>Hueco entre portadas</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="182"/>
         <source>High Performance</source>
         <translation>Alto rendimiento</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="201"/>
         <source>Performance:</source>
         <translation>Rendimiento:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="193"/>
         <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
         <translation>Usar VSync (mejora la calidad de imagen en pantalla completa, peor rendimiento) </translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="136"/>
         <source>Visibility</source>
         <translation>Visibilidad</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="180"/>
         <source>Low Performance</source>
         <translation>Rendimiento bajo</translation>
     </message>
@@ -1759,10 +2259,12 @@ to improve the performance</source>
 <context>
     <name>YACReaderNavigationController</name>
     <message>
+        <location filename="yacreader_navigation_controller.cpp" line="123"/>
         <source>No favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="yacreader_navigation_controller.cpp" line="127"/>
         <source>You are not reading anything yet, come on!!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1770,22 +2272,27 @@ to improve the performance</source>
 <context>
     <name>YACReaderOptionsDialog</name>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28"/>
         <source>Save</source>
         <translation>Guardar</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="46"/>
         <source>Use hardware acceleration (restart needed)</source>
         <translation>Usar aceleración por hardware (necesario reiniciar)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="29"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="34"/>
         <source>Edit shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="37"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1793,6 +2300,7 @@ to improve the performance</source>
 <context>
     <name>YACReaderSearchLineEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_search_line_edit.cpp" line="68"/>
         <source>type to search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1800,26 +2308,32 @@ to improve the performance</source>
 <context>
     <name>YACReaderSideBar</name>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="31"/>
         <source>LIBRARIES</source>
         <translation>BIBLIOTECAS</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="32"/>
         <source>FOLDERS</source>
         <translation>CARPETAS</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="27"/>
         <source>Libraries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="28"/>
         <source>Folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="29"/>
         <source>Reading Lists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="33"/>
         <source>READING LISTS</source>
         <translation type="unfinished"></translation>
     </message>

--- a/YACReaderLibrary/yacreaderlibrary_fr.ts
+++ b/YACReaderLibrary/yacreaderlibrary_fr.ts
@@ -4,6 +4,7 @@
 <context>
     <name>ActionsShortcutsModel</name>
     <message>
+        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="73"/>
         <source>None</source>
         <translation>Rien</translation>
     </message>
@@ -11,66 +12,82 @@
 <context>
     <name>AddLabelDialog</name>
     <message>
+        <location filename="add_label_dialog.cpp" line="14"/>
         <source>red</source>
         <translation>rouge</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="19"/>
         <source>blue</source>
         <translation>bleu</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="25"/>
         <source>dark</source>
         <translation>foncé</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="18"/>
         <source>cyan</source>
         <translation>cyan</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="22"/>
         <source>pink</source>
         <translation>rose</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="17"/>
         <source>green</source>
         <translation>vert</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="24"/>
         <source>light</source>
         <translation>clair</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="23"/>
         <source>white</source>
         <translation>blanc</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="11"/>
         <source>Choose a color:</source>
         <translation>Choisissez une couleur:</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="36"/>
         <source>accept</source>
         <translation>accepter</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="37"/>
         <source>cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="15"/>
         <source>orange</source>
         <translation>orange</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="21"/>
         <source>purple</source>
         <translation>violet</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="20"/>
         <source>violet</source>
         <translation>violet</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="16"/>
         <source>yellow</source>
         <translation>jaune</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="8"/>
         <source>Label name:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -78,22 +95,27 @@
 <context>
     <name>AddLibraryDialog</name>
     <message>
+        <location filename="add_library_dialog.cpp" line="26"/>
         <source>Add</source>
         <translation>Ajouter</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="66"/>
         <source>Add an existing library</source>
         <translation>Ajouter une librairie existante</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="30"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="16"/>
         <source>Comics folder : </source>
         <translation>Dossier des bandes dessinées : </translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="21"/>
         <source>Library name : </source>
         <translation>Nom de la librairie :</translation>
     </message>
@@ -101,18 +123,22 @@
 <context>
     <name>ApiKeyDialog</name>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="28"/>
         <source>Accept</source>
         <translation>Accepter</translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="32"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="21"/>
         <source>Before you can connect to Comic Vine, you need your own API key. Please, get one free &lt;a href=&quot;http://www.comicvine.com/api/&quot;&gt;here&lt;/a&gt;</source>
         <translation>Avant de pouvoir vous connecter à Comic Vine, vous avez besoin de votre propre clé API. Veuillez en obtenir une gratuitement ici: &lt;a href=&quot;http://www.comicvine.com/api/&quot;&gt;&lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="25"/>
         <source>Paste here your Comic Vine API key</source>
         <translation>Collez ici votre clé API Comic Vine</translation>
     </message>
@@ -120,6 +146,7 @@
 <context>
     <name>ClassicComicsView</name>
     <message>
+        <location filename="classic_comics_view.cpp" line="90"/>
         <source>Hide comic flow</source>
         <translation>Cacher le flux de bande dessinée</translation>
     </message>
@@ -127,46 +154,57 @@
 <context>
     <name>ComicInfoView</name>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
         <source>b/w</source>
         <translation>noir et blanc</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="419"/>
         <source>cover artist</source>
         <translation>couverture</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
         <source>color</source>
         <translation>couleur</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="353"/>
         <source>inker</source>
         <translation>encre</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="331"/>
         <source>penciller</source>
         <translation>dessin</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="375"/>
         <source>colorist</source>
         <translation>couleur</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="309"/>
         <source>writer</source>
         <translation>scénario</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="502"/>
         <source>Characters</source>
         <translation>Personnages</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="279"/>
         <source>Authors</source>
         <translation>Auteurs</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="434"/>
         <source>Publisher</source>
         <translation>Editeur</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="397"/>
         <source>letterer</source>
         <translation>lettreur</translation>
     </message>
@@ -174,38 +212,52 @@
 <context>
     <name>ComicModel</name>
     <message>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>no</source>
         <translation>non</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>yes</source>
         <translation>oui</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="351"/>
         <source>Read</source>
         <translation>Lu</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="349"/>
         <source>Size</source>
         <translation>Taille</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="347"/>
         <source>Pages</source>
         <translation>Pages</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="343"/>
         <source>Title</source>
         <translation>Titre</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="353"/>
         <source>Current Page</source>
         <translation>Page en cours</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="345"/>
         <source>File Name</source>
         <translation>Nom du fichier</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="355"/>
+        <source>Publication Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="357"/>
         <source>Rating</source>
         <translation>Note</translation>
     </message>
@@ -213,50 +265,67 @@
 <context>
     <name>ComicVineDialog</name>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="58"/>
         <source>back</source>
         <translation>retour</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="59"/>
         <source>next</source>
         <translation>suivant</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="57"/>
         <source>skip</source>
         <translation>passer</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="61"/>
         <source>close</source>
         <translation>fermer</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="467"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="503"/>
         <source>Retrieving tags for : %1</source>
         <translation>Retrouver les infomartions de: %1</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="814"/>
         <source>Looking for comic...</source>
         <translation>Vous cherchez une bande dessinée ...</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="60"/>
         <source>search</source>
         <translation>chercher</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="141"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="735"/>
         <source>comic %1 of %2 - %3</source>
         <translation>bande dessinée %1 sur %2 - %3</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="262"/>
         <source>%1 comics selected</source>
         <translation>%1 bande(s) dessinnée(s) sélectionnée(s)</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="295"/>
         <source>Error connecting to ComicVine</source>
         <translation>Erreur de connexion à Comic Vine</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="143"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="257"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="773"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="807"/>
         <source>Looking for volume...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="788"/>
         <source>Retrieving volume info...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -264,34 +333,42 @@
 <context>
     <name>CreateLibraryDialog</name>
     <message>
+        <location filename="create_library_dialog.cpp" line="75"/>
         <source>Create new library</source>
         <translation>Créer une nouvelle librairie</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="31"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="27"/>
         <source>Create</source>
         <translation>Créer</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="53"/>
         <source>Create a library could take several minutes. You can stop the process and update the library later for completing the task.</source>
         <translation>La création d&apos;une librairie peut prendre quelques minutes. Vous pouvez arrêter le processus et continuer plus tard.</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="95"/>
         <source>The selected path does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation>Le chemin sélectionné n&apos;existe pas ou contient un chemin invalide. Assurez-vous d&apos;avoir les droits d&apos;accès à ce dossier</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="17"/>
         <source>Comics folder : </source>
         <translation>Dossier des bandes dessinées :</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="22"/>
         <source>Library Name : </source>
         <translation>Nom de la librairie :</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="95"/>
         <source>Path not found</source>
         <translation>Chemin introuvable</translation>
     </message>
@@ -299,22 +376,27 @@
 <context>
     <name>EditShortcutsDialog</name>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="21"/>
         <source>Restore defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="22"/>
         <source>To change a shortcut, double click in the key combination and type the new keys.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="69"/>
         <source>Shortcuts settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>Shortcut in use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>The shortcut &quot;%1&quot; is already assigned to other function</source>
         <translation type="unfinished"></translation>
     </message>
@@ -322,14 +404,18 @@
 <context>
     <name>EmptyFolderWidget</name>
     <message>
+        <location filename="empty_folder_widget.cpp" line="75"/>
+        <location filename="empty_folder_widget.cpp" line="140"/>
         <source>Subfolders in this folder</source>
         <translation>Sous-dossiers dans ce dossier</translation>
     </message>
     <message>
+        <location filename="empty_folder_widget.cpp" line="138"/>
         <source>Drag and drop folders and comics here</source>
         <translation>Glissez et déposez les dossiers et les bandes dessinées ici</translation>
     </message>
     <message>
+        <location filename="empty_folder_widget.cpp" line="138"/>
         <source>Empty folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -337,6 +423,7 @@
 <context>
     <name>EmptyLabelWidget</name>
     <message>
+        <location filename="empty_label_widget.cpp" line="11"/>
         <source>This label doesn&apos;t contain comics yet</source>
         <translation>Ce dossier ne contient pas encore de bandes dessinées</translation>
     </message>
@@ -344,6 +431,7 @@
 <context>
     <name>EmptyReadingListWidget</name>
     <message>
+        <location filename="empty_reading_list_widget.cpp" line="8"/>
         <source>This reading list does not contain any comics yet</source>
         <translation>Cette liste de lecture ne contient aucune bande dessinée</translation>
     </message>
@@ -351,30 +439,37 @@
 <context>
     <name>ExportComicsInfoDialog</name>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="14"/>
         <source>Output file : </source>
         <translation>Fichier de sortie :</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="66"/>
         <source>Destination database name</source>
         <translation>Nom de la base de données de destination</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="22"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="18"/>
         <source>Create</source>
         <translation>Créer</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="81"/>
         <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation>Le chemin sélectionné pour le fichier n&apos;existe pas ou contient un chemin invalide. Assurez-vous d&apos;avoir les droits d&apos;accès à ce dossier</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="57"/>
         <source>Export comics info</source>
         <translation>Exporter les infos des bandes dessinées</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="81"/>
         <source>Problem found while writing</source>
         <translation>Problème durant l&apos;écriture</translation>
     </message>
@@ -382,30 +477,37 @@
 <context>
     <name>ExportLibraryDialog</name>
     <message>
+        <location filename="export_library_dialog.cpp" line="19"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="15"/>
         <source>Create</source>
         <translation>Créer</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="71"/>
         <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation>Le chemin sélectionné pour le fichier n&apos;existe pas ou contient un chemin invalide. Assurez-vous d&apos;avoir les droits d&apos;accès à ce dossier</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="11"/>
         <source>Output folder : </source>
         <translation>Dossier de sortie :</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="71"/>
         <source>Problem found while writing</source>
         <translation>Problème durant l&apos;écriture</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="60"/>
         <source>Create covers package</source>
         <translation>Créer un pack de couvertures</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="76"/>
         <source>Destination directory</source>
         <translation>Répertoire de destination</translation>
     </message>
@@ -413,25 +515,46 @@
 <context>
     <name>FileComic</name>
     <message>
+        <location filename="../common/comic.cpp" line="562"/>
         <source>7z not found</source>
         <translation>7z introuvable</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="454"/>
         <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="461"/>
         <source>Unknown error opening the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="568"/>
         <source>Format not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FolderContentView</name>
+    <message>
+        <location filename="qml/FolderContentView.qml" line="238"/>
+        <source>Continue Reading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FolderContentView6</name>
+    <message>
+        <location filename="qml/FolderContentView6.qml" line="240"/>
+        <source>Continue Reading...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>GridComicsView</name>
     <message>
+        <location filename="grid_comics_view.cpp" line="147"/>
         <source>Show info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -439,10 +562,17 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Aide</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
+        <source>System info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation>A propos</translation>
     </message>
@@ -450,22 +580,27 @@
 <context>
     <name>ImportComicsInfoDialog</name>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="24"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="20"/>
         <source>Import</source>
         <translation>Importer</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="16"/>
         <source>Info database location : </source>
         <translation>Emplacement des infos:</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="14"/>
         <source>Import comics info</source>
         <translation>Importer les infos des bandes dessinées</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="74"/>
         <source>Comics info file (*.ydb)</source>
         <translation>Fichier infos BD (*.ydb)</translation>
     </message>
@@ -473,30 +608,37 @@
 <context>
     <name>ImportLibraryDialog</name>
     <message>
+        <location filename="import_library_dialog.cpp" line="26"/>
         <source>Destination folder : </source>
         <translation>Dossier de destination :</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="34"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="30"/>
         <source>Unpack</source>
         <translation>Désarchiver</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="108"/>
         <source>Compresed library covers (*.clc)</source>
         <translation>Compresed library covers (*.clc)</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="22"/>
         <source>Package location : </source>
         <translation>Emplacement :</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="17"/>
         <source>Library Name : </source>
         <translation>Nom de la librairie :</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="87"/>
         <source>Extract a catalog</source>
         <translation>Extraire un catalogue</translation>
     </message>
@@ -504,193 +646,256 @@
 <context>
     <name>ImportWidget</name>
     <message>
+        <location filename="import_widget.cpp" line="150"/>
         <source>stop</source>
         <translation>Stop</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="334"/>
         <source>Importing comics</source>
         <translation>Importation de bande dessinée</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="335"/>
         <source>&lt;p&gt;YACReaderLibrary is now creating a new library.&lt;/p&gt;&lt;p&gt;Create a library could take several minutes. You can stop the process and update the library later for completing the task.&lt;/p&gt;</source>
         <translation>&lt;p&gt;YACReaderLibrary est en train de créer une nouvelle librairie.&lt;/p&gt;&lt;p&gt;La création d&apos;une librairie peut prendre quelques minutes. Vous pouvez arrêter le processus et poursuivre plus tard.&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="190"/>
         <source>Some of the comics being added...</source>
         <translation>Ajout de bande dessinée...</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="346"/>
         <source>Updating the library</source>
         <translation>Mise à jour de la librairie</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="347"/>
         <source>&lt;p&gt;The current library is being updated. For faster updates, please, update your libraries frequently.&lt;/p&gt;&lt;p&gt;You can stop the process and continue updating this library later.&lt;/p&gt;</source>
         <translation>&lt;p&gt;Mise à jour de la librairie. Pour plus de rapidité lors de la mise à jour, veuillez effectuer cette dernière régulièrement.&lt;/p&gt;&lt;p&gt;Vous pouvez arrêter le processus et poursuivre plus tard.&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="358"/>
         <source>Upgrading the library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="359"/>
         <source>&lt;p&gt;The current library is being upgraded, please wait.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="370"/>
+        <source>Scanning the library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="371"/>
+        <source>&lt;p&gt;Current library is being scanned for legacy XML metadata information.&lt;/p&gt;&lt;p&gt;This is only needed once, and only if the library was crated with YACReaderLibrary 9.8.2 or earlier.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LibraryWindow</name>
     <message>
+        <location filename="library_window.cpp" line="730"/>
         <source>Edit</source>
         <translation>Editer</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2083"/>
         <source>The selected folder doesn&apos;t contain any library.</source>
         <translation>Le dossier sélectionné ne contient aucune librairie.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1269"/>
         <source>This library was created with a previous version of YACReaderLibrary. It needs to be updated. Update now?</source>
         <translation>Cette librairie a été créée avec une ancienne version de YACReaderLibrary. Mise à jour necessaire. Mettre à jour?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1060"/>
         <source>Comic</source>
         <translation>Bande dessinée</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="787"/>
         <source>Update current folder</source>
         <translation>Mettre à jour ce dossier</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2659"/>
         <source>Error opening the library</source>
         <translation>Erreur lors de l&apos;ouverture de la librairie</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="585"/>
         <source>Show/Hide marks</source>
         <translation>Afficher/Cacher les marqueurs</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="648"/>
         <source>Show comics server options dialog</source>
         <translation>Ouvrir la boite de dialogue du serveur</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="532"/>
         <source>Remove current library from your collection</source>
         <translation>Enlever cette librairie de votre collection</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="554"/>
         <source>Set comic as read</source>
         <translation>Marquer cette bande dessinée comme lu</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="822"/>
         <source>Add selected comics to favorites list</source>
         <translation>Ajouter la bande dessinée sélectionnée à la liste des favoris</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2139"/>
         <source>Remove and delete metadata</source>
         <translation>Supprimer les métadata</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Old library</source>
         <translation>Ancienne librairie</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="742"/>
         <source>Update cover</source>
         <translation>Mise à jour des couvertures</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="685"/>
+        <location filename="library_window.cpp" line="1797"/>
         <source>Set as completed</source>
         <translation>Marquer comme complet</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1027"/>
         <source>Library</source>
         <translation>Librairie</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="526"/>
         <source>Rename current library</source>
         <translation>Renommer la librairie actuelle</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="593"/>
+        <location filename="library_window.cpp" line="594"/>
         <source>Fullscreen mode on/off</source>
         <translation>Mode plein écran activé/désactivé</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1336"/>
         <source>This library was created with a newer version of YACReaderLibrary. Download the new version now?</source>
         <translation>Cette librairie a été créée avec une version plus récente de YACReaderLibrary. Télécharger la nouvelle version?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1426"/>
+        <location filename="library_window.cpp" line="1464"/>
         <source>Moving comics...</source>
         <translation>Déplacer la bande dessinée...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="543"/>
         <source>Open current comic on YACReader</source>
         <translation>Ouvrir cette bande dessinée dans YACReader</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="520"/>
         <source>Update current library</source>
         <translation>Mettre à jour la librairie actuelle</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1409"/>
+        <location filename="library_window.cpp" line="1445"/>
         <source>Copying comics...</source>
         <translation>Copier la bande dessinée...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library &apos;%1&apos; is no longer available. Do you want to remove it?</source>
         <translation>La librarie &apos;%1&apos; n&apos;est plus disponible. Voulez-vous la supprimer?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="519"/>
         <source>Update library</source>
         <translation>Mettre la librairie à jour</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="674"/>
+        <location filename="library_window.cpp" line="1787"/>
         <source>Open folder...</source>
         <translation>Ouvrir le dossier...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Do you want remove </source>
         <translation>Voulez-vous supprimer</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="680"/>
+        <location filename="library_window.cpp" line="1794"/>
         <source>Set as uncompleted</source>
         <translation>Marquer comme incomplet</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="718"/>
         <source>Reset comic rating</source>
         <translation>Supprimer la note d&apos;évaluation</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2654"/>
         <source>Error updating the library</source>
         <translation>Erreur lors de la mise à jour de la librairie</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1046"/>
         <source>Folder</source>
         <translation>Dossier</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1667"/>
         <source>The selected item will be deleted, your comics or folders will NOT be deleted from your disk. Are you sure?</source>
         <translation>L&apos;élément sélectionné sera supprimé, vos bandes dessinées ou dossiers ne seront pas supprimés de votre disque. Êtes-vous sûr?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="628"/>
         <source>Expand all nodes</source>
         <translation>Afficher tous les noeuds</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="817"/>
         <source>Add to...</source>
         <translation>Ajouter à...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Library &apos;%1&apos; has been created with an older version of YACReaderLibrary. It must be created again. Do you want to create the library now?</source>
         <translation>La librarie &apos;%1&apos; a été créée avec une ancienne version de YACReaderLibrary. Elle doit être re-créée. Voulez-vous créer la librairie?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="507"/>
         <source>Pack covers</source>
         <translation>Archiver les couvertures</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="801"/>
         <source>Remove current reading list from the library</source>
         <translation>Supprimer la liste de lecture actuelle de la bibliothèque</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1648"/>
         <source>Add new reading lists</source>
         <translation>Ajouter de nouvelles listes de lecture</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.
 
 You probably only need one library in your top level comics folder, you can browse any subfolders using the folders section in the left sidebar.
@@ -703,322 +908,443 @@ Vous n&apos;avez probablement besoin que d&apos;une bibliothèque dans votre dos
 YACReaderLibrary ne vous empêchera pas de créer plus de bibliothèques, mais vous devriez garder le nombre de bibliothèques bas.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="553"/>
+        <location filename="library_window.cpp" line="690"/>
+        <location filename="library_window.cpp" line="1800"/>
         <source>Set as read</source>
         <translation>Marquer comme lu</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="748"/>
         <source>Delete selected comics</source>
         <translation>Supprimer la bande dessinée sélectionnée</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="495"/>
+        <location filename="library_window.cpp" line="496"/>
         <source>Export comics info</source>
         <translation>Exporter les infos des bandes dessinées</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="640"/>
         <source>Show options dialog</source>
         <translation>Ouvrir la boite de dialogue</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="484"/>
         <source>Create a new library</source>
         <translation>Créer une nouvelle librairie</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library not available</source>
         <translation>Librairie non disponible</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="501"/>
+        <location filename="library_window.cpp" line="502"/>
         <source>Import comics info</source>
         <translation>Importer les infos des bandes dessinées</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="792"/>
         <source>Add new reading list</source>
         <translation>Ajouter une nouvelle liste de lecture</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="548"/>
         <source>Save selected covers to...</source>
         <translation>Exporter la couverture vers...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="542"/>
         <source>Open current comic</source>
         <translation>Ouvrir cette bande dessinée</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="188"/>
         <source>YACReader Library</source>
         <translation>Librairie de YACReader</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="795"/>
         <source>Add a new reading list to the current library</source>
         <translation>Ajouter une nouvelle liste de lecture à la bibliothèque actuelle</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2649"/>
         <source>Error creating the library</source>
         <translation>Erreur lors de la création de la librairie</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="784"/>
+        <location filename="library_window.cpp" line="1790"/>
         <source>Update folder</source>
         <translation>Mettre à jour le dossier</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="513"/>
         <source>Unpack covers</source>
         <translation>Désarchiver les couvertures</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1269"/>
         <source>Update needed</source>
         <translation>Mise à jour requise</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="490"/>
         <source>Open an existing library</source>
         <translation>Ouvrir une librairie existante</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="586"/>
         <source>Show or hide read marks</source>
         <translation>Afficher ou masquer les marques de lecture</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2805"/>
         <source>Library name already exists</source>
         <translation>Le nom de la librairie existe déjà</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2805"/>
         <source>There is another library with the name &apos;%1&apos;.</source>
         <translation>Une autre librairie a le nom &apos;%1&apos;.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="798"/>
         <source>Remove reading list</source>
         <translation>Supprimer la liste de lecture</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1336"/>
         <source>Download new version</source>
         <translation>Téléchrger la nouvelle version</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2694"/>
         <source>Delete comics</source>
         <translation>Supprimer les comics</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="724"/>
         <source>Select all comics</source>
         <translation>Sélectionner toutes les bandes dessinées</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="736"/>
         <source>Assign current order to comics</source>
         <translation>Assigner l&apos;ordre actuel aux bandes dessinées</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="508"/>
         <source>Pack the covers of the selected library</source>
         <translation>Archiver les couvertures de la librairie sélectionnée</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="602"/>
         <source>Help, About YACReader</source>
         <translation>Aide, à propos de YACReader</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="819"/>
         <source>Favorites</source>
         <translation>Favoris</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="560"/>
         <source>Set comic as unread</source>
         <translation>Marquer cette bande dessinée comme non-lu</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="624"/>
         <source>Select root node</source>
         <translation>Allerà la racine</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="514"/>
         <source>Unpack a catalog</source>
         <translation>Désarchiver un catalogue</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2694"/>
         <source>All the selected comics will be deleted from your disk. Are you sure?</source>
         <translation>Tous les comics sélectionnés vont être supprimés de votre disque. Êtes-vous sûr?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="756"/>
         <source>Download tags from Comic Vine</source>
         <translation>Télécharger les informations de Comic Vine</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="559"/>
+        <location filename="library_window.cpp" line="695"/>
+        <location filename="library_window.cpp" line="1803"/>
         <source>Set as unread</source>
         <translation>Marquer comme non-lu</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2083"/>
         <source>Library not found</source>
         <translation>Librairie introuvable</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="525"/>
         <source>Rename library</source>
         <translation>Renommer la librairie</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="531"/>
         <source>Remove library</source>
         <translation>Supprimer la librairie</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="712"/>
         <source>Open containing folder...</source>
         <translation>Ouvrir le dossier...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source> library?</source>
         <translation> la librairie?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="549"/>
         <source>Save covers of the selected comics as JPG files</source>
         <translation>Enregistrer les couvertures des bandes dessinées sélectionnées en tant que fichiers JPG</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Are you sure?</source>
         <translation>Êtes-vous sûr?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="565"/>
+        <location filename="library_window.cpp" line="700"/>
+        <location filename="library_window.cpp" line="1806"/>
         <source>Set as manga</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="537"/>
+        <source>Rescan library for XML info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="538"/>
+        <source>Tries to find XML info embedded in comic files. You only need to do this if the library was created with 9.8.2 or earlier versions or if you are using third party software to embed XML info in the files.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="566"/>
         <source>Set issue as manga</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="571"/>
         <source>Set as normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="572"/>
         <source>Set issue as normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="609"/>
+        <location filename="library_window.cpp" line="1574"/>
         <source>Add new folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="612"/>
         <source>Add new folder to the current library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="615"/>
+        <location filename="library_window.cpp" line="1610"/>
         <source>Delete folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="618"/>
         <source>Delete current folder from disk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="634"/>
         <source>Collapse all nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="655"/>
+        <location filename="library_window.cpp" line="656"/>
         <source>Change between comics views</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="705"/>
+        <location filename="library_window.cpp" line="1809"/>
         <source>Set as comic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="760"/>
+        <source>Focus search line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="766"/>
+        <source>Focus comics view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="771"/>
         <source>Edit shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="777"/>
+        <source>&amp;Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="804"/>
         <source>Add new label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="807"/>
         <source>Add a new label to this library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="810"/>
         <source>Rename selected list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="813"/>
         <source>Rename any selected labels or lists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1251"/>
         <source>Upgrade failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1251"/>
         <source>There were errors during library upgrade in: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1575"/>
         <source>Folder name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1604"/>
         <source>No folder selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1604"/>
         <source>Please, select a folder first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1608"/>
         <source>Error in path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1608"/>
         <source>There was an error accessing the folder&apos;s path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1610"/>
         <source>The selected folder and all its contents will be deleted from your disk. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1636"/>
+        <location filename="library_window.cpp" line="2417"/>
         <source>Unable to delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1636"/>
         <source>There was an issue trying to delete the selected folders. Please, check for write permissions and be sure that any applications are using these folders or any of the contained files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1649"/>
+        <location filename="library_window.cpp" line="1698"/>
         <source>List name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1667"/>
         <source>Delete list/label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1697"/>
         <source>Rename list name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1916"/>
         <source>Save covers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1993"/>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1993"/>
         <source>YACReader not found. YACReader should be installed in the same folder as YACReaderLibrary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found. There might be a problem with your YACReader installation.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2417"/>
         <source>There was an issue trying to delete the selected comics. Please, check for write permissions in the selected files or containing folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2448"/>
         <source>Assign comics numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2449"/>
         <source>Assign numbers starting in:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Remove comics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Comics will only be deleted from the current label/list. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1026,6 +1352,7 @@ YACReaderLibrary ne vous empêchera pas de créer plus de bibliothèques, mais v
 <context>
     <name>LocalComicListModel</name>
     <message>
+        <location filename="comic_vine/model/local_comic_list_model.cpp" line="72"/>
         <source>file name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1033,30 +1360,37 @@ YACReaderLibrary ne vous empêchera pas de créer plus de bibliothèques, mais v
 <context>
     <name>LogWindow</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="14"/>
         <source>Log window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="22"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="39"/>
         <source>&amp;Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="56"/>
         <source>C&amp;lear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="73"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="90"/>
         <source>Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="136"/>
         <source>&amp;Auto scroll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1064,18 +1398,22 @@ YACReaderLibrary ne vous empêchera pas de créer plus de bibliothèques, mais v
 <context>
     <name>NoLibrariesWidget</name>
     <message>
+        <location filename="no_libraries_widget.cpp" line="32"/>
         <source>create your first library</source>
         <translation>Créez votre première librairie</translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="26"/>
         <source>You don&apos;t have any libraries yet</source>
         <translation>Vous n&apos;avez pas encore de librairie</translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="28"/>
         <source>&lt;p&gt;You can create a library in any folder, YACReaderLibrary will import all comics and folders from this folder. If you have created any library in the past you can open them.&lt;/p&gt;&lt;p&gt;Don&apos;t forget that you can use YACReader as a stand alone application for reading the comics on your computer.&lt;/p&gt;</source>
         <translation>&lt;p&gt;Vous pouvez creer une librairie dans n&apos;importe quel dossierr, YACReaderLibrary importera les dossiers et les bandes dessinées contenus dans ce dossier. Si vous avez déjà crer des librairies, vous pouvez les ouvrir.&lt;/p&gt;&lt;p&gt;N&apos;oubliez pas que vous pouvez utiliser YACReader en tant que stand alone pour lire vos bandes dessinées sur votre ordinateur.&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="34"/>
         <source>add an existing one</source>
         <translation>Ajouter une librairie existante</translation>
     </message>
@@ -1083,70 +1421,87 @@ YACReaderLibrary ne vous empêchera pas de créer plus de bibliothèques, mais v
 <context>
     <name>OptionsDialog</name>
     <message>
+        <location filename="options_dialog.cpp" line="156"/>
         <source>Options</source>
         <translation>Options</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="47"/>
         <source>Tray icon settings (experimental)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="50"/>
         <source>Close to tray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="51"/>
         <source>Start into the system tray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="69"/>
         <source>Edit Comic Vine API key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="72"/>
         <source>Comic Vine API key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="78"/>
         <source>Enable background image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="80"/>
         <source>Opacity level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="85"/>
         <source>Blur level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="90"/>
         <source>Use selected comic cover as background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="92"/>
         <source>Restore defautls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="103"/>
         <source>Background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="106"/>
         <source>Display continue reading banner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="111"/>
         <source>Continue reading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="144"/>
         <source>Comic Flow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="146"/>
         <source>Grid view</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="148"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1154,142 +1509,178 @@ YACReaderLibrary ne vous empêchera pas de créer plus de bibliothèques, mais v
 <context>
     <name>PropertiesDialog</name>
     <message>
+        <location filename="properties_dialog.cpp" line="151"/>
+        <location filename="properties_dialog.cpp" line="168"/>
         <source>of:</source>
         <translation>sur:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="240"/>
         <source>Day:</source>
         <translation>Jour:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="85"/>
         <source>Plot</source>
         <translation>Intrigue</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="177"/>
         <source>Size:</source>
         <translation>Taille:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="248"/>
         <source>Year:</source>
         <translation>Année:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="207"/>
         <source>Inker(s):</source>
         <translation>Encreur(s):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="84"/>
         <source>Publishing</source>
         <translation>Publication</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="256"/>
         <source>Publisher:</source>
         <translation>Editeur:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="82"/>
         <source>General info</source>
         <translation>Infos générales</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="258"/>
         <source>Color/BW:</source>
         <translation>Couleur/Noir et blanc:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="501"/>
         <source>Edit selected comics information</source>
         <translation>Editer les informations du comic sélectionné</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="200"/>
         <source>Penciller(s):</source>
         <translation>Dessinateur(s):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="210"/>
         <source>Colorist(s):</source>
         <translation>Coloriste(s):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="175"/>
         <source>Genre:</source>
         <translation>Genre:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="158"/>
         <source>Issue number:</source>
         <translation>Numéro:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="244"/>
         <source>Month:</source>
         <translation>Mois:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="275"/>
         <source>Notes:</source>
         <translation>Notes:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="273"/>
         <source>Synopsis:</source>
         <translation>Synopsis:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="143"/>
         <source>Title:</source>
         <translation>Titre:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="164"/>
         <source>Arc number:</source>
         <translation>Arc numéro:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Not found</source>
         <translation>Introuvable</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="274"/>
         <source>Characters:</source>
         <translation>Personnages:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="83"/>
         <source>Authors</source>
         <translation>Auteurs</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="259"/>
         <source>Age rating:</source>
         <translation>Limite d&apos;âge:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="173"/>
         <source>Story arc:</source>
         <translation>Arc narratif:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="197"/>
         <source>Writer(s):</source>
         <translation>Scénariste(s):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Comic not found. You should update your library.</source>
         <translation>Comic introuvable. Vous devriez mettre à jour votre librairie.</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="467"/>
         <source>Edit comic information</source>
         <translation>Editer les informations du comic</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="94"/>
         <source>Cover page</source>
         <translation>Couverture</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="220"/>
         <source>Cover Artist(s):</source>
         <translation>Artiste(s) de couverture:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="160"/>
         <source>Volume:</source>
         <translation>Volume:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="257"/>
         <source>Format:</source>
         <translation>Format:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="217"/>
         <source>Letterer(s):</source>
         <translation>Lettreur(s):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="260"/>
         <source>Manga:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="369"/>
         <source>Comic Vine link: &lt;a style=&apos;color: #FFCB00; text-decoration:none; font-weight:bold;&apos; href=&quot;http://www.comicvine.com/comic/4000-%1/&quot;&gt; view &lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1297,34 +1688,42 @@ YACReaderLibrary ne vous empêchera pas de créer plus de bibliothèques, mais v
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>7z lib not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>unable to load 7z lib from ./utils</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41"/>
         <source>Trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45"/>
         <source>Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51"/>
         <source>Fatal</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1332,14 +1731,17 @@ YACReaderLibrary ne vous empêchera pas de créer plus de bibliothèques, mais v
 <context>
     <name>QsLogging::LogWindowModel</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="141"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="143"/>
         <source>Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="145"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1347,18 +1749,22 @@ YACReaderLibrary ne vous empêchera pas de créer plus de bibliothèques, mais v
 <context>
     <name>QsLogging::Window</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="236"/>
         <source>Save log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="237"/>
         <source>Log file (*.log)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1366,18 +1772,22 @@ YACReaderLibrary ne vous empêchera pas de créer plus de bibliothèques, mais v
 <context>
     <name>RenameLibraryDialog</name>
     <message>
+        <location filename="rename_library_dialog.cpp" line="51"/>
         <source>Rename current library</source>
         <translation>Renommer la librairie actuelle</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="24"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="20"/>
         <source>Rename</source>
         <translation>Renommer</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="15"/>
         <source>New Library Name : </source>
         <translation>Nouveau nom de librairie:</translation>
     </message>
@@ -1385,14 +1795,18 @@ YACReaderLibrary ne vous empêchera pas de créer plus de bibliothèques, mais v
 <context>
     <name>ScraperResultsPaginator</name>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="30"/>
         <source>Number of volumes found : %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="32"/>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="55"/>
         <source>page %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="54"/>
         <source>Number of %1 found : %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1400,10 +1814,12 @@ YACReaderLibrary ne vous empêchera pas de créer plus de bibliothèques, mais v
 <context>
     <name>SearchSingleComic</name>
     <message>
+        <location filename="comic_vine/search_single_comic.cpp" line="14"/>
         <source>Please provide some additional information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/search_single_comic.cpp" line="19"/>
         <source>Series:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1411,10 +1827,12 @@ YACReaderLibrary ne vous empêchera pas de créer plus de bibliothèques, mais v
 <context>
     <name>SearchVolume</name>
     <message>
+        <location filename="comic_vine/search_volume.cpp" line="11"/>
         <source>Please provide some additional information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/search_volume.cpp" line="14"/>
         <source>Series:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1422,22 +1840,27 @@ YACReaderLibrary ne vous empêchera pas de créer plus de bibliothèques, mais v
 <context>
     <name>SelectComic</name>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="18"/>
         <source>Please, select the right comic info.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="38"/>
         <source>comics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="94"/>
         <source>loading cover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="95"/>
         <source>loading description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="135"/>
         <source>description unavailable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1445,22 +1868,37 @@ YACReaderLibrary ne vous empêchera pas de créer plus de bibliothèques, mais v
 <context>
     <name>SelectVolume</name>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="35"/>
         <source>Please, select the right series for your comic.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="56"/>
+        <source>Filter:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="68"/>
         <source>volumes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="138"/>
+        <source>Nothing found, clear the filter if any.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="144"/>
         <source>loading cover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="145"/>
         <source>loading description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="185"/>
         <source>description unavailable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1468,14 +1906,17 @@ YACReaderLibrary ne vous empêchera pas de créer plus de bibliothèques, mais v
 <context>
     <name>SeriesQuestion</name>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="15"/>
         <source>no</source>
         <translation>non</translation>
     </message>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="14"/>
         <source>yes</source>
         <translation>oui</translation>
     </message>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="12"/>
         <source>You are trying to get information for various comics at once, are they part of the same series?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1483,39 +1924,48 @@ YACReaderLibrary ne vous empêchera pas de créer plus de bibliothèques, mais v
 <context>
     <name>ServerConfigDialog</name>
     <message>
+        <location filename="server_config_dialog.cpp" line="115"/>
         <source>Port</source>
         <translation>Port</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="147"/>
         <source>enable the server</source>
         <translation>Autoriser le serveur</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="86"/>
         <source>set port</source>
         <translation>Configurer le port</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="92"/>
         <source>Server connectivity information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="96"/>
         <source>Scan it!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="102"/>
         <source>YACReader is available for iOS devices. &lt;a href=&apos;http://ios.yacreader.com&apos; style=&apos;color:rgb(193, 148, 65)&apos;&gt; Discover it! &lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="111"/>
         <source>Choose an IP address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="152"/>
         <source>display less information about folders in the browser
 to improve the performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="268"/>
         <source>Could not load libqrencode.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1523,22 +1973,27 @@ to improve the performance</source>
 <context>
     <name>SortVolumeComics</name>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="18"/>
         <source>Please, sort the list of comics on the left until it matches the comics&apos; information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="21"/>
         <source>sort comics to match comic information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="58"/>
         <source>issues</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="87"/>
         <source>remove selected comics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="88"/>
         <source>restore all removed comics</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1546,6 +2001,7 @@ to improve the performance</source>
 <context>
     <name>TitleHeader</name>
     <message>
+        <location filename="comic_vine/title_header.cpp" line="30"/>
         <source>SEARCH</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1553,14 +2009,17 @@ to improve the performance</source>
 <context>
     <name>UpdateLibraryDialog</name>
     <message>
+        <location filename="create_library_dialog.cpp" line="180"/>
         <source>Update library</source>
         <translation>Mettre la librairie à jour</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="161"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="155"/>
         <source>Updating....</source>
         <translation>Mise à jour...</translation>
     </message>
@@ -1568,6 +2027,7 @@ to improve the performance</source>
 <context>
     <name>VolumeComicsModel</name>
     <message>
+        <location filename="comic_vine/model/volume_comics_model.cpp" line="120"/>
         <source>title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1575,14 +2035,17 @@ to improve the performance</source>
 <context>
     <name>VolumesModel</name>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="122"/>
         <source>publisher</source>
         <translation>éditeur</translation>
     </message>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="118"/>
         <source>year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="120"/>
         <source>issues</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1590,18 +2053,17 @@ to improve the performance</source>
 <context>
     <name>YACReader::TrayIconController</name>
     <message>
+        <location filename="trayicon_controller.cpp" line="52"/>
         <source>&amp;Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Quit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="trayicon_controller.cpp" line="79"/>
         <source>Systray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="trayicon_controller.cpp" line="80"/>
         <source>YACReaderLibrary will keep running in the system tray. To terminate the program, choose &lt;b&gt;Quit&lt;/b&gt; in the context menu of the system tray icon.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1609,6 +2071,7 @@ to improve the performance</source>
 <context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1616,10 +2079,12 @@ to improve the performance</source>
 <context>
     <name>YACReaderDeletingProgress</name>
     <message>
+        <location filename="../custom_widgets/yacreader_deleting_progress.cpp" line="35"/>
         <source>cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_deleting_progress.cpp" line="20"/>
         <source>Please wait, deleting in progress...</source>
         <translation>Attendez, suppression en cours...</translation>
     </message>
@@ -1627,10 +2092,13 @@ to improve the performance</source>
 <context>
     <name>YACReaderFieldEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11"/>
         <source>Restore to default</source>
         <translation>Restaurer les paramètres par défaut</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28"/>
         <source>Click to overwrite</source>
         <translation>Cliquer pour modifier</translation>
     </message>
@@ -1638,10 +2106,15 @@ to improve the performance</source>
 <context>
     <name>YACReaderFieldPlainTextEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10"/>
         <source>Restore to default</source>
         <translation>Restaurer les paramètres par défaut</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50"/>
         <source>Click to overwrite</source>
         <translation>Cliquer pour modifier</translation>
     </message>
@@ -1649,18 +2122,22 @@ to improve the performance</source>
 <context>
     <name>YACReaderFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="15"/>
         <source>CoverFlow look</source>
         <translation>Vue CoverFlow</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="13"/>
         <source>How to show covers:</source>
         <translation>Comment voir les couvertures:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="16"/>
         <source>Stripe look</source>
         <translation>Vue alignée</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="17"/>
         <source>Overlapped Stripe look</source>
         <translation>Vue superposée</translation>
     </message>
@@ -1668,94 +2145,117 @@ to improve the performance</source>
 <context>
     <name>YACReaderGLFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="112"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="142"/>
         <source>Light</source>
         <translation>Lumière</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="76"/>
         <source>Show advanced settings</source>
         <translation>Réglages avancés</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="32"/>
         <source>Roulette look</source>
         <translation>Vue roulette</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="130"/>
         <source>Cover Angle</source>
         <translation>Angle des couvertures</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="23"/>
         <source>Stripe look</source>
         <translation>Vue alignée</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="94"/>
         <source>Position</source>
         <translation>Position</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="124"/>
         <source>Z offset</source>
         <translation>Axe Z</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="118"/>
         <source>Y offset</source>
         <translation>Axe Y</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="106"/>
         <source>Central gap</source>
         <translation>Espace central</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="18"/>
         <source>Presets:</source>
         <translation>Réglages:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="26"/>
         <source>Overlapped Stripe look</source>
         <translation>Vue superposée</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="29"/>
         <source>Modern look</source>
         <translation>Vue moderne</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="88"/>
         <source>View angle</source>
         <translation>Angle de vue</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="148"/>
         <source>Max angle</source>
         <translation>Angle maximum</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="85"/>
         <source>Custom:</source>
         <translation>Personnalisation:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="20"/>
         <source>Classic look</source>
         <translation>Vue classique</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="100"/>
         <source>Cover gap</source>
         <translation>Espace entre les couvertures</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="182"/>
         <source>High Performance</source>
         <translation>Haute performance</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="201"/>
         <source>Performance:</source>
         <translation>Performance:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="193"/>
         <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
         <translation>Utiliser VSync (améliore la qualité de l&apos;image en plein écran, diminue la performance)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="136"/>
         <source>Visibility</source>
         <translation>Visibilité</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="180"/>
         <source>Low Performance</source>
         <translation>Basse performance</translation>
     </message>
@@ -1763,10 +2263,12 @@ to improve the performance</source>
 <context>
     <name>YACReaderNavigationController</name>
     <message>
+        <location filename="yacreader_navigation_controller.cpp" line="127"/>
         <source>You are not reading anything yet, come on!!</source>
         <translation>Vous ne lisez rien encore, allez !!</translation>
     </message>
     <message>
+        <location filename="yacreader_navigation_controller.cpp" line="123"/>
         <source>No favorites</source>
         <translation>Pas de favoris</translation>
     </message>
@@ -1774,22 +2276,27 @@ to improve the performance</source>
 <context>
     <name>YACReaderOptionsDialog</name>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28"/>
         <source>Save</source>
         <translation>Sauvegarder</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="46"/>
         <source>Use hardware acceleration (restart needed)</source>
         <translation>Utiliser l&apos;accélération hardware (redémarrage nécessaire)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="29"/>
         <source>Cancel</source>
         <translation>Annuler</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="34"/>
         <source>Edit shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="37"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1797,6 +2304,7 @@ to improve the performance</source>
 <context>
     <name>YACReaderSearchLineEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_search_line_edit.cpp" line="68"/>
         <source>type to search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1804,26 +2312,32 @@ to improve the performance</source>
 <context>
     <name>YACReaderSideBar</name>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="29"/>
         <source>Reading Lists</source>
         <translation>Listes de lecture</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="31"/>
         <source>LIBRARIES</source>
         <translation>LIBRAIRIES</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="32"/>
         <source>FOLDERS</source>
         <translation>DOSSIERS</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="33"/>
         <source>READING LISTS</source>
         <translation>Listes de lecture</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="27"/>
         <source>Libraries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="28"/>
         <source>Folders</source>
         <translation type="unfinished"></translation>
     </message>

--- a/YACReaderLibrary/yacreaderlibrary_it.ts
+++ b/YACReaderLibrary/yacreaderlibrary_it.ts
@@ -4,6 +4,7 @@
 <context>
     <name>ActionsShortcutsModel</name>
     <message>
+        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="73"/>
         <source>None</source>
         <translation>Nessuno</translation>
     </message>
@@ -11,66 +12,82 @@
 <context>
     <name>AddLabelDialog</name>
     <message>
+        <location filename="add_label_dialog.cpp" line="14"/>
         <source>red</source>
         <translation>Rosso</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="19"/>
         <source>blue</source>
         <translation>Blu</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="25"/>
         <source>dark</source>
         <translation>Scuro</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="18"/>
         <source>cyan</source>
         <translation>Azzurro</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="22"/>
         <source>pink</source>
         <translation>Rosa</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="17"/>
         <source>green</source>
         <translation>Verde</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="24"/>
         <source>light</source>
         <translation>Luminoso</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="23"/>
         <source>white</source>
         <translation>Bianco</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="11"/>
         <source>Choose a color:</source>
         <translation>Seleziona un colore:</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="36"/>
         <source>accept</source>
         <translation>Accetta</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="37"/>
         <source>cancel</source>
         <translation>Cancella</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="15"/>
         <source>orange</source>
         <translation>Arancione</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="21"/>
         <source>purple</source>
         <translation>Porpora</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="20"/>
         <source>violet</source>
         <translation>Viola</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="16"/>
         <source>yellow</source>
         <translation>Giallo</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="8"/>
         <source>Label name:</source>
         <translation>Nome etichetta:</translation>
     </message>
@@ -78,18 +95,22 @@
 <context>
     <name>AddLibraryDialog</name>
     <message>
+        <location filename="add_library_dialog.cpp" line="26"/>
         <source>Add</source>
         <translation>Aggiungi</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="66"/>
         <source>Add an existing library</source>
         <translation>Aggiungi ad una libreria esistente</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="30"/>
         <source>Cancel</source>
         <translation>Cancella</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="16"/>
         <source>Comics folder : </source>
         <translation>Cartella fumetti: </translation>
     </message>
@@ -98,6 +119,7 @@
         <translation type="vanished">Nome libreria: </translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="21"/>
         <source>Library name : </source>
         <translation type="unfinished"></translation>
     </message>
@@ -105,18 +127,22 @@
 <context>
     <name>ApiKeyDialog</name>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="28"/>
         <source>Accept</source>
         <translation>Accetta</translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="32"/>
         <source>Cancel</source>
         <translation>Cancella</translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="21"/>
         <source>Before you can connect to Comic Vine, you need your own API key. Please, get one free &lt;a href=&quot;http://www.comicvine.com/api/&quot;&gt;here&lt;/a&gt;</source>
         <translation>Prima di conneterti a &quot;Comic Vine&quot; devi avere la tua chiave API. Per favore recuperane una da &lt;a href=&quot;http://www.comicvine.com/api/&quot;&gt;QUI&lt;/a</translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="25"/>
         <source>Paste here your Comic Vine API key</source>
         <translation>Incolla qui la tua chiave API di &quot;Comic Vine&quot;</translation>
     </message>
@@ -124,6 +150,7 @@
 <context>
     <name>ClassicComicsView</name>
     <message>
+        <location filename="classic_comics_view.cpp" line="90"/>
         <source>Hide comic flow</source>
         <translation>Nascondi il flusso dei fumetti</translation>
     </message>
@@ -131,46 +158,57 @@
 <context>
     <name>ComicInfoView</name>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="279"/>
         <source>Authors</source>
         <translation type="unfinished">Autori</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="309"/>
         <source>writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="331"/>
         <source>penciller</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="353"/>
         <source>inker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="375"/>
         <source>colorist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="397"/>
         <source>letterer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="419"/>
         <source>cover artist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="434"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
         <source>color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
         <source>b/w</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="502"/>
         <source>Characters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -178,38 +216,52 @@
 <context>
     <name>ComicModel</name>
     <message>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>no</source>
         <translation>No</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>yes</source>
         <translation>Si</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="351"/>
         <source>Read</source>
         <translation>Leggi</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="349"/>
         <source>Size</source>
         <translation>Dimensione</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="347"/>
         <source>Pages</source>
         <translation>Pagine</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="343"/>
         <source>Title</source>
         <translation>Titolo</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="353"/>
         <source>Current Page</source>
         <translation>Pagina corrente</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="345"/>
         <source>File Name</source>
         <translation>Nome file</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="355"/>
+        <source>Publication Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="357"/>
         <source>Rating</source>
         <translation>Valutazione</translation>
     </message>
@@ -217,50 +269,67 @@
 <context>
     <name>ComicVineDialog</name>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="58"/>
         <source>back</source>
         <translation>Indietro</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="59"/>
         <source>next</source>
         <translation>Prossimo</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="57"/>
         <source>skip</source>
         <translation>Salta</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="61"/>
         <source>close</source>
         <translation>Chiudi</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="467"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="503"/>
         <source>Retrieving tags for : %1</source>
         <translation>Ricezione tag per: %1</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="814"/>
         <source>Looking for comic...</source>
         <translation>Sto cercando il fumetto...</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="60"/>
         <source>search</source>
         <translation>Cerca</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="143"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="257"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="773"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="807"/>
         <source>Looking for volume...</source>
         <translation>Sto cercando il fumetto...</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="141"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="735"/>
         <source>comic %1 of %2 - %3</source>
         <translation>Fumetto %1 di %2 - %3</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="262"/>
         <source>%1 comics selected</source>
         <translation>Fumetto %1 selezionato</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="295"/>
         <source>Error connecting to ComicVine</source>
         <translation>Errore durante la connessione a ComicVine</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="788"/>
         <source>Retrieving volume info...</source>
         <translation>Sto ricevendo le informazioni per l&apos;abum...</translation>
     </message>
@@ -268,34 +337,42 @@
 <context>
     <name>CreateLibraryDialog</name>
     <message>
+        <location filename="create_library_dialog.cpp" line="75"/>
         <source>Create new library</source>
         <translation>Crea una nuova libreria</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="31"/>
         <source>Cancel</source>
         <translation>Cancella</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="27"/>
         <source>Create</source>
         <translation>Crea</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="53"/>
         <source>Create a library could take several minutes. You can stop the process and update the library later for completing the task.</source>
         <translation>Creare una Libreria può aver bisogno di alcuni minuti. Puoi fermare il processo ed aggiornare la libreria più tardi.</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="95"/>
         <source>The selected path does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation>Il percorso selezionato non esiste oppure non è valido. Controlla di avere i permessi di scrittura per questa cartella</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="17"/>
         <source>Comics folder : </source>
         <translation>Cartella fumetti: </translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="22"/>
         <source>Library Name : </source>
         <translation>Nome libreria: </translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="95"/>
         <source>Path not found</source>
         <translation>Percorso non trovato</translation>
     </message>
@@ -303,22 +380,27 @@
 <context>
     <name>EditShortcutsDialog</name>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>Shortcut in use</source>
         <translation>Scorciatoia in uso</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="21"/>
         <source>Restore defaults</source>
         <translation>Resetta al Default</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="69"/>
         <source>Shortcuts settings</source>
         <translation>Impostazioni scorciatoie</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>The shortcut &quot;%1&quot; is already assigned to other function</source>
         <translation>La scorciatoia &quot;%1&quot; è già assegnata ad un&apos; altra funzione</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="22"/>
         <source>To change a shortcut, double click in the key combination and type the new keys.</source>
         <translation>Per cambiare una sorciatoia fai doppio click sulla combinazione tasti e digita la nuova combinazione.</translation>
     </message>
@@ -326,14 +408,18 @@
 <context>
     <name>EmptyFolderWidget</name>
     <message>
+        <location filename="empty_folder_widget.cpp" line="138"/>
         <source>Empty folder</source>
         <translation>Cartella vuota</translation>
     </message>
     <message>
+        <location filename="empty_folder_widget.cpp" line="75"/>
+        <location filename="empty_folder_widget.cpp" line="140"/>
         <source>Subfolders in this folder</source>
         <translation>Sottocartelle in questa cartella</translation>
     </message>
     <message>
+        <location filename="empty_folder_widget.cpp" line="138"/>
         <source>Drag and drop folders and comics here</source>
         <translation>Prendi e sposta le cartelle qui</translation>
     </message>
@@ -341,6 +427,7 @@
 <context>
     <name>EmptyLabelWidget</name>
     <message>
+        <location filename="empty_label_widget.cpp" line="11"/>
         <source>This label doesn&apos;t contain comics yet</source>
         <translation>Per ora questa etichetta non contiene fumetti</translation>
     </message>
@@ -348,6 +435,7 @@
 <context>
     <name>EmptyReadingListWidget</name>
     <message>
+        <location filename="empty_reading_list_widget.cpp" line="8"/>
         <source>This reading list does not contain any comics yet</source>
         <translation>Per ora questa lista non contiene fumetti</translation>
     </message>
@@ -355,30 +443,37 @@
 <context>
     <name>ExportComicsInfoDialog</name>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="14"/>
         <source>Output file : </source>
         <translation>File di Output: </translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="66"/>
         <source>Destination database name</source>
         <translation>Nome database di destinazione</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="22"/>
         <source>Cancel</source>
         <translation>Cancella</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="18"/>
         <source>Create</source>
         <translation>Crea</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="81"/>
         <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation>Il percorso selezionato per il file di Output non esiste oppure non è valido. Controlla di avere i permessi di scrittura per questa cartella</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="57"/>
         <source>Export comics info</source>
         <translation>Esporta informazioni fumetto</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="81"/>
         <source>Problem found while writing</source>
         <translation>Trovato problema durante la scrittura</translation>
     </message>
@@ -386,30 +481,37 @@
 <context>
     <name>ExportLibraryDialog</name>
     <message>
+        <location filename="export_library_dialog.cpp" line="19"/>
         <source>Cancel</source>
         <translation>Cancella</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="15"/>
         <source>Create</source>
         <translation>Crea</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="71"/>
         <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation>Il percorso selezionato per il file di Output non esiste oppure non è valido. Controlla di avere i permessi di scrittura per questa cartella</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="11"/>
         <source>Output folder : </source>
         <translation>Cartella di Output: </translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="71"/>
         <source>Problem found while writing</source>
         <translation>Trovato problema durante la scrittura</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="60"/>
         <source>Create covers package</source>
         <translation>Crea pacchetto delle copertine</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="76"/>
         <source>Destination directory</source>
         <translation>Cartella di destinazione</translation>
     </message>
@@ -417,25 +519,46 @@
 <context>
     <name>FileComic</name>
     <message>
+        <location filename="../common/comic.cpp" line="568"/>
         <source>Format not supported</source>
         <translation>Formato non supportato</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="562"/>
         <source>7z not found</source>
         <translation>7z non trovato</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="461"/>
         <source>Unknown error opening the file</source>
         <translation>Errore sconosciuto all&apos;apertura del file</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="454"/>
         <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
         <translation>Errore CRC alla pagina (%1): alcune pagine potrebbero non essere visualizzate correttamente</translation>
     </message>
 </context>
 <context>
+    <name>FolderContentView</name>
+    <message>
+        <location filename="qml/FolderContentView.qml" line="238"/>
+        <source>Continue Reading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FolderContentView6</name>
+    <message>
+        <location filename="qml/FolderContentView6.qml" line="240"/>
+        <source>Continue Reading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GridComicsView</name>
     <message>
+        <location filename="grid_comics_view.cpp" line="147"/>
         <source>Show info</source>
         <translation>Mostra informazioni</translation>
     </message>
@@ -443,10 +566,17 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Aiuto</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
+        <source>System info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation>Informazioni</translation>
     </message>
@@ -454,22 +584,27 @@
 <context>
     <name>ImportComicsInfoDialog</name>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="24"/>
         <source>Cancel</source>
         <translation>Cancella</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="20"/>
         <source>Import</source>
         <translation>Importa</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="16"/>
         <source>Info database location : </source>
         <translation>Informazioni posizione database: </translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="14"/>
         <source>Import comics info</source>
         <translation>Importa informazioni fumetto</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="74"/>
         <source>Comics info file (*.ydb)</source>
         <translation>File informazioni fumetto (*.ydb)</translation>
     </message>
@@ -477,30 +612,37 @@
 <context>
     <name>ImportLibraryDialog</name>
     <message>
+        <location filename="import_library_dialog.cpp" line="26"/>
         <source>Destination folder : </source>
         <translation>Cartella di destinazione: </translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="34"/>
         <source>Cancel</source>
         <translation>Cancella</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="30"/>
         <source>Unpack</source>
         <translation>Decomprimi</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="108"/>
         <source>Compresed library covers (*.clc)</source>
         <translation>Libreria di copertine compresse (*.clc)</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="22"/>
         <source>Package location : </source>
         <translation>Posizione PAcchetto: </translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="17"/>
         <source>Library Name : </source>
         <translation>Nome libreria: </translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="87"/>
         <source>Extract a catalog</source>
         <translation>Estrai un catalogo</translation>
     </message>
@@ -508,105 +650,141 @@
 <context>
     <name>ImportWidget</name>
     <message>
+        <location filename="import_widget.cpp" line="150"/>
         <source>stop</source>
         <translation>Ferma</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="334"/>
         <source>Importing comics</source>
         <translation>Sto importando i fumetti</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="335"/>
         <source>&lt;p&gt;YACReaderLibrary is now creating a new library.&lt;/p&gt;&lt;p&gt;Create a library could take several minutes. You can stop the process and update the library later for completing the task.&lt;/p&gt;</source>
         <translation>&lt;p&gt;YacReader sta creando una nuova libreria.&lt;/p&gt;&lt;p&gt;La creazione di una libreria può durare diversi minuti. Puoi fermare l&apos;attività ed aggiornare la libreria più tardi, completando l&apos;attività&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="190"/>
         <source>Some of the comics being added...</source>
         <translation>Alcuni fumetti che sto aggiungendo...</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="346"/>
         <source>Updating the library</source>
         <translation>Sto aggiornando la Libreria</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="347"/>
         <source>&lt;p&gt;The current library is being updated. For faster updates, please, update your libraries frequently.&lt;/p&gt;&lt;p&gt;You can stop the process and continue updating this library later.&lt;/p&gt;</source>
         <translation>&lt;p&gt;Quest alibreria si sta aggiornando. Per aggiornamenti più veloci aggiorna la tua libreria di frequente.&lt;/p&gt;&lt;p&gt;Puoi fermare il processo ed aggiornare la libreria più tardi.&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="358"/>
         <source>Upgrading the library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="359"/>
         <source>&lt;p&gt;The current library is being upgraded, please wait.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="370"/>
+        <source>Scanning the library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="371"/>
+        <source>&lt;p&gt;Current library is being scanned for legacy XML metadata information.&lt;/p&gt;&lt;p&gt;This is only needed once, and only if the library was crated with YACReaderLibrary 9.8.2 or earlier.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LibraryWindow</name>
     <message>
+        <location filename="library_window.cpp" line="730"/>
         <source>Edit</source>
         <translation>Edita</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2083"/>
         <source>The selected folder doesn&apos;t contain any library.</source>
         <translation>La cartella selezionata non contiene nessuna Libreria.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1269"/>
         <source>This library was created with a previous version of YACReaderLibrary. It needs to be updated. Update now?</source>
         <translation>Questa libreria è stata creata con una versione precedente di YACREaderLibrary. Deve essere aggiornata. Aggiorno ora?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1060"/>
         <source>Comic</source>
         <translation>Fumetto</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1575"/>
         <source>Folder name:</source>
         <translation>Nome della cartella:</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1610"/>
         <source>The selected folder and all its contents will be deleted from your disk. Are you sure?</source>
         <translation>La cartella seleziona e tutto il suo contenuto verranno cancellati dal tuo disco. Sei sicuro?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="787"/>
         <source>Update current folder</source>
         <translation>Aggiorna la cartella corrente</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2659"/>
         <source>Error opening the library</source>
         <translation>Errore nell&apos;apertura della libreria</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="585"/>
         <source>Show/Hide marks</source>
         <translation>Mostra/Nascondi</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1993"/>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found</source>
         <translation>YACReader non trovato</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="648"/>
         <source>Show comics server options dialog</source>
         <translation>Mostra le opzioni per il server dei fumetti</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1636"/>
         <source>There was an issue trying to delete the selected folders. Please, check for write permissions and be sure that any applications are using these folders or any of the contained files.</source>
         <translation>C&apos;è stato un problema cancellando le cartelle selezionate. Per favore controlla i tuoi permessi di scrittura e sii sicuro che non ci siano altre applicazioni che usano le stesse cartelle.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="532"/>
         <source>Remove current library from your collection</source>
         <translation>Rimuovi la libreria corrente dalla tua collezione</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="554"/>
         <source>Set comic as read</source>
         <translation>Setta il fumetto come letto</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1697"/>
         <source>Rename list name</source>
         <translation>Rinomina la lista</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="822"/>
         <source>Add selected comics to favorites list</source>
         <translation>Aggiungi i fumetti selezionati alla lista dei favoriti</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2139"/>
         <source>Remove and delete metadata</source>
         <translation>Rimuovi e cancella i Metadati</translation>
     </message>
@@ -615,146 +793,190 @@
         <translation type="vanished">YACReader non trovato, YACReader deve esere installato nella stessa cartella di YACReaderLibrary.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Old library</source>
         <translation>Vecchia libreria</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="742"/>
         <source>Update cover</source>
         <translation>Aggiorna copertina</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="813"/>
         <source>Rename any selected labels or lists</source>
         <translation>Rinomina qualsiasi etichetta o lista selezionata</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="685"/>
+        <location filename="library_window.cpp" line="1797"/>
         <source>Set as completed</source>
         <translation>Segna come completo</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1608"/>
         <source>There was an error accessing the folder&apos;s path</source>
         <translation>C&apos;è stato un errore nell&apos;accesso al percorso della cartella</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1027"/>
         <source>Library</source>
         <translation>Libreria</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="612"/>
         <source>Add new folder to the current library</source>
         <translation>Aggiungi una nuova cartella alla libreria corrente</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Comics will only be deleted from the current label/list. Are you sure?</source>
         <translation>I fumetti verranno cancellati dall&apos;etichetta/lista corrente. Sei sicuro?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="526"/>
         <source>Rename current library</source>
         <translation>Rinomina la libreria corrente</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="593"/>
+        <location filename="library_window.cpp" line="594"/>
         <source>Fullscreen mode on/off</source>
         <translation>Modalità a schermo interno on/off</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1336"/>
         <source>This library was created with a newer version of YACReaderLibrary. Download the new version now?</source>
         <translation>Questa libreria è stata creata con una verisone più recente di YACReaderLibrary. Scarico la versione aggiornata ora?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1426"/>
+        <location filename="library_window.cpp" line="1464"/>
         <source>Moving comics...</source>
         <translation>Sto muovendo i fumetti...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="543"/>
         <source>Open current comic on YACReader</source>
         <translation>Apri il fumetto corrente con YACReader</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="520"/>
         <source>Update current library</source>
         <translation>Aggiorna la Libreria corrente</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1409"/>
+        <location filename="library_window.cpp" line="1445"/>
         <source>Copying comics...</source>
         <translation>Sto copiando i fumetti...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library &apos;%1&apos; is no longer available. Do you want to remove it?</source>
         <translation>La libreria &apos;%1&apos; non è più disponibile, la vuoi cancellare?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="519"/>
         <source>Update library</source>
         <translation>Aggiorna Libreria</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="674"/>
+        <location filename="library_window.cpp" line="1787"/>
         <source>Open folder...</source>
         <translation>Apri Cartella...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Do you want remove </source>
         <translation>Vuoi rimuovere </translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="680"/>
+        <location filename="library_window.cpp" line="1794"/>
         <source>Set as uncompleted</source>
         <translation>Segna come non completo</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1608"/>
         <source>Error in path</source>
         <translation>Errore nel percorso</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="718"/>
         <source>Reset comic rating</source>
         <translation>Resetta la valutazione dei fumetti</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2654"/>
         <source>Error updating the library</source>
         <translation>Errore aggiornando la libreria</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1046"/>
         <source>Folder</source>
         <translation>Cartella</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1667"/>
         <source>The selected item will be deleted, your comics or folders will NOT be deleted from your disk. Are you sure?</source>
         <translation>Gli elementi selezionati verranno cancellati, i tuoi fumetti o cartella NON verranno cancellati dal tuo disco. Sei sicuro?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="628"/>
         <source>Expand all nodes</source>
         <translation>Espandi tutti i nodi</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="618"/>
         <source>Delete current folder from disk</source>
         <translation>Cancella la cartella corrente dal disco</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1649"/>
+        <location filename="library_window.cpp" line="1698"/>
         <source>List name:</source>
         <translation>Nome lista:</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="817"/>
         <source>Add to...</source>
         <translation>Aggiungi a...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Library &apos;%1&apos; has been created with an older version of YACReaderLibrary. It must be created again. Do you want to create the library now?</source>
         <translation>La libreria &apos;%1&apos; è stata creata con una versione precedente di YACREaderLibrary. Deve essere ricreata. Lo vuoi fare ora?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="507"/>
         <source>Pack covers</source>
         <translation>Compatta Copertine</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1916"/>
         <source>Save covers</source>
         <translation>Salva Copertine</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="655"/>
+        <location filename="library_window.cpp" line="656"/>
         <source>Change between comics views</source>
         <translation>Cambia tra i modi di visualizzazione dei fumetti</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="801"/>
         <source>Remove current reading list from the library</source>
         <translation>Rimuovi la lista di lettura dalla libreria</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1648"/>
         <source>Add new reading lists</source>
         <translation>Aggiungi una lista di lettura</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.
 
 You probably only need one library in your top level comics folder, you can browse any subfolders using the folders section in the left sidebar.
@@ -767,38 +989,51 @@ Hai probabilemnte bisogno di una sola Libreria al livello superiore, puoi poi na
 YACReader non ti fermerà dal creare altre librerie ma è meglio se terrai il numero di librerie basso.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="553"/>
+        <location filename="library_window.cpp" line="690"/>
+        <location filename="library_window.cpp" line="1800"/>
         <source>Set as read</source>
         <translation>Setta come letto</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2448"/>
         <source>Assign comics numbers</source>
         <translation>Assegna un numero ai fumetti</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="748"/>
         <source>Delete selected comics</source>
         <translation>Cancella i fumetti selezionati</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="495"/>
+        <location filename="library_window.cpp" line="496"/>
         <source>Export comics info</source>
         <translation>Esporta informazioni fumetto</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="640"/>
         <source>Show options dialog</source>
         <translation>Mostra le opzioni</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1604"/>
         <source>Please, select a folder first</source>
         <translation>Per cortesia prima seleziona una cartella</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="484"/>
         <source>Create a new library</source>
         <translation>Crea una nuova libreria</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library not available</source>
         <translation>Libreria non disponibile</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="501"/>
+        <location filename="library_window.cpp" line="502"/>
         <source>Import comics info</source>
         <translation>Importa informazioni fumetto</translation>
     </message>
@@ -807,30 +1042,37 @@ YACReader non ti fermerà dal creare altre librerie ma è meglio se terrai il nu
         <translation type="vanished">La libreria corrente non può essere aggiornata. Controlla i tuoi permessi di scrittura su: </translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2417"/>
         <source>There was an issue trying to delete the selected comics. Please, check for write permissions in the selected files or containing folder.</source>
         <translation>C&apos;è un problema nel cancellare i fumetti selezionati. Per favore controlla i tuoi permessi di scrittura sui file o sulla cartella.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="792"/>
         <source>Add new reading list</source>
         <translation>Aggiorna la lista di lettura</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="548"/>
         <source>Save selected covers to...</source>
         <translation>Salva le copertine selezionate in...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="542"/>
         <source>Open current comic</source>
         <translation>Apri il fumetto corrente</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="188"/>
         <source>YACReader Library</source>
         <translation>Libreria YACReader</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="795"/>
         <source>Add a new reading list to the current library</source>
         <translation>Aggiungi una lista di lettura alla libreria corrente</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2649"/>
         <source>Error creating the library</source>
         <translation>Errore creando la libreria</translation>
     </message>
@@ -839,202 +1081,286 @@ YACReader non ti fermerà dal creare altre librerie ma è meglio se terrai il nu
         <translation type="vanished">Aggiornamento fallito</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.</source>
         <translation>Stai aggiungendto troppe librerie.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="784"/>
+        <location filename="library_window.cpp" line="1790"/>
         <source>Update folder</source>
         <translation>Aggiorna Cartella</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="513"/>
         <source>Unpack covers</source>
         <translation>Scompatta le Copertine</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1269"/>
         <source>Update needed</source>
         <translation>Devi aggiornarmi</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="490"/>
         <source>Open an existing library</source>
         <translation>Apri una libreria esistente</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="586"/>
         <source>Show or hide read marks</source>
         <translation>Mostra o nascondi lo stato di lettura</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2805"/>
         <source>Library name already exists</source>
         <translation>Esiste già una libreria con lo stesso nome</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2805"/>
         <source>There is another library with the name &apos;%1&apos;.</source>
         <translation>Esiste già una libreria con il nome &apos;%1&apos;.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="798"/>
         <source>Remove reading list</source>
         <translation>Rimuovi la lista di lettura</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="615"/>
+        <location filename="library_window.cpp" line="1610"/>
         <source>Delete folder</source>
         <translation>Cancella Cartella</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2449"/>
         <source>Assign numbers starting in:</source>
         <translation>Assegna numeri partendo da:</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1336"/>
         <source>Download new version</source>
         <translation>Scarica la nuova versione</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2694"/>
         <source>Delete comics</source>
         <translation>Cancella i fumetti</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="609"/>
+        <location filename="library_window.cpp" line="1574"/>
         <source>Add new folder</source>
         <translation>Aggiungi una nuova cartella</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="724"/>
         <source>Select all comics</source>
         <translation>Seleziona tutti i fumetti</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="736"/>
         <source>Assign current order to comics</source>
         <translation>Assegna l&apos;ordinamento corrente ai fumetti</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="508"/>
         <source>Pack the covers of the selected library</source>
         <translation>Compatta le copertine della libreria selezionata</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="602"/>
         <source>Help, About YACReader</source>
         <translation>Aiuto, Crediti YACReader</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="634"/>
         <source>Collapse all nodes</source>
         <translation>Compatta tutti i nodi</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="819"/>
         <source>Favorites</source>
         <translation>Favoriti</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="810"/>
         <source>Rename selected list</source>
         <translation>Rinomina la lista selezionata</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1667"/>
         <source>Delete list/label</source>
         <translation>Cancella Lista/Etichetta</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="560"/>
         <source>Set comic as unread</source>
         <translation>Setta il fumetto come non letto</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="771"/>
         <source>Edit shortcuts</source>
         <translation>Edita scorciatoie</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="624"/>
         <source>Select root node</source>
         <translation>Seleziona il nodo principale</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1604"/>
         <source>No folder selected</source>
         <translation>Nessuna cartella selezionata</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="514"/>
         <source>Unpack a catalog</source>
         <translation>Scompatta un catalogo</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2694"/>
         <source>All the selected comics will be deleted from your disk. Are you sure?</source>
         <translation>Tutti i fumetti selezionati saranno cancellati dal tuo disco. Sei sicuro?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="756"/>
         <source>Download tags from Comic Vine</source>
         <translation>Scarica i Tag da Comic Vine</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Remove comics</source>
         <translation>Rimuovi i fumetti</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="807"/>
         <source>Add a new label to this library</source>
         <translation>Aggiungi una nuova etichetta a questa libreria</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="559"/>
+        <location filename="library_window.cpp" line="695"/>
+        <location filename="library_window.cpp" line="1803"/>
         <source>Set as unread</source>
         <translation>Setta come non letto</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2083"/>
         <source>Library not found</source>
         <translation>Libreria non trovata</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="525"/>
         <source>Rename library</source>
         <translation>Rinomina la libreria</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="531"/>
         <source>Remove library</source>
         <translation>Rimuovi la libreria</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="712"/>
         <source>Open containing folder...</source>
         <translation>Apri la cartella dei contenuti...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="804"/>
         <source>Add new label</source>
         <translation>Aggiungi una nuova etichetta</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1636"/>
+        <location filename="library_window.cpp" line="2417"/>
         <source>Unable to delete</source>
         <translation>Non posso cancellare</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source> library?</source>
         <translation> Libreria?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="549"/>
         <source>Save covers of the selected comics as JPG files</source>
         <translation>Salva le copertine dei fumetti selezionati come file JPG</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Are you sure?</source>
         <translation>Sei sicuro?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="565"/>
+        <location filename="library_window.cpp" line="700"/>
+        <location filename="library_window.cpp" line="1806"/>
         <source>Set as manga</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="537"/>
+        <source>Rescan library for XML info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="538"/>
+        <source>Tries to find XML info embedded in comic files. You only need to do this if the library was created with 9.8.2 or earlier versions or if you are using third party software to embed XML info in the files.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="566"/>
         <source>Set issue as manga</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="571"/>
         <source>Set as normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="572"/>
         <source>Set issue as normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="705"/>
+        <location filename="library_window.cpp" line="1809"/>
         <source>Set as comic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="760"/>
+        <source>Focus search line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="766"/>
+        <source>Focus comics view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="777"/>
+        <source>&amp;Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1251"/>
         <source>Upgrade failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1251"/>
         <source>There were errors during library upgrade in: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1993"/>
         <source>YACReader not found. YACReader should be installed in the same folder as YACReaderLibrary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found. There might be a problem with your YACReader installation.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1042,6 +1368,7 @@ YACReader non ti fermerà dal creare altre librerie ma è meglio se terrai il nu
 <context>
     <name>LocalComicListModel</name>
     <message>
+        <location filename="comic_vine/model/local_comic_list_model.cpp" line="72"/>
         <source>file name</source>
         <translation>Nome file</translation>
     </message>
@@ -1049,30 +1376,37 @@ YACReader non ti fermerà dal creare altre librerie ma è meglio se terrai il nu
 <context>
     <name>LogWindow</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="14"/>
         <source>Log window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="22"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="39"/>
         <source>&amp;Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="56"/>
         <source>C&amp;lear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="73"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="90"/>
         <source>Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="136"/>
         <source>&amp;Auto scroll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1080,18 +1414,22 @@ YACReader non ti fermerà dal creare altre librerie ma è meglio se terrai il nu
 <context>
     <name>NoLibrariesWidget</name>
     <message>
+        <location filename="no_libraries_widget.cpp" line="32"/>
         <source>create your first library</source>
         <translation>Crea la tua prima libreria</translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="26"/>
         <source>You don&apos;t have any libraries yet</source>
         <translation>Per ora non hai ancora nessuna libreria</translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="28"/>
         <source>&lt;p&gt;You can create a library in any folder, YACReaderLibrary will import all comics and folders from this folder. If you have created any library in the past you can open them.&lt;/p&gt;&lt;p&gt;Don&apos;t forget that you can use YACReader as a stand alone application for reading the comics on your computer.&lt;/p&gt;</source>
         <translation>&lt;p&gt;Puoi creare una libreria in qualsiasi cartella, YACReader importerà tutti i fumetti e struttura da questa certella. Se hai creato una qualsiasia libreria nel passato la puoi aprire. &lt;/p&gt;&lt;p&gt;Non dimenticare che puoi usare YACReader come applicazione stand alone per leggere i fumetti sul tuo PC.&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="34"/>
         <source>add an existing one</source>
         <translation>Aggiungine una esistente</translation>
     </message>
@@ -1099,70 +1437,87 @@ YACReader non ti fermerà dal creare altre librerie ma è meglio se terrai il nu
 <context>
     <name>OptionsDialog</name>
     <message>
+        <location filename="options_dialog.cpp" line="92"/>
         <source>Restore defautls</source>
         <translation>Resetta al Default</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="103"/>
         <source>Background</source>
         <translation>Sfondo</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="85"/>
         <source>Blur level</source>
         <translation>Livello di sfumatura</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="78"/>
         <source>Enable background image</source>
         <translation>Abilita l&apos;immagine di sfondo</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="156"/>
         <source>Options</source>
         <translation>Opzioni</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="72"/>
         <source>Comic Vine API key</source>
         <translation>API di ComicVine</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="69"/>
         <source>Edit Comic Vine API key</source>
         <translation>Edita l&apos;API di ComicVine</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="80"/>
         <source>Opacity level</source>
         <translation>Livello di opacità</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="148"/>
         <source>General</source>
         <translation>Generale</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="90"/>
         <source>Use selected comic cover as background</source>
         <translation>Usa la cover del fumetto selezionato come sfondo</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="144"/>
         <source>Comic Flow</source>
         <translation>Flusso dei fumetti</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="146"/>
         <source>Grid view</source>
         <translation>Vista a Griglia</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="47"/>
         <source>Tray icon settings (experimental)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="50"/>
         <source>Close to tray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="51"/>
         <source>Start into the system tray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="106"/>
         <source>Display continue reading banner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="111"/>
         <source>Continue reading</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1170,142 +1525,178 @@ YACReader non ti fermerà dal creare altre librerie ma è meglio se terrai il nu
 <context>
     <name>PropertiesDialog</name>
     <message>
+        <location filename="properties_dialog.cpp" line="240"/>
         <source>Day:</source>
         <translation>Giorno:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="85"/>
         <source>Plot</source>
         <translation>Trama</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="177"/>
         <source>Size:</source>
         <translation>Dimesioni:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="248"/>
         <source>Year:</source>
         <translation>Anno:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="207"/>
         <source>Inker(s):</source>
         <translation>Inchiostratore(i):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="84"/>
         <source>Publishing</source>
         <translation>Pubblicazione</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="256"/>
         <source>Publisher:</source>
         <translation>Editore:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="82"/>
         <source>General info</source>
         <translation>Informazioni generali</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="258"/>
         <source>Color/BW:</source>
         <translation>Colore o B/N:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="501"/>
         <source>Edit selected comics information</source>
         <translation>Edita le informazioni del fumetto selezionato</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="200"/>
         <source>Penciller(s):</source>
         <translation>Mine:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="210"/>
         <source>Colorist(s):</source>
         <translation>Colorista(i):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="175"/>
         <source>Genre:</source>
         <translation>Genere:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="158"/>
         <source>Issue number:</source>
         <translation>Numeri emessi:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="244"/>
         <source>Month:</source>
         <translation>Mese:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="275"/>
         <source>Notes:</source>
         <translation>Note:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="273"/>
         <source>Synopsis:</source>
         <translation>Sinossi:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="143"/>
         <source>Title:</source>
         <translation>Titolo:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Not found</source>
         <translation>Non trovato</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="274"/>
         <source>Characters:</source>
         <translation>Personaggi:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="83"/>
         <source>Authors</source>
         <translation>Autori</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="259"/>
         <source>Age rating:</source>
         <translation>Valutazione età:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="173"/>
         <source>Story arc:</source>
         <translation>Arco Narrativo:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="197"/>
         <source>Writer(s):</source>
         <translation>Scrittore(i):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Comic not found. You should update your library.</source>
         <translation>Fumetto non trovato, dovresti aggiornare la Libreria.</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="467"/>
         <source>Edit comic information</source>
         <translation>Edita le informazioni del fumetto</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="94"/>
         <source>Cover page</source>
         <translation>Pagina Copertina</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="220"/>
         <source>Cover Artist(s):</source>
         <translation>Artista(i) copertina:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="369"/>
         <source>Comic Vine link: &lt;a style=&apos;color: #FFCB00; text-decoration:none; font-weight:bold;&apos; href=&quot;http://www.comicvine.com/comic/4000-%1/&quot;&gt; view &lt;/a&gt;</source>
         <translation>Comic Vine link: &lt;a style=&apos;color: #FFCB00; text-decoration:none; font-weight:bold;&apos; href=&quot;http://www.comicvine.com/comic/4000-%1/&quot;&gt; Vai &lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="160"/>
         <source>Volume:</source>
         <translation>Album:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="257"/>
         <source>Format:</source>
         <translation>Formato:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="217"/>
         <source>Letterer(s):</source>
         <translation>Letterista(i):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="151"/>
+        <location filename="properties_dialog.cpp" line="168"/>
         <source>of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="164"/>
         <source>Arc number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="260"/>
         <source>Manga:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1313,34 +1704,42 @@ YACReader non ti fermerà dal creare altre librerie ma è meglio se terrai il nu
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>7z lib not found</source>
         <translation>Libreria 7z non trovata</translation>
     </message>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>unable to load 7z lib from ./utils</source>
         <translation>Impossibile caricare la libreria 7z da ./utils</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41"/>
         <source>Trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45"/>
         <source>Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51"/>
         <source>Fatal</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1348,14 +1747,17 @@ YACReader non ti fermerà dal creare altre librerie ma è meglio se terrai il nu
 <context>
     <name>QsLogging::LogWindowModel</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="141"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="143"/>
         <source>Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="145"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1363,18 +1765,22 @@ YACReader non ti fermerà dal creare altre librerie ma è meglio se terrai il nu
 <context>
     <name>QsLogging::Window</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="236"/>
         <source>Save log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="237"/>
         <source>Log file (*.log)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1382,18 +1788,22 @@ YACReader non ti fermerà dal creare altre librerie ma è meglio se terrai il nu
 <context>
     <name>RenameLibraryDialog</name>
     <message>
+        <location filename="rename_library_dialog.cpp" line="51"/>
         <source>Rename current library</source>
         <translation>Rinomina la libreria corrente</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="24"/>
         <source>Cancel</source>
         <translation>Cancella</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="20"/>
         <source>Rename</source>
         <translation>Rinomina</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="15"/>
         <source>New Library Name : </source>
         <translation>Nome della nuova libreria: </translation>
     </message>
@@ -1401,14 +1811,18 @@ YACReader non ti fermerà dal creare altre librerie ma è meglio se terrai il nu
 <context>
     <name>ScraperResultsPaginator</name>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="54"/>
         <source>Number of %1 found : %2</source>
         <translation>Numero di %1 trovati; %2</translation>
     </message>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="32"/>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="55"/>
         <source>page %1 of %2</source>
         <translation>pagina %1 di %2</translation>
     </message>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="30"/>
         <source>Number of volumes found : %1</source>
         <translation>Numero di volumi trovati: %1</translation>
     </message>
@@ -1416,10 +1830,12 @@ YACReader non ti fermerà dal creare altre librerie ma è meglio se terrai il nu
 <context>
     <name>SearchSingleComic</name>
     <message>
+        <location filename="comic_vine/search_single_comic.cpp" line="14"/>
         <source>Please provide some additional information.</source>
         <translation>Per favore aggiugi informazioni addizionali.</translation>
     </message>
     <message>
+        <location filename="comic_vine/search_single_comic.cpp" line="19"/>
         <source>Series:</source>
         <translation>Serie:</translation>
     </message>
@@ -1427,10 +1843,12 @@ YACReader non ti fermerà dal creare altre librerie ma è meglio se terrai il nu
 <context>
     <name>SearchVolume</name>
     <message>
+        <location filename="comic_vine/search_volume.cpp" line="11"/>
         <source>Please provide some additional information.</source>
         <translation>Per favore aggiugi informazioni addizionali.</translation>
     </message>
     <message>
+        <location filename="comic_vine/search_volume.cpp" line="14"/>
         <source>Series:</source>
         <translation>Serie:</translation>
     </message>
@@ -1438,22 +1856,27 @@ YACReader non ti fermerà dal creare altre librerie ma è meglio se terrai il nu
 <context>
     <name>SelectComic</name>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="95"/>
         <source>loading description</source>
         <translation>Caricamento descrizione</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="38"/>
         <source>comics</source>
         <translation>Fumetti</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="94"/>
         <source>loading cover</source>
         <translation>Caricamento copertine</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="18"/>
         <source>Please, select the right comic info.</source>
         <translation>Per favore seleziona le informazioni corrette per il fumetto.</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="135"/>
         <source>description unavailable</source>
         <translation>Descrizione non disponibile</translation>
     </message>
@@ -1461,22 +1884,37 @@ YACReader non ti fermerà dal creare altre librerie ma è meglio se terrai il nu
 <context>
     <name>SelectVolume</name>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="145"/>
         <source>loading description</source>
         <translation>Caricamento descrizione</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="35"/>
         <source>Please, select the right series for your comic.</source>
         <translation>Per favore seleziona la serie corretta per il fumetto.</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="56"/>
+        <source>Filter:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="138"/>
+        <source>Nothing found, clear the filter if any.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="144"/>
         <source>loading cover</source>
         <translation>Caricamento copertine</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="68"/>
         <source>volumes</source>
         <translation>Volumi</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="185"/>
         <source>description unavailable</source>
         <translation>Descrizione non disponibile</translation>
     </message>
@@ -1484,14 +1922,17 @@ YACReader non ti fermerà dal creare altre librerie ma è meglio se terrai il nu
 <context>
     <name>SeriesQuestion</name>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="15"/>
         <source>no</source>
         <translation>No</translation>
     </message>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="14"/>
         <source>yes</source>
         <translation>Si</translation>
     </message>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="12"/>
         <source>You are trying to get information for various comics at once, are they part of the same series?</source>
         <translation>Stai cercando di recuperare informazioni per diversi fumetti in una sola volta, sono parte della stessa serie?</translation>
     </message>
@@ -1499,28 +1940,34 @@ YACReader non ti fermerà dal creare altre librerie ma è meglio se terrai il nu
 <context>
     <name>ServerConfigDialog</name>
     <message>
+        <location filename="server_config_dialog.cpp" line="115"/>
         <source>Port</source>
         <translation>Porta</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="102"/>
         <source>YACReader is available for iOS devices. &lt;a href=&apos;http://ios.yacreader.com&apos; style=&apos;color:rgb(193, 148, 65)&apos;&gt; Discover it! &lt;/a&gt;</source>
         <translation>YACReader è disponibile per dispositivi iOS. &lt;a href=&apos;http://ios.yacreader.com&apos; style=&apos;color:rgb(193, 148, 65)&apos;&gt; Provalo! &lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="147"/>
         <source>enable the server</source>
         <translation>Abilita il server</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="92"/>
         <source>Server connectivity information</source>
         <translation>Informazioni sulla connettività del server</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="152"/>
         <source>display less information about folders in the browser
 to improve the performance</source>
         <translation>Mostra meno informazioni sulle cartelle nel Browser.
 Migliora le prestazioni!</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="96"/>
         <source>Scan it!</source>
         <translation>Scansiona!</translation>
     </message>
@@ -1529,14 +1976,17 @@ Migliora le prestazioni!</translation>
         <translation type="vanished">Errore nel generatore QR!</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="86"/>
         <source>set port</source>
         <translation>Configura porta</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="111"/>
         <source>Choose an IP address</source>
         <translation>Scegli un indirizzo IP</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="268"/>
         <source>Could not load libqrencode.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1544,22 +1994,27 @@ Migliora le prestazioni!</translation>
 <context>
     <name>SortVolumeComics</name>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="87"/>
         <source>remove selected comics</source>
         <translation>Rimuovi i fumetti selezionati</translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="21"/>
         <source>sort comics to match comic information</source>
         <translation>Ordina i fumetti per far corrispondere le informazioni</translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="88"/>
         <source>restore all removed comics</source>
         <translation>Ripristina tutti i fumetti rimossi</translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="58"/>
         <source>issues</source>
         <translation>Emissione</translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="18"/>
         <source>Please, sort the list of comics on the left until it matches the comics&apos; information.</source>
         <translation>Per favore ordina la lista dei fumetti a sinistra sino a che corrisponde alle informazioni dei fumetti.</translation>
     </message>
@@ -1571,6 +2026,7 @@ Migliora le prestazioni!</translation>
 <context>
     <name>TitleHeader</name>
     <message>
+        <location filename="comic_vine/title_header.cpp" line="30"/>
         <source>SEARCH</source>
         <translation>CERCA</translation>
     </message>
@@ -1578,14 +2034,17 @@ Migliora le prestazioni!</translation>
 <context>
     <name>UpdateLibraryDialog</name>
     <message>
+        <location filename="create_library_dialog.cpp" line="180"/>
         <source>Update library</source>
         <translation>Aggiorna Libreria</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="161"/>
         <source>Cancel</source>
         <translation>Cancella</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="155"/>
         <source>Updating....</source>
         <translation>Aggiornamento...</translation>
     </message>
@@ -1593,6 +2052,7 @@ Migliora le prestazioni!</translation>
 <context>
     <name>VolumeComicsModel</name>
     <message>
+        <location filename="comic_vine/model/volume_comics_model.cpp" line="120"/>
         <source>title</source>
         <translation>Titolo</translation>
     </message>
@@ -1600,14 +2060,17 @@ Migliora le prestazioni!</translation>
 <context>
     <name>VolumesModel</name>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="118"/>
         <source>year</source>
         <translation>Anno</translation>
     </message>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="120"/>
         <source>issues</source>
         <translation>Emissione</translation>
     </message>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="122"/>
         <source>publisher</source>
         <translation>Pubblicato da</translation>
     </message>
@@ -1615,18 +2078,17 @@ Migliora le prestazioni!</translation>
 <context>
     <name>YACReader::TrayIconController</name>
     <message>
+        <location filename="trayicon_controller.cpp" line="52"/>
         <source>&amp;Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Quit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="trayicon_controller.cpp" line="79"/>
         <source>Systray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="trayicon_controller.cpp" line="80"/>
         <source>YACReaderLibrary will keep running in the system tray. To terminate the program, choose &lt;b&gt;Quit&lt;/b&gt; in the context menu of the system tray icon.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1634,6 +2096,7 @@ Migliora le prestazioni!</translation>
 <context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1641,10 +2104,12 @@ Migliora le prestazioni!</translation>
 <context>
     <name>YACReaderDeletingProgress</name>
     <message>
+        <location filename="../custom_widgets/yacreader_deleting_progress.cpp" line="35"/>
         <source>cancel</source>
         <translation>Cancella</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_deleting_progress.cpp" line="20"/>
         <source>Please wait, deleting in progress...</source>
         <translation>Aspetta, cancellazione in corso...</translation>
     </message>
@@ -1652,10 +2117,13 @@ Migliora le prestazioni!</translation>
 <context>
     <name>YACReaderFieldEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11"/>
         <source>Restore to default</source>
         <translation>Resetta al Default</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28"/>
         <source>Click to overwrite</source>
         <translation>Clikka per sovrascrivere</translation>
     </message>
@@ -1663,10 +2131,15 @@ Migliora le prestazioni!</translation>
 <context>
     <name>YACReaderFieldPlainTextEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10"/>
         <source>Restore to default</source>
         <translation>Resetta al Default</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50"/>
         <source>Click to overwrite</source>
         <translation>Clikka per sovrascrivere</translation>
     </message>
@@ -1674,18 +2147,22 @@ Migliora le prestazioni!</translation>
 <context>
     <name>YACReaderFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="15"/>
         <source>CoverFlow look</source>
         <translation>Aspetto del flusso copertine</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="13"/>
         <source>How to show covers:</source>
         <translation>Come mostrare le copertine:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="16"/>
         <source>Stripe look</source>
         <translation>Aspetto a striscia</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="17"/>
         <source>Overlapped Stripe look</source>
         <translation>Aspetto a striscia sovrapposta</translation>
     </message>
@@ -1693,94 +2170,117 @@ Migliora le prestazioni!</translation>
 <context>
     <name>YACReaderGLFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="112"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="142"/>
         <source>Light</source>
         <translation>Luminoso</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="76"/>
         <source>Show advanced settings</source>
         <translation>Mostra le impostazioni avanzate</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="32"/>
         <source>Roulette look</source>
         <translation>Aspetto a Roulette</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="130"/>
         <source>Cover Angle</source>
         <translation>Angolo copertine</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="23"/>
         <source>Stripe look</source>
         <translation>Aspetto a striscia</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="94"/>
         <source>Position</source>
         <translation>Posizione</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="124"/>
         <source>Z offset</source>
         <translation>Traslazione Z</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="118"/>
         <source>Y offset</source>
         <translation>Traslazione Y</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="106"/>
         <source>Central gap</source>
         <translation>Distanza centrale</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="18"/>
         <source>Presets:</source>
         <translation>Preselezione:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="26"/>
         <source>Overlapped Stripe look</source>
         <translation>Aspetto a Striscia sovrapposto</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="29"/>
         <source>Modern look</source>
         <translation>Aspetto moderno</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="88"/>
         <source>View angle</source>
         <translation>Vista ad Angolo</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="148"/>
         <source>Max angle</source>
         <translation>Angolo massimo</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="85"/>
         <source>Custom:</source>
         <translation>Personalizza:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="20"/>
         <source>Classic look</source>
         <translation>Aspetto Classico</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="100"/>
         <source>Cover gap</source>
         <translation>Distanza tra le Cover</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="182"/>
         <source>High Performance</source>
         <translation>Alte Prestazioni</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="201"/>
         <source>Performance:</source>
         <translation>Prestazioni:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="193"/>
         <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
         <translation>UIsa VSync. (Migliora la qualità dell&apos;immagine a modalità tutto schermo, peggiora le prestazioni)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="136"/>
         <source>Visibility</source>
         <translation>Visibilità</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="180"/>
         <source>Low Performance</source>
         <translation>Basse Prestazioni</translation>
     </message>
@@ -1788,10 +2288,12 @@ Migliora le prestazioni!</translation>
 <context>
     <name>YACReaderNavigationController</name>
     <message>
+        <location filename="yacreader_navigation_controller.cpp" line="127"/>
         <source>You are not reading anything yet, come on!!</source>
         <translation>Non stai ancora leggendo nulla, Forza!!</translation>
     </message>
     <message>
+        <location filename="yacreader_navigation_controller.cpp" line="123"/>
         <source>No favorites</source>
         <translation>Nessun Favorito</translation>
     </message>
@@ -1799,22 +2301,27 @@ Migliora le prestazioni!</translation>
 <context>
     <name>YACReaderOptionsDialog</name>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28"/>
         <source>Save</source>
         <translation>Salva</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="46"/>
         <source>Use hardware acceleration (restart needed)</source>
         <translation>Usa accelerazione hardware (necessita riavvio)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="29"/>
         <source>Cancel</source>
         <translation>Cancella</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="37"/>
         <source>Shortcuts</source>
         <translation>Scorciatoie</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="34"/>
         <source>Edit shortcuts</source>
         <translation>Modifica scorciatoia</translation>
     </message>
@@ -1822,6 +2329,7 @@ Migliora le prestazioni!</translation>
 <context>
     <name>YACReaderSearchLineEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_search_line_edit.cpp" line="68"/>
         <source>type to search</source>
         <translation>Digita per cercare</translation>
     </message>
@@ -1829,26 +2337,32 @@ Migliora le prestazioni!</translation>
 <context>
     <name>YACReaderSideBar</name>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="29"/>
         <source>Reading Lists</source>
         <translation>Lista di lettura</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="31"/>
         <source>LIBRARIES</source>
         <translation>LIBRERIE</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="27"/>
         <source>Libraries</source>
         <translation>Librerie</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="32"/>
         <source>FOLDERS</source>
         <translation>CARTELLE</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="28"/>
         <source>Folders</source>
         <translation>Cartelle</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="33"/>
         <source>READING LISTS</source>
         <translation>LISTA DI LETTURA</translation>
     </message>

--- a/YACReaderLibrary/yacreaderlibrary_nl.ts
+++ b/YACReaderLibrary/yacreaderlibrary_nl.ts
@@ -4,6 +4,7 @@
 <context>
     <name>ActionsShortcutsModel</name>
     <message>
+        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="73"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11,66 +12,82 @@
 <context>
     <name>AddLabelDialog</name>
     <message>
+        <location filename="add_label_dialog.cpp" line="37"/>
         <source>cancel</source>
         <translation>annuleren</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="8"/>
         <source>Label name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="11"/>
         <source>Choose a color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="14"/>
         <source>red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="15"/>
         <source>orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="16"/>
         <source>yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="17"/>
         <source>green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="18"/>
         <source>cyan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="19"/>
         <source>blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="20"/>
         <source>violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="21"/>
         <source>purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="22"/>
         <source>pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="23"/>
         <source>white</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="24"/>
         <source>light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="25"/>
         <source>dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="36"/>
         <source>accept</source>
         <translation type="unfinished"></translation>
     </message>
@@ -78,22 +95,27 @@
 <context>
     <name>AddLibraryDialog</name>
     <message>
+        <location filename="add_library_dialog.cpp" line="26"/>
         <source>Add</source>
         <translation>Toevoegen</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="66"/>
         <source>Add an existing library</source>
         <translation>Voeg een bestaand bibliotheek toe</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="30"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="16"/>
         <source>Comics folder : </source>
         <translation>Strips map:</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="21"/>
         <source>Library name : </source>
         <translation>Bibliotheek Naam :</translation>
     </message>
@@ -101,18 +123,22 @@
 <context>
     <name>ApiKeyDialog</name>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="32"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="21"/>
         <source>Before you can connect to Comic Vine, you need your own API key. Please, get one free &lt;a href=&quot;http://www.comicvine.com/api/&quot;&gt;here&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="25"/>
         <source>Paste here your Comic Vine API key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="28"/>
         <source>Accept</source>
         <translation type="unfinished"></translation>
     </message>
@@ -120,6 +146,7 @@
 <context>
     <name>ClassicComicsView</name>
     <message>
+        <location filename="classic_comics_view.cpp" line="90"/>
         <source>Hide comic flow</source>
         <translation>Sluit de Omslagbrowser</translation>
     </message>
@@ -127,46 +154,57 @@
 <context>
     <name>ComicInfoView</name>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="279"/>
         <source>Authors</source>
         <translation>Auteurs</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="309"/>
         <source>writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="331"/>
         <source>penciller</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="353"/>
         <source>inker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="375"/>
         <source>colorist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="397"/>
         <source>letterer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="419"/>
         <source>cover artist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="434"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
         <source>color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
         <source>b/w</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="502"/>
         <source>Characters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,38 +212,52 @@
 <context>
     <name>ComicModel</name>
     <message>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>no</source>
         <translation>neen</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>yes</source>
         <translation>Ja</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="351"/>
         <source>Read</source>
         <translation>Gelezen</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="349"/>
         <source>Size</source>
         <translation>Grootte(MB)</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="347"/>
         <source>Pages</source>
         <translation>Pagina&apos;s</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="343"/>
         <source>Title</source>
         <translation>Titel</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="345"/>
         <source>File Name</source>
         <translation>Bestandsnaam</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="353"/>
         <source>Current Page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="355"/>
+        <source>Publication Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="357"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
@@ -213,50 +265,67 @@
 <context>
     <name>ComicVineDialog</name>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="57"/>
         <source>skip</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="58"/>
         <source>back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="59"/>
         <source>next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="60"/>
         <source>search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="61"/>
         <source>close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="143"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="257"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="773"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="807"/>
         <source>Looking for volume...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="141"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="735"/>
         <source>comic %1 of %2 - %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="262"/>
         <source>%1 comics selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="295"/>
         <source>Error connecting to ComicVine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="467"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="503"/>
         <source>Retrieving tags for : %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="788"/>
         <source>Retrieving volume info...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="814"/>
         <source>Looking for comic...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -264,34 +333,42 @@
 <context>
     <name>CreateLibraryDialog</name>
     <message>
+        <location filename="create_library_dialog.cpp" line="75"/>
         <source>Create new library</source>
         <translation>Een nieuwe Bibliotheek aanmaken</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="31"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="27"/>
         <source>Create</source>
         <translation>Aanmaken</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="53"/>
         <source>Create a library could take several minutes. You can stop the process and update the library later for completing the task.</source>
         <translation>Een bibliotheek aanmaken kan enkele minuten duren. U kunt het proces stoppen en de bibliotheek later voltooien.</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="95"/>
         <source>The selected path does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation>De geselecteerde pad bestaat niet of is geen geldig pad. Controleer of u schrijftoegang hebt tot deze map</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="17"/>
         <source>Comics folder : </source>
         <translation>Strips map:</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="22"/>
         <source>Library Name : </source>
         <translation>Bibliotheek Naam :</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="95"/>
         <source>Path not found</source>
         <translation>Pad niet gevonden </translation>
     </message>
@@ -299,22 +376,27 @@
 <context>
     <name>EditShortcutsDialog</name>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="21"/>
         <source>Restore defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="22"/>
         <source>To change a shortcut, double click in the key combination and type the new keys.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="69"/>
         <source>Shortcuts settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>Shortcut in use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>The shortcut &quot;%1&quot; is already assigned to other function</source>
         <translation type="unfinished"></translation>
     </message>
@@ -322,14 +404,18 @@
 <context>
     <name>EmptyFolderWidget</name>
     <message>
+        <location filename="empty_folder_widget.cpp" line="75"/>
+        <location filename="empty_folder_widget.cpp" line="140"/>
         <source>Subfolders in this folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="empty_folder_widget.cpp" line="138"/>
         <source>Empty folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="empty_folder_widget.cpp" line="138"/>
         <source>Drag and drop folders and comics here</source>
         <translation type="unfinished"></translation>
     </message>
@@ -337,6 +423,7 @@
 <context>
     <name>EmptyLabelWidget</name>
     <message>
+        <location filename="empty_label_widget.cpp" line="11"/>
         <source>This label doesn&apos;t contain comics yet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -344,6 +431,7 @@
 <context>
     <name>EmptyReadingListWidget</name>
     <message>
+        <location filename="empty_reading_list_widget.cpp" line="8"/>
         <source>This reading list does not contain any comics yet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -351,30 +439,37 @@
 <context>
     <name>ExportComicsInfoDialog</name>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="14"/>
         <source>Output file : </source>
         <translation>Uitvoerbestand:</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="66"/>
         <source>Destination database name</source>
         <translation>Bestemmingsdatabase naam</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="22"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="18"/>
         <source>Create</source>
         <translation>Aanmaken</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="81"/>
         <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation>Het gekozen pad voor het uitvoerbestand bestaat niet of is geen geldig pad. Controleer of u schrijftoegang hebt tot deze map</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="57"/>
         <source>Export comics info</source>
         <translation>Strip info exporteren </translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="81"/>
         <source>Problem found while writing</source>
         <translation>Probleem bij het schrijven</translation>
     </message>
@@ -382,30 +477,37 @@
 <context>
     <name>ExportLibraryDialog</name>
     <message>
+        <location filename="export_library_dialog.cpp" line="19"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="15"/>
         <source>Create</source>
         <translation>Aanmaken</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="71"/>
         <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation>Het gekozen pad voor het uitvoerbestand bestaat niet of is geen geldig pad. Controleer of u schrijftoegang hebt tot deze map</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="11"/>
         <source>Output folder : </source>
         <translation>Uitvoermap :</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="71"/>
         <source>Problem found while writing</source>
         <translation>Probleem bij het schrijven</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="60"/>
         <source>Create covers package</source>
         <translation>Aanmaken omslag pakket</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="76"/>
         <source>Destination directory</source>
         <translation>Doeldirectory</translation>
     </message>
@@ -413,25 +515,46 @@
 <context>
     <name>FileComic</name>
     <message>
+        <location filename="../common/comic.cpp" line="562"/>
         <source>7z not found</source>
         <translation>7Z Archiefbestand niet gevonden</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="454"/>
         <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="461"/>
         <source>Unknown error opening the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="568"/>
         <source>Format not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FolderContentView</name>
+    <message>
+        <location filename="qml/FolderContentView.qml" line="238"/>
+        <source>Continue Reading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FolderContentView6</name>
+    <message>
+        <location filename="qml/FolderContentView6.qml" line="240"/>
+        <source>Continue Reading...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>GridComicsView</name>
     <message>
+        <location filename="grid_comics_view.cpp" line="147"/>
         <source>Show info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -439,10 +562,17 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Help</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
+        <source>System info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation>Over</translation>
     </message>
@@ -450,22 +580,27 @@
 <context>
     <name>ImportComicsInfoDialog</name>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="24"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="20"/>
         <source>Import</source>
         <translation>Importeren</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="16"/>
         <source>Info database location : </source>
         <translation>Info database locatie :</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="14"/>
         <source>Import comics info</source>
         <translation>Strip info Importeren</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="74"/>
         <source>Comics info file (*.ydb)</source>
         <translation>Strips info bestand ( * .ydb)</translation>
     </message>
@@ -473,30 +608,37 @@
 <context>
     <name>ImportLibraryDialog</name>
     <message>
+        <location filename="import_library_dialog.cpp" line="26"/>
         <source>Destination folder : </source>
         <translation>Doelmap:</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="34"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="30"/>
         <source>Unpack</source>
         <translation>Uitpakken</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="108"/>
         <source>Compresed library covers (*.clc)</source>
         <translation>Compresed omslag- bibliotheek ( * .clc)</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="22"/>
         <source>Package location : </source>
         <translation>Arrangement locatie :</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="17"/>
         <source>Library Name : </source>
         <translation>Bibliotheek Naam :</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="87"/>
         <source>Extract a catalog</source>
         <translation>Een catalogus uitpakken</translation>
     </message>
@@ -504,481 +646,656 @@
 <context>
     <name>ImportWidget</name>
     <message>
+        <location filename="import_widget.cpp" line="150"/>
         <source>stop</source>
         <translation>stop</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="334"/>
         <source>Importing comics</source>
         <translation>Strips importeren</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="335"/>
         <source>&lt;p&gt;YACReaderLibrary is now creating a new library.&lt;/p&gt;&lt;p&gt;Create a library could take several minutes. You can stop the process and update the library later for completing the task.&lt;/p&gt;</source>
         <translation>&lt;P&gt;YACReaderLibrary maak nu een nieuwe bibliotheek. &lt; /p&gt; &lt;p&gt;Een bibliotheek aanmaken kan enkele minuten duren. U kunt het proces stoppen en de bibliotheek later voltooien. &lt; /p&gt;</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="190"/>
         <source>Some of the comics being added...</source>
         <translation>Enkele strips zijn toegevoegd ...</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="346"/>
         <source>Updating the library</source>
         <translation>Actualisering van de bibliotheek</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="347"/>
         <source>&lt;p&gt;The current library is being updated. For faster updates, please, update your libraries frequently.&lt;/p&gt;&lt;p&gt;You can stop the process and continue updating this library later.&lt;/p&gt;</source>
         <translation>&lt;P&gt;De huidige bibliotheek wordt bijgewerkt. Voor snellere updates, update uw bibliotheken regelmatig. &lt; /p&gt; &lt;p&gt;u kunt het proces stoppen om later bij te werken. &lt; /p&gt;</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="358"/>
         <source>Upgrading the library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="359"/>
         <source>&lt;p&gt;The current library is being upgraded, please wait.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="370"/>
+        <source>Scanning the library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="371"/>
+        <source>&lt;p&gt;Current library is being scanned for legacy XML metadata information.&lt;/p&gt;&lt;p&gt;This is only needed once, and only if the library was crated with YACReaderLibrary 9.8.2 or earlier.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LibraryWindow</name>
     <message>
+        <location filename="library_window.cpp" line="730"/>
         <source>Edit</source>
         <translation>Bewerken</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2083"/>
         <source>The selected folder doesn&apos;t contain any library.</source>
         <translation>De geselecteerde map bevat geen bibliotheek.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1269"/>
         <source>This library was created with a previous version of YACReaderLibrary. It needs to be updated. Update now?</source>
         <translation>Deze bibliotheek is gemaakt met een vorige versie van YACReaderLibrary. Het moet worden bijgewerkt. Nu bijwerken?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2659"/>
         <source>Error opening the library</source>
         <translation>Fout bij openen Bibliotheek</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="585"/>
         <source>Show/Hide marks</source>
         <translation>Toon/Verberg markeringen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="648"/>
         <source>Show comics server options dialog</source>
         <translation>Toon strips-server opties dialoog</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="532"/>
         <source>Remove current library from your collection</source>
         <translation>De huidige Bibliotheek verwijderen uit uw verzameling</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="554"/>
         <source>Set comic as read</source>
         <translation>Strip Instellen als gelezen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2139"/>
         <source>Remove and delete metadata</source>
         <translation>Verwijder  metagegevens </translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Old library</source>
         <translation>Oude Bibliotheek </translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="742"/>
         <source>Update cover</source>
         <translation>Strip omslagen bijwerken</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1027"/>
         <source>Library</source>
         <translation>Bibliotheek</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="526"/>
         <source>Rename current library</source>
         <translation>Huidige Bibliotheek hernoemen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="593"/>
+        <location filename="library_window.cpp" line="594"/>
         <source>Fullscreen mode on/off</source>
         <translation>Volledig scherm modus aan/of</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1336"/>
         <source>This library was created with a newer version of YACReaderLibrary. Download the new version now?</source>
         <translation>Deze bibliotheek is gemaakt met een nieuwere versie van YACReaderLibrary. Download de nieuwe versie?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="543"/>
         <source>Open current comic on YACReader</source>
         <translation>Huidige strip openen in YACReader</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="520"/>
         <source>Update current library</source>
         <translation>Huidige Bibliotheek bijwerken</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library &apos;%1&apos; is no longer available. Do you want to remove it?</source>
         <translation>Bibliotheek &apos; %1&apos; is niet langer beschikbaar. Wilt u het verwijderen?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="519"/>
         <source>Update library</source>
         <translation>Bibliotheek bijwerken</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="674"/>
+        <location filename="library_window.cpp" line="1787"/>
         <source>Open folder...</source>
         <translation>Map openen ...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Do you want remove </source>
         <translation>Wilt u verwijderen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2654"/>
         <source>Error updating the library</source>
         <translation>Fout bij bijwerken Bibliotheek</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="628"/>
         <source>Expand all nodes</source>
         <translation>Alle categorieën uitklappen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Library &apos;%1&apos; has been created with an older version of YACReaderLibrary. It must be created again. Do you want to create the library now?</source>
         <translation>Bibliotheek &apos; %1&apos; is gemaakt met een oudere versie van YACReaderLibrary. Zij moet opnieuw worden aangemaakt. Wilt u de bibliotheek nu aanmaken?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="507"/>
         <source>Pack covers</source>
         <translation>Inpakken strip voorbladen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="553"/>
+        <location filename="library_window.cpp" line="690"/>
+        <location filename="library_window.cpp" line="1800"/>
         <source>Set as read</source>
         <translation>Instellen als gelezen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="748"/>
         <source>Delete selected comics</source>
         <translation>Geselecteerde strips verwijderen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="495"/>
+        <location filename="library_window.cpp" line="496"/>
         <source>Export comics info</source>
         <translation>Exporteren van strip info</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="640"/>
         <source>Show options dialog</source>
         <translation>Toon opties dialoog</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="484"/>
         <source>Create a new library</source>
         <translation>Maak een nieuwe Bibliotheek </translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library not available</source>
         <translation>Bibliotheek niet beschikbaar </translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="501"/>
+        <location filename="library_window.cpp" line="502"/>
         <source>Import comics info</source>
         <translation>Importeren van strip info</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="542"/>
         <source>Open current comic</source>
         <translation>Huidige strip openen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="188"/>
         <source>YACReader Library</source>
         <translation>YACReader Bibliotheek</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2649"/>
         <source>Error creating the library</source>
         <translation>Fout bij aanmaken Bibliotheek</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="513"/>
         <source>Unpack covers</source>
         <translation>Uitpakken voorbladen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1269"/>
         <source>Update needed</source>
         <translation>Bijwerken is nodig</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="490"/>
         <source>Open an existing library</source>
         <translation>Open een bestaande Bibliotheek</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2805"/>
         <source>Library name already exists</source>
         <translation>Bibliotheek naam bestaat al</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2805"/>
         <source>There is another library with the name &apos;%1&apos;.</source>
         <translation>Er is al een bibliotheek met de naam &apos; %1 &apos;.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1336"/>
         <source>Download new version</source>
         <translation>Nieuwe versie ophalen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2694"/>
         <source>Delete comics</source>
         <translation>Strips verwijderen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="724"/>
         <source>Select all comics</source>
         <translation>Selecteer alle strips</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="508"/>
         <source>Pack the covers of the selected library</source>
         <translation>Inpakken alle strip voorbladen  van de geselecteerde Bibliotheek</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="602"/>
         <source>Help, About YACReader</source>
         <translation>Help, Over YACReader</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="560"/>
         <source>Set comic as unread</source>
         <translation>Strip Instellen als ongelezen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="624"/>
         <source>Select root node</source>
         <translation>Selecteer de hoofd categorie</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="514"/>
         <source>Unpack a catalog</source>
         <translation>Uitpaken van een catalogus</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2694"/>
         <source>All the selected comics will be deleted from your disk. Are you sure?</source>
         <translation>Alle geselecteerde strips worden verwijderd van uw schijf. Weet u het zeker?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="559"/>
+        <location filename="library_window.cpp" line="695"/>
+        <location filename="library_window.cpp" line="1803"/>
         <source>Set as unread</source>
         <translation>Instellen als ongelezen </translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2083"/>
         <source>Library not found</source>
         <translation>Bibliotheek niet gevonden</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="525"/>
         <source>Rename library</source>
         <translation>Bibliotheek hernoemen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="531"/>
         <source>Remove library</source>
         <translation>Bibliotheek verwijderen</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="712"/>
         <source>Open containing folder...</source>
         <translation>Open map ...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source> library?</source>
         <translation>Bibliotheek?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Are you sure?</source>
         <translation>Weet u het zeker?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="548"/>
         <source>Save selected covers to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="537"/>
+        <source>Rescan library for XML info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="538"/>
+        <source>Tries to find XML info embedded in comic files. You only need to do this if the library was created with 9.8.2 or earlier versions or if you are using third party software to embed XML info in the files.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="549"/>
         <source>Save covers of the selected comics as JPG files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="565"/>
+        <location filename="library_window.cpp" line="700"/>
+        <location filename="library_window.cpp" line="1806"/>
         <source>Set as manga</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="566"/>
         <source>Set issue as manga</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="571"/>
         <source>Set as normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="572"/>
         <source>Set issue as normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="586"/>
         <source>Show or hide read marks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="609"/>
+        <location filename="library_window.cpp" line="1574"/>
         <source>Add new folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="612"/>
         <source>Add new folder to the current library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="615"/>
+        <location filename="library_window.cpp" line="1610"/>
         <source>Delete folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="618"/>
         <source>Delete current folder from disk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="634"/>
         <source>Collapse all nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="655"/>
+        <location filename="library_window.cpp" line="656"/>
         <source>Change between comics views</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="680"/>
+        <location filename="library_window.cpp" line="1794"/>
         <source>Set as uncompleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="685"/>
+        <location filename="library_window.cpp" line="1797"/>
         <source>Set as completed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="705"/>
+        <location filename="library_window.cpp" line="1809"/>
         <source>Set as comic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="718"/>
         <source>Reset comic rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="736"/>
         <source>Assign current order to comics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="756"/>
         <source>Download tags from Comic Vine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="760"/>
+        <source>Focus search line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="766"/>
+        <source>Focus comics view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="771"/>
         <source>Edit shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="777"/>
+        <source>&amp;Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="784"/>
+        <location filename="library_window.cpp" line="1790"/>
         <source>Update folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="787"/>
         <source>Update current folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="792"/>
         <source>Add new reading list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="795"/>
         <source>Add a new reading list to the current library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="798"/>
         <source>Remove reading list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="801"/>
         <source>Remove current reading list from the library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="804"/>
         <source>Add new label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="807"/>
         <source>Add a new label to this library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="810"/>
         <source>Rename selected list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="813"/>
         <source>Rename any selected labels or lists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="817"/>
         <source>Add to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="819"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="822"/>
         <source>Add selected comics to favorites list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1046"/>
         <source>Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1060"/>
         <source>Comic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1251"/>
         <source>Upgrade failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1251"/>
         <source>There were errors during library upgrade in: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1409"/>
+        <location filename="library_window.cpp" line="1445"/>
         <source>Copying comics...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1426"/>
+        <location filename="library_window.cpp" line="1464"/>
         <source>Moving comics...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1575"/>
         <source>Folder name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1604"/>
         <source>No folder selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1604"/>
         <source>Please, select a folder first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1608"/>
         <source>Error in path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1608"/>
         <source>There was an error accessing the folder&apos;s path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1610"/>
         <source>The selected folder and all its contents will be deleted from your disk. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1636"/>
+        <location filename="library_window.cpp" line="2417"/>
         <source>Unable to delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1636"/>
         <source>There was an issue trying to delete the selected folders. Please, check for write permissions and be sure that any applications are using these folders or any of the contained files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1648"/>
         <source>Add new reading lists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1649"/>
+        <location filename="library_window.cpp" line="1698"/>
         <source>List name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1667"/>
         <source>Delete list/label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1667"/>
         <source>The selected item will be deleted, your comics or folders will NOT be deleted from your disk. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1697"/>
         <source>Rename list name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1916"/>
         <source>Save covers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.
 
 You probably only need one library in your top level comics folder, you can browse any subfolders using the folders section in the left sidebar.
@@ -987,34 +1304,43 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1993"/>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1993"/>
         <source>YACReader not found. YACReader should be installed in the same folder as YACReaderLibrary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found. There might be a problem with your YACReader installation.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2417"/>
         <source>There was an issue trying to delete the selected comics. Please, check for write permissions in the selected files or containing folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2448"/>
         <source>Assign comics numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2449"/>
         <source>Assign numbers starting in:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Remove comics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Comics will only be deleted from the current label/list. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1022,6 +1348,7 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>LocalComicListModel</name>
     <message>
+        <location filename="comic_vine/model/local_comic_list_model.cpp" line="72"/>
         <source>file name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1029,30 +1356,37 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>LogWindow</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="14"/>
         <source>Log window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="22"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="39"/>
         <source>&amp;Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="56"/>
         <source>C&amp;lear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="73"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="90"/>
         <source>Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="136"/>
         <source>&amp;Auto scroll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1060,18 +1394,22 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>NoLibrariesWidget</name>
     <message>
+        <location filename="no_libraries_widget.cpp" line="32"/>
         <source>create your first library</source>
         <translation>Maak uw eerste bibliotheek</translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="26"/>
         <source>You don&apos;t have any libraries yet</source>
         <translation>Je hebt geen nog libraries</translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="28"/>
         <source>&lt;p&gt;You can create a library in any folder, YACReaderLibrary will import all comics and folders from this folder. If you have created any library in the past you can open them.&lt;/p&gt;&lt;p&gt;Don&apos;t forget that you can use YACReader as a stand alone application for reading the comics on your computer.&lt;/p&gt;</source>
         <translation>&lt;P&gt;u kunt een bibliotheek maken in een willekeurige map, YACReaderLibrary importeert alle strips en mappen uit deze map. Alle bibliotheek aangemaakt in het verleden kan je openen. &lt; /p&gt; &lt;p&gt;vergeet niet dat u YACReader kan gebruiken als stand-alone applicatie voor het lezen van de strips op de computer. &lt; /p&gt;</translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="34"/>
         <source>add an existing one</source>
         <translation>voeg een bestaande bibliotheek toe</translation>
     </message>
@@ -1079,70 +1417,87 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>OptionsDialog</name>
     <message>
+        <location filename="options_dialog.cpp" line="156"/>
         <source>Options</source>
         <translation>Opties</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="47"/>
         <source>Tray icon settings (experimental)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="50"/>
         <source>Close to tray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="51"/>
         <source>Start into the system tray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="69"/>
         <source>Edit Comic Vine API key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="72"/>
         <source>Comic Vine API key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="78"/>
         <source>Enable background image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="80"/>
         <source>Opacity level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="85"/>
         <source>Blur level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="90"/>
         <source>Use selected comic cover as background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="92"/>
         <source>Restore defautls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="103"/>
         <source>Background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="106"/>
         <source>Display continue reading banner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="111"/>
         <source>Continue reading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="144"/>
         <source>Comic Flow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="146"/>
         <source>Grid view</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="148"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1150,142 +1505,178 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>PropertiesDialog</name>
     <message>
+        <location filename="properties_dialog.cpp" line="240"/>
         <source>Day:</source>
         <translation>Dag:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="85"/>
         <source>Plot</source>
         <translation>Verhaal</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="177"/>
         <source>Size:</source>
         <translation>Grootte(MB):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="248"/>
         <source>Year:</source>
         <translation>Jaar:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="207"/>
         <source>Inker(s):</source>
         <translation>Inker(s):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="84"/>
         <source>Publishing</source>
         <translation>Uitgever</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="256"/>
         <source>Publisher:</source>
         <translation>Uitgever:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="82"/>
         <source>General info</source>
         <translation>Algemene Info</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="258"/>
         <source>Color/BW:</source>
         <translation>Kleur/ZW:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="501"/>
         <source>Edit selected comics information</source>
         <translation>Geselecteerde strip informatie bijwerken</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="200"/>
         <source>Penciller(s):</source>
         <translation>Tekenaar(s):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="210"/>
         <source>Colorist(s):</source>
         <translation>Inkleurder(s):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="175"/>
         <source>Genre:</source>
         <translation>Genre:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="158"/>
         <source>Issue number:</source>
         <translation>Ids:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="244"/>
         <source>Month:</source>
         <translation>Maand:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="275"/>
         <source>Notes:</source>
         <translation>Opmerkingen:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="273"/>
         <source>Synopsis:</source>
         <translation>Synopsis:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="143"/>
         <source>Title:</source>
         <translation>Titel:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Not found</source>
         <translation>Niet gevonden</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="274"/>
         <source>Characters:</source>
         <translation>Personages:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="83"/>
         <source>Authors</source>
         <translation>Auteurs</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="259"/>
         <source>Age rating:</source>
         <translation>Leeftijdsbeperking:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="173"/>
         <source>Story arc:</source>
         <translation>Verhaallijn:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="197"/>
         <source>Writer(s):</source>
         <translation>Schrijver(s):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Comic not found. You should update your library.</source>
         <translation>Strip niet gevonden. U moet uw bibliotheek.bijwerken.</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="467"/>
         <source>Edit comic information</source>
         <translation>Strip informatie bijwerken</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="94"/>
         <source>Cover page</source>
         <translation>Omslag</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="220"/>
         <source>Cover Artist(s):</source>
         <translation>Omslag ontwikkelaar(s):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="160"/>
         <source>Volume:</source>
         <translation>Inhoud:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="257"/>
         <source>Format:</source>
         <translation>Formaat:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="217"/>
         <source>Letterer(s):</source>
         <translation>Letterzetter(s):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="151"/>
+        <location filename="properties_dialog.cpp" line="168"/>
         <source>of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="164"/>
         <source>Arc number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="260"/>
         <source>Manga:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="369"/>
         <source>Comic Vine link: &lt;a style=&apos;color: #FFCB00; text-decoration:none; font-weight:bold;&apos; href=&quot;http://www.comicvine.com/comic/4000-%1/&quot;&gt; view &lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1293,34 +1684,42 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>7z lib not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>unable to load 7z lib from ./utils</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41"/>
         <source>Trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45"/>
         <source>Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51"/>
         <source>Fatal</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1328,14 +1727,17 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>QsLogging::LogWindowModel</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="141"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="143"/>
         <source>Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="145"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1343,18 +1745,22 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>QsLogging::Window</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="236"/>
         <source>Save log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="237"/>
         <source>Log file (*.log)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1362,18 +1768,22 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>RenameLibraryDialog</name>
     <message>
+        <location filename="rename_library_dialog.cpp" line="51"/>
         <source>Rename current library</source>
         <translation>Hernoem de huidige bibiliotheek</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="24"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="20"/>
         <source>Rename</source>
         <translation>Hernoem</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="15"/>
         <source>New Library Name : </source>
         <translation>Nieuwe Bibliotheek Naam :</translation>
     </message>
@@ -1381,14 +1791,18 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>ScraperResultsPaginator</name>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="30"/>
         <source>Number of volumes found : %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="32"/>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="55"/>
         <source>page %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="54"/>
         <source>Number of %1 found : %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1396,10 +1810,12 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>SearchSingleComic</name>
     <message>
+        <location filename="comic_vine/search_single_comic.cpp" line="14"/>
         <source>Please provide some additional information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/search_single_comic.cpp" line="19"/>
         <source>Series:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1407,10 +1823,12 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>SearchVolume</name>
     <message>
+        <location filename="comic_vine/search_volume.cpp" line="11"/>
         <source>Please provide some additional information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/search_volume.cpp" line="14"/>
         <source>Series:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1418,22 +1836,27 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>SelectComic</name>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="18"/>
         <source>Please, select the right comic info.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="38"/>
         <source>comics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="94"/>
         <source>loading cover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="95"/>
         <source>loading description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="135"/>
         <source>description unavailable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1441,22 +1864,37 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>SelectVolume</name>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="35"/>
         <source>Please, select the right series for your comic.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="56"/>
+        <source>Filter:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="68"/>
         <source>volumes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="138"/>
+        <source>Nothing found, clear the filter if any.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="144"/>
         <source>loading cover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="145"/>
         <source>loading description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="185"/>
         <source>description unavailable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1464,14 +1902,17 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>SeriesQuestion</name>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="15"/>
         <source>no</source>
         <translation>neen</translation>
     </message>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="14"/>
         <source>yes</source>
         <translation>Ja</translation>
     </message>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="12"/>
         <source>You are trying to get information for various comics at once, are they part of the same series?</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1479,39 +1920,48 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>ServerConfigDialog</name>
     <message>
+        <location filename="server_config_dialog.cpp" line="115"/>
         <source>Port</source>
         <translation>Poort</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="147"/>
         <source>enable the server</source>
         <translation>De server instellen</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="86"/>
         <source>set port</source>
         <translation>Poort instellen</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="92"/>
         <source>Server connectivity information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="96"/>
         <source>Scan it!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="102"/>
         <source>YACReader is available for iOS devices. &lt;a href=&apos;http://ios.yacreader.com&apos; style=&apos;color:rgb(193, 148, 65)&apos;&gt; Discover it! &lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="111"/>
         <source>Choose an IP address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="152"/>
         <source>display less information about folders in the browser
 to improve the performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="268"/>
         <source>Could not load libqrencode.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1519,22 +1969,27 @@ to improve the performance</source>
 <context>
     <name>SortVolumeComics</name>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="18"/>
         <source>Please, sort the list of comics on the left until it matches the comics&apos; information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="21"/>
         <source>sort comics to match comic information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="58"/>
         <source>issues</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="87"/>
         <source>remove selected comics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="88"/>
         <source>restore all removed comics</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1542,6 +1997,7 @@ to improve the performance</source>
 <context>
     <name>TitleHeader</name>
     <message>
+        <location filename="comic_vine/title_header.cpp" line="30"/>
         <source>SEARCH</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1549,14 +2005,17 @@ to improve the performance</source>
 <context>
     <name>UpdateLibraryDialog</name>
     <message>
+        <location filename="create_library_dialog.cpp" line="180"/>
         <source>Update library</source>
         <translation>Bibliotheek bijwerken</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="161"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="155"/>
         <source>Updating....</source>
         <translation>Bijwerken....</translation>
     </message>
@@ -1564,6 +2023,7 @@ to improve the performance</source>
 <context>
     <name>VolumeComicsModel</name>
     <message>
+        <location filename="comic_vine/model/volume_comics_model.cpp" line="120"/>
         <source>title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1571,14 +2031,17 @@ to improve the performance</source>
 <context>
     <name>VolumesModel</name>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="118"/>
         <source>year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="120"/>
         <source>issues</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="122"/>
         <source>publisher</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1586,18 +2049,17 @@ to improve the performance</source>
 <context>
     <name>YACReader::TrayIconController</name>
     <message>
+        <location filename="trayicon_controller.cpp" line="52"/>
         <source>&amp;Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Quit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="trayicon_controller.cpp" line="79"/>
         <source>Systray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="trayicon_controller.cpp" line="80"/>
         <source>YACReaderLibrary will keep running in the system tray. To terminate the program, choose &lt;b&gt;Quit&lt;/b&gt; in the context menu of the system tray icon.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1605,6 +2067,7 @@ to improve the performance</source>
 <context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1612,10 +2075,12 @@ to improve the performance</source>
 <context>
     <name>YACReaderDeletingProgress</name>
     <message>
+        <location filename="../custom_widgets/yacreader_deleting_progress.cpp" line="35"/>
         <source>cancel</source>
         <translation>annuleren</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_deleting_progress.cpp" line="20"/>
         <source>Please wait, deleting in progress...</source>
         <translation>Even geduld, verwijderen ...</translation>
     </message>
@@ -1623,10 +2088,13 @@ to improve the performance</source>
 <context>
     <name>YACReaderFieldEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11"/>
         <source>Restore to default</source>
         <translation>Standaardwaarden herstellen</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28"/>
         <source>Click to overwrite</source>
         <translation>Klik hier om te overschrijven</translation>
     </message>
@@ -1634,10 +2102,15 @@ to improve the performance</source>
 <context>
     <name>YACReaderFieldPlainTextEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10"/>
         <source>Restore to default</source>
         <translation>Standaardwaarden herstellen</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50"/>
         <source>Click to overwrite</source>
         <translation>Klik hier om te overschrijven</translation>
     </message>
@@ -1645,18 +2118,22 @@ to improve the performance</source>
 <context>
     <name>YACReaderFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="15"/>
         <source>CoverFlow look</source>
         <translation>Omslagbrowser uiterlijk</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="13"/>
         <source>How to show covers:</source>
         <translation>Hoe omslagbladen bekijken:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="16"/>
         <source>Stripe look</source>
         <translation>Brede band</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="17"/>
         <source>Overlapped Stripe look</source>
         <translation>Overlappende band</translation>
     </message>
@@ -1664,94 +2141,117 @@ to improve the performance</source>
 <context>
     <name>YACReaderGLFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="112"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="142"/>
         <source>Light</source>
         <translation>Licht</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="76"/>
         <source>Show advanced settings</source>
         <translation>Toon geavanceerde instellingen</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="32"/>
         <source>Roulette look</source>
         <translation>Roulette</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="130"/>
         <source>Cover Angle</source>
         <translation>Omslag hoek</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="23"/>
         <source>Stripe look</source>
         <translation>Brede band</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="94"/>
         <source>Position</source>
         <translation>Positie</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="124"/>
         <source>Z offset</source>
         <translation>Z- positie</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="118"/>
         <source>Y offset</source>
         <translation>Y-positie</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="106"/>
         <source>Central gap</source>
         <translation>Centrale ruimte</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="18"/>
         <source>Presets:</source>
         <translation>Voorinstellingen:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="26"/>
         <source>Overlapped Stripe look</source>
         <translation>Overlappende band</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="29"/>
         <source>Modern look</source>
         <translation>Modern</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="88"/>
         <source>View angle</source>
         <translation>Kijkhoek</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="148"/>
         <source>Max angle</source>
         <translation>Maximale hoek</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="85"/>
         <source>Custom:</source>
         <translation>Aangepast:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="20"/>
         <source>Classic look</source>
         <translation>Klassiek</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="100"/>
         <source>Cover gap</source>
         <translation>Ruimte tss Omslag</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="182"/>
         <source>High Performance</source>
         <translation>Hoge Prestaties</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="201"/>
         <source>Performance:</source>
         <translation>Prestatie:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="193"/>
         <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
         <translation>Gebruik VSync (verbetering van de beeldkwaliteit in de modus volledig scherm, slechtere prestatie)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="136"/>
         <source>Visibility</source>
         <translation>Zichtbaarheid</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="180"/>
         <source>Low Performance</source>
         <translation>Lage Prestaties</translation>
     </message>
@@ -1759,10 +2259,12 @@ to improve the performance</source>
 <context>
     <name>YACReaderNavigationController</name>
     <message>
+        <location filename="yacreader_navigation_controller.cpp" line="123"/>
         <source>No favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="yacreader_navigation_controller.cpp" line="127"/>
         <source>You are not reading anything yet, come on!!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1770,22 +2272,27 @@ to improve the performance</source>
 <context>
     <name>YACReaderOptionsDialog</name>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28"/>
         <source>Save</source>
         <translation>Bewaar</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="46"/>
         <source>Use hardware acceleration (restart needed)</source>
         <translation>Gebruik hardware versnelling (opnieuw opstarten vereist)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="29"/>
         <source>Cancel</source>
         <translation>Annuleren</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="34"/>
         <source>Edit shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="37"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1793,6 +2300,7 @@ to improve the performance</source>
 <context>
     <name>YACReaderSearchLineEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_search_line_edit.cpp" line="68"/>
         <source>type to search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1800,26 +2308,32 @@ to improve the performance</source>
 <context>
     <name>YACReaderSideBar</name>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="31"/>
         <source>LIBRARIES</source>
         <translation>BIBLIOTHEKEN</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="32"/>
         <source>FOLDERS</source>
         <translation>MAPPEN</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="27"/>
         <source>Libraries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="28"/>
         <source>Folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="29"/>
         <source>Reading Lists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="33"/>
         <source>READING LISTS</source>
         <translation type="unfinished"></translation>
     </message>

--- a/YACReaderLibrary/yacreaderlibrary_pt.ts
+++ b/YACReaderLibrary/yacreaderlibrary_pt.ts
@@ -4,6 +4,7 @@
 <context>
     <name>ActionsShortcutsModel</name>
     <message>
+        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="73"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11,66 +12,82 @@
 <context>
     <name>AddLabelDialog</name>
     <message>
+        <location filename="add_label_dialog.cpp" line="8"/>
         <source>Label name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="11"/>
         <source>Choose a color:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="14"/>
         <source>red</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="15"/>
         <source>orange</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="16"/>
         <source>yellow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="17"/>
         <source>green</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="18"/>
         <source>cyan</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="19"/>
         <source>blue</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="20"/>
         <source>violet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="21"/>
         <source>purple</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="22"/>
         <source>pink</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="23"/>
         <source>white</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="24"/>
         <source>light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="25"/>
         <source>dark</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="36"/>
         <source>accept</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="37"/>
         <source>cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -78,22 +95,27 @@
 <context>
     <name>AddLibraryDialog</name>
     <message>
+        <location filename="add_library_dialog.cpp" line="26"/>
         <source>Add</source>
         <translation>Adicionar</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="66"/>
         <source>Add an existing library</source>
         <translation>Adicionar uma biblioteca existente</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="30"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="16"/>
         <source>Comics folder : </source>
         <translation>Pasta dos quadrinhos : </translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="21"/>
         <source>Library name : </source>
         <translation>Nome da Biblioteca : </translation>
     </message>
@@ -101,18 +123,22 @@
 <context>
     <name>ApiKeyDialog</name>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="32"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="21"/>
         <source>Before you can connect to Comic Vine, you need your own API key. Please, get one free &lt;a href=&quot;http://www.comicvine.com/api/&quot;&gt;here&lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="25"/>
         <source>Paste here your Comic Vine API key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="28"/>
         <source>Accept</source>
         <translation type="unfinished"></translation>
     </message>
@@ -120,6 +146,7 @@
 <context>
     <name>ClassicComicsView</name>
     <message>
+        <location filename="classic_comics_view.cpp" line="90"/>
         <source>Hide comic flow</source>
         <translation type="unfinished"></translation>
     </message>
@@ -127,46 +154,57 @@
 <context>
     <name>ComicInfoView</name>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="279"/>
         <source>Authors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="309"/>
         <source>writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="331"/>
         <source>penciller</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="353"/>
         <source>inker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="375"/>
         <source>colorist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="397"/>
         <source>letterer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="419"/>
         <source>cover artist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="434"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
         <source>color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
         <source>b/w</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="502"/>
         <source>Characters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,38 +212,52 @@
 <context>
     <name>ComicModel</name>
     <message>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>no</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="343"/>
         <source>Title</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="345"/>
         <source>File Name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="347"/>
         <source>Pages</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="349"/>
         <source>Size</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="351"/>
         <source>Read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="353"/>
         <source>Current Page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="355"/>
+        <source>Publication Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="357"/>
         <source>Rating</source>
         <translation type="unfinished"></translation>
     </message>
@@ -213,50 +265,67 @@
 <context>
     <name>ComicVineDialog</name>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="57"/>
         <source>skip</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="58"/>
         <source>back</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="59"/>
         <source>next</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="60"/>
         <source>search</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="61"/>
         <source>close</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="143"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="257"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="773"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="807"/>
         <source>Looking for volume...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="141"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="735"/>
         <source>comic %1 of %2 - %3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="262"/>
         <source>%1 comics selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="295"/>
         <source>Error connecting to ComicVine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="467"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="503"/>
         <source>Retrieving tags for : %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="788"/>
         <source>Retrieving volume info...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="814"/>
         <source>Looking for comic...</source>
         <translation type="unfinished"></translation>
     </message>
@@ -264,34 +333,42 @@
 <context>
     <name>CreateLibraryDialog</name>
     <message>
+        <location filename="create_library_dialog.cpp" line="75"/>
         <source>Create new library</source>
         <translation>Criar uma nova biblioteca</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="31"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="27"/>
         <source>Create</source>
         <translation>Criar</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="17"/>
         <source>Comics folder : </source>
         <translation>Pasta dos quadrinhos : </translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="22"/>
         <source>Library Name : </source>
         <translation>Nome da Biblioteca : </translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="53"/>
         <source>Create a library could take several minutes. You can stop the process and update the library later for completing the task.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="95"/>
         <source>Path not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="95"/>
         <source>The selected path does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -299,22 +376,27 @@
 <context>
     <name>EditShortcutsDialog</name>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="21"/>
         <source>Restore defaults</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="22"/>
         <source>To change a shortcut, double click in the key combination and type the new keys.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="69"/>
         <source>Shortcuts settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>Shortcut in use</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>The shortcut &quot;%1&quot; is already assigned to other function</source>
         <translation type="unfinished"></translation>
     </message>
@@ -322,14 +404,18 @@
 <context>
     <name>EmptyFolderWidget</name>
     <message>
+        <location filename="empty_folder_widget.cpp" line="75"/>
+        <location filename="empty_folder_widget.cpp" line="140"/>
         <source>Subfolders in this folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="empty_folder_widget.cpp" line="138"/>
         <source>Empty folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="empty_folder_widget.cpp" line="138"/>
         <source>Drag and drop folders and comics here</source>
         <translation type="unfinished"></translation>
     </message>
@@ -337,6 +423,7 @@
 <context>
     <name>EmptyLabelWidget</name>
     <message>
+        <location filename="empty_label_widget.cpp" line="11"/>
         <source>This label doesn&apos;t contain comics yet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -344,6 +431,7 @@
 <context>
     <name>EmptyReadingListWidget</name>
     <message>
+        <location filename="empty_reading_list_widget.cpp" line="8"/>
         <source>This reading list does not contain any comics yet</source>
         <translation type="unfinished"></translation>
     </message>
@@ -351,30 +439,37 @@
 <context>
     <name>ExportComicsInfoDialog</name>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="22"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="18"/>
         <source>Create</source>
         <translation>Criar</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="14"/>
         <source>Output file : </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="57"/>
         <source>Export comics info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="66"/>
         <source>Destination database name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="81"/>
         <source>Problem found while writing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="81"/>
         <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -382,30 +477,37 @@
 <context>
     <name>ExportLibraryDialog</name>
     <message>
+        <location filename="export_library_dialog.cpp" line="19"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="15"/>
         <source>Create</source>
         <translation>Criar</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="11"/>
         <source>Output folder : </source>
         <translation>Pasta de saída : </translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="60"/>
         <source>Create covers package</source>
         <translation>Criar pacote de capas</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="76"/>
         <source>Destination directory</source>
         <translation>Diretório de destino</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="71"/>
         <source>Problem found while writing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="71"/>
         <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation type="unfinished"></translation>
     </message>
@@ -413,25 +515,46 @@
 <context>
     <name>FileComic</name>
     <message>
+        <location filename="../common/comic.cpp" line="562"/>
         <source>7z not found</source>
         <translation>7z não encontrado</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="454"/>
         <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="461"/>
         <source>Unknown error opening the file</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="568"/>
         <source>Format not supported</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FolderContentView</name>
+    <message>
+        <location filename="qml/FolderContentView.qml" line="238"/>
+        <source>Continue Reading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FolderContentView6</name>
+    <message>
+        <location filename="qml/FolderContentView6.qml" line="240"/>
+        <source>Continue Reading...</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>GridComicsView</name>
     <message>
+        <location filename="grid_comics_view.cpp" line="147"/>
         <source>Show info</source>
         <translation type="unfinished"></translation>
     </message>
@@ -439,33 +562,45 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
+        <source>System info</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>ImportComicsInfoDialog</name>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="24"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="14"/>
         <source>Import comics info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="16"/>
         <source>Info database location : </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="20"/>
         <source>Import</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="74"/>
         <source>Comics info file (*.ydb)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -473,30 +608,37 @@
 <context>
     <name>ImportLibraryDialog</name>
     <message>
+        <location filename="import_library_dialog.cpp" line="26"/>
         <source>Destination folder : </source>
         <translation>Pasta de destino : </translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="34"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="30"/>
         <source>Unpack</source>
         <translation>Desempacotar</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="108"/>
         <source>Compresed library covers (*.clc)</source>
         <translation>Capas da biblioteca compactada (*.clc)</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="22"/>
         <source>Package location : </source>
         <translation>Local do pacote : </translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="17"/>
         <source>Library Name : </source>
         <translation>Nome da Biblioteca : </translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="87"/>
         <source>Extract a catalog</source>
         <translation>Extrair um catálogo</translation>
     </message>
@@ -504,437 +646,601 @@
 <context>
     <name>ImportWidget</name>
     <message>
+        <location filename="import_widget.cpp" line="150"/>
         <source>stop</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="190"/>
         <source>Some of the comics being added...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="334"/>
         <source>Importing comics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="335"/>
         <source>&lt;p&gt;YACReaderLibrary is now creating a new library.&lt;/p&gt;&lt;p&gt;Create a library could take several minutes. You can stop the process and update the library later for completing the task.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="346"/>
         <source>Updating the library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="347"/>
         <source>&lt;p&gt;The current library is being updated. For faster updates, please, update your libraries frequently.&lt;/p&gt;&lt;p&gt;You can stop the process and continue updating this library later.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="358"/>
         <source>Upgrading the library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="359"/>
         <source>&lt;p&gt;The current library is being upgraded, please wait.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="370"/>
+        <source>Scanning the library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="371"/>
+        <source>&lt;p&gt;Current library is being scanned for legacy XML metadata information.&lt;/p&gt;&lt;p&gt;This is only needed once, and only if the library was crated with YACReaderLibrary 9.8.2 or earlier.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LibraryWindow</name>
     <message>
+        <location filename="library_window.cpp" line="532"/>
         <source>Remove current library from your collection</source>
         <translation>Remover biblioteca atual da sua coleção</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1027"/>
         <source>Library</source>
         <translation>Biblioteca</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="526"/>
         <source>Rename current library</source>
         <translation>Renomear biblioteca atual</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="543"/>
         <source>Open current comic on YACReader</source>
         <translation>Abrir quadrinho atual no YACReader</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="520"/>
         <source>Update current library</source>
         <translation>Atualizar biblioteca atual</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="674"/>
+        <location filename="library_window.cpp" line="1787"/>
         <source>Open folder...</source>
         <translation>Abrir pasta...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Do you want remove </source>
         <translation>Você deseja remover </translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="628"/>
         <source>Expand all nodes</source>
         <translation>Expandir todos</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="640"/>
         <source>Show options dialog</source>
         <translation>Mostrar opções</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="484"/>
         <source>Create a new library</source>
         <translation>Criar uma nova biblioteca</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="188"/>
         <source>YACReader Library</source>
         <translation>Biblioteca YACReader</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="490"/>
         <source>Open an existing library</source>
         <translation>Abrir uma biblioteca existente</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="508"/>
         <source>Pack the covers of the selected library</source>
         <translation>Pacote de capas da biblioteca selecionada</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="602"/>
         <source>Help, About YACReader</source>
         <translation>Ajuda, Sobre o YACReader</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="624"/>
         <source>Select root node</source>
         <translation>Selecionar raiz</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="514"/>
         <source>Unpack a catalog</source>
         <translation>Desempacotar um catálogo</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="712"/>
         <source>Open containing folder...</source>
         <translation>Abrir a pasta contendo...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Are you sure?</source>
         <translation>Você tem certeza?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="495"/>
+        <location filename="library_window.cpp" line="496"/>
         <source>Export comics info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="501"/>
+        <location filename="library_window.cpp" line="502"/>
         <source>Import comics info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="507"/>
         <source>Pack covers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="513"/>
         <source>Unpack covers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="519"/>
         <source>Update library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="525"/>
         <source>Rename library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="531"/>
         <source>Remove library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="537"/>
+        <source>Rescan library for XML info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="538"/>
+        <source>Tries to find XML info embedded in comic files. You only need to do this if the library was created with 9.8.2 or earlier versions or if you are using third party software to embed XML info in the files.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="542"/>
         <source>Open current comic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="548"/>
         <source>Save selected covers to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="549"/>
         <source>Save covers of the selected comics as JPG files</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="553"/>
+        <location filename="library_window.cpp" line="690"/>
+        <location filename="library_window.cpp" line="1800"/>
         <source>Set as read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="554"/>
         <source>Set comic as read</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="559"/>
+        <location filename="library_window.cpp" line="695"/>
+        <location filename="library_window.cpp" line="1803"/>
         <source>Set as unread</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="560"/>
         <source>Set comic as unread</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="565"/>
+        <location filename="library_window.cpp" line="700"/>
+        <location filename="library_window.cpp" line="1806"/>
         <source>Set as manga</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="566"/>
         <source>Set issue as manga</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="571"/>
         <source>Set as normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="572"/>
         <source>Set issue as normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="585"/>
         <source>Show/Hide marks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="586"/>
         <source>Show or hide read marks</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="593"/>
+        <location filename="library_window.cpp" line="594"/>
         <source>Fullscreen mode on/off</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="609"/>
+        <location filename="library_window.cpp" line="1574"/>
         <source>Add new folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="612"/>
         <source>Add new folder to the current library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="615"/>
+        <location filename="library_window.cpp" line="1610"/>
         <source>Delete folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="618"/>
         <source>Delete current folder from disk</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="634"/>
         <source>Collapse all nodes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="648"/>
         <source>Show comics server options dialog</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="655"/>
+        <location filename="library_window.cpp" line="656"/>
         <source>Change between comics views</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="680"/>
+        <location filename="library_window.cpp" line="1794"/>
         <source>Set as uncompleted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="685"/>
+        <location filename="library_window.cpp" line="1797"/>
         <source>Set as completed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="705"/>
+        <location filename="library_window.cpp" line="1809"/>
         <source>Set as comic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="718"/>
         <source>Reset comic rating</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="724"/>
         <source>Select all comics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="730"/>
         <source>Edit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="736"/>
         <source>Assign current order to comics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="742"/>
         <source>Update cover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="748"/>
         <source>Delete selected comics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="756"/>
         <source>Download tags from Comic Vine</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="760"/>
+        <source>Focus search line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="766"/>
+        <source>Focus comics view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="771"/>
         <source>Edit shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="777"/>
+        <source>&amp;Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="784"/>
+        <location filename="library_window.cpp" line="1790"/>
         <source>Update folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="787"/>
         <source>Update current folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="792"/>
         <source>Add new reading list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="795"/>
         <source>Add a new reading list to the current library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="798"/>
         <source>Remove reading list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="801"/>
         <source>Remove current reading list from the library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="804"/>
         <source>Add new label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="807"/>
         <source>Add a new label to this library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="810"/>
         <source>Rename selected list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="813"/>
         <source>Rename any selected labels or lists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="817"/>
         <source>Add to...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="819"/>
         <source>Favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="822"/>
         <source>Add selected comics to favorites list</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1046"/>
         <source>Folder</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1060"/>
         <source>Comic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1251"/>
         <source>Upgrade failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1251"/>
         <source>There were errors during library upgrade in: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1269"/>
         <source>Update needed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1269"/>
         <source>This library was created with a previous version of YACReaderLibrary. It needs to be updated. Update now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1336"/>
         <source>Download new version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1336"/>
         <source>This library was created with a newer version of YACReaderLibrary. Download the new version now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library not available</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library &apos;%1&apos; is no longer available. Do you want to remove it?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Old library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Library &apos;%1&apos; has been created with an older version of YACReaderLibrary. It must be created again. Do you want to create the library now?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1409"/>
+        <location filename="library_window.cpp" line="1445"/>
         <source>Copying comics...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1426"/>
+        <location filename="library_window.cpp" line="1464"/>
         <source>Moving comics...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1575"/>
         <source>Folder name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1604"/>
         <source>No folder selected</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1604"/>
         <source>Please, select a folder first</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1608"/>
         <source>Error in path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1608"/>
         <source>There was an error accessing the folder&apos;s path</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1610"/>
         <source>The selected folder and all its contents will be deleted from your disk. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1636"/>
+        <location filename="library_window.cpp" line="2417"/>
         <source>Unable to delete</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1636"/>
         <source>There was an issue trying to delete the selected folders. Please, check for write permissions and be sure that any applications are using these folders or any of the contained files.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1648"/>
         <source>Add new reading lists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1649"/>
+        <location filename="library_window.cpp" line="1698"/>
         <source>List name:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1667"/>
         <source>Delete list/label</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1667"/>
         <source>The selected item will be deleted, your comics or folders will NOT be deleted from your disk. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1697"/>
         <source>Rename list name</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1916"/>
         <source>Save covers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.
 
 You probably only need one library in your top level comics folder, you can browse any subfolders using the folders section in the left sidebar.
@@ -943,78 +1249,98 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1993"/>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1993"/>
         <source>YACReader not found. YACReader should be installed in the same folder as YACReaderLibrary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found. There might be a problem with your YACReader installation.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2083"/>
         <source>Library not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2083"/>
         <source>The selected folder doesn&apos;t contain any library.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source> library?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2139"/>
         <source>Remove and delete metadata</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2417"/>
         <source>There was an issue trying to delete the selected comics. Please, check for write permissions in the selected files or containing folder.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2448"/>
         <source>Assign comics numbers</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2449"/>
         <source>Assign numbers starting in:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2649"/>
         <source>Error creating the library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2654"/>
         <source>Error updating the library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2659"/>
         <source>Error opening the library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2694"/>
         <source>Delete comics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2694"/>
         <source>All the selected comics will be deleted from your disk. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Remove comics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Comics will only be deleted from the current label/list. Are you sure?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2805"/>
         <source>Library name already exists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2805"/>
         <source>There is another library with the name &apos;%1&apos;.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1022,6 +1348,7 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>LocalComicListModel</name>
     <message>
+        <location filename="comic_vine/model/local_comic_list_model.cpp" line="72"/>
         <source>file name</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1029,30 +1356,37 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>LogWindow</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="14"/>
         <source>Log window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="22"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="39"/>
         <source>&amp;Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="56"/>
         <source>C&amp;lear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="73"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="90"/>
         <source>Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="136"/>
         <source>&amp;Auto scroll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1060,18 +1394,22 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>NoLibrariesWidget</name>
     <message>
+        <location filename="no_libraries_widget.cpp" line="26"/>
         <source>You don&apos;t have any libraries yet</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="28"/>
         <source>&lt;p&gt;You can create a library in any folder, YACReaderLibrary will import all comics and folders from this folder. If you have created any library in the past you can open them.&lt;/p&gt;&lt;p&gt;Don&apos;t forget that you can use YACReader as a stand alone application for reading the comics on your computer.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="32"/>
         <source>create your first library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="34"/>
         <source>add an existing one</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1079,70 +1417,87 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>OptionsDialog</name>
     <message>
+        <location filename="options_dialog.cpp" line="47"/>
         <source>Tray icon settings (experimental)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="50"/>
         <source>Close to tray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="51"/>
         <source>Start into the system tray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="69"/>
         <source>Edit Comic Vine API key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="72"/>
         <source>Comic Vine API key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="78"/>
         <source>Enable background image</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="80"/>
         <source>Opacity level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="85"/>
         <source>Blur level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="90"/>
         <source>Use selected comic cover as background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="92"/>
         <source>Restore defautls</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="103"/>
         <source>Background</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="106"/>
         <source>Display continue reading banner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="111"/>
         <source>Continue reading</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="144"/>
         <source>Comic Flow</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="146"/>
         <source>Grid view</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="148"/>
         <source>General</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="156"/>
         <source>Options</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1150,142 +1505,178 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>PropertiesDialog</name>
     <message>
+        <location filename="properties_dialog.cpp" line="82"/>
         <source>General info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="83"/>
         <source>Authors</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="84"/>
         <source>Publishing</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="85"/>
         <source>Plot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="94"/>
         <source>Cover page</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="143"/>
         <source>Title:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="151"/>
+        <location filename="properties_dialog.cpp" line="168"/>
         <source>of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="158"/>
         <source>Issue number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="160"/>
         <source>Volume:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="164"/>
         <source>Arc number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="173"/>
         <source>Story arc:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="175"/>
         <source>Genre:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="177"/>
         <source>Size:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="197"/>
         <source>Writer(s):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="200"/>
         <source>Penciller(s):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="207"/>
         <source>Inker(s):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="210"/>
         <source>Colorist(s):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="217"/>
         <source>Letterer(s):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="220"/>
         <source>Cover Artist(s):</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="240"/>
         <source>Day:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="244"/>
         <source>Month:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="248"/>
         <source>Year:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="256"/>
         <source>Publisher:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="257"/>
         <source>Format:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="258"/>
         <source>Color/BW:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="259"/>
         <source>Age rating:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="260"/>
         <source>Manga:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="273"/>
         <source>Synopsis:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="274"/>
         <source>Characters:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="275"/>
         <source>Notes:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="369"/>
         <source>Comic Vine link: &lt;a style=&apos;color: #FFCB00; text-decoration:none; font-weight:bold;&apos; href=&quot;http://www.comicvine.com/comic/4000-%1/&quot;&gt; view &lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Comic not found. You should update your library.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="501"/>
         <source>Edit selected comics information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="467"/>
         <source>Edit comic information</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1293,34 +1684,42 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>7z lib not found</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>unable to load 7z lib from ./utils</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41"/>
         <source>Trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45"/>
         <source>Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51"/>
         <source>Fatal</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1328,14 +1727,17 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>QsLogging::LogWindowModel</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="141"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="143"/>
         <source>Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="145"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1343,18 +1745,22 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>QsLogging::Window</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="236"/>
         <source>Save log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="237"/>
         <source>Log file (*.log)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1362,18 +1768,22 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>RenameLibraryDialog</name>
     <message>
+        <location filename="rename_library_dialog.cpp" line="51"/>
         <source>Rename current library</source>
         <translation>Renomear biblioteca atual</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="24"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="20"/>
         <source>Rename</source>
         <translation>Renomear</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="15"/>
         <source>New Library Name : </source>
         <translation>Novo nome da biblioteca : </translation>
     </message>
@@ -1381,14 +1791,18 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>ScraperResultsPaginator</name>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="30"/>
         <source>Number of volumes found : %1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="32"/>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="55"/>
         <source>page %1 of %2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="54"/>
         <source>Number of %1 found : %2</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1396,10 +1810,12 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>SearchSingleComic</name>
     <message>
+        <location filename="comic_vine/search_single_comic.cpp" line="14"/>
         <source>Please provide some additional information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/search_single_comic.cpp" line="19"/>
         <source>Series:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1407,10 +1823,12 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>SearchVolume</name>
     <message>
+        <location filename="comic_vine/search_volume.cpp" line="11"/>
         <source>Please provide some additional information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/search_volume.cpp" line="14"/>
         <source>Series:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1418,22 +1836,27 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>SelectComic</name>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="18"/>
         <source>Please, select the right comic info.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="38"/>
         <source>comics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="94"/>
         <source>loading cover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="95"/>
         <source>loading description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="135"/>
         <source>description unavailable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1441,22 +1864,37 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>SelectVolume</name>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="35"/>
         <source>Please, select the right series for your comic.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="56"/>
+        <source>Filter:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="68"/>
         <source>volumes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="138"/>
+        <source>Nothing found, clear the filter if any.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="144"/>
         <source>loading cover</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="145"/>
         <source>loading description</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="185"/>
         <source>description unavailable</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1464,14 +1902,17 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>SeriesQuestion</name>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="12"/>
         <source>You are trying to get information for various comics at once, are they part of the same series?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="14"/>
         <source>yes</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="15"/>
         <source>no</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1479,39 +1920,48 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 <context>
     <name>ServerConfigDialog</name>
     <message>
+        <location filename="server_config_dialog.cpp" line="86"/>
         <source>set port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="92"/>
         <source>Server connectivity information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="96"/>
         <source>Scan it!</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="102"/>
         <source>YACReader is available for iOS devices. &lt;a href=&apos;http://ios.yacreader.com&apos; style=&apos;color:rgb(193, 148, 65)&apos;&gt; Discover it! &lt;/a&gt;</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="111"/>
         <source>Choose an IP address</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="115"/>
         <source>Port</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="147"/>
         <source>enable the server</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="152"/>
         <source>display less information about folders in the browser
 to improve the performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="268"/>
         <source>Could not load libqrencode.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1519,22 +1969,27 @@ to improve the performance</source>
 <context>
     <name>SortVolumeComics</name>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="18"/>
         <source>Please, sort the list of comics on the left until it matches the comics&apos; information.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="21"/>
         <source>sort comics to match comic information</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="58"/>
         <source>issues</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="87"/>
         <source>remove selected comics</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="88"/>
         <source>restore all removed comics</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1542,6 +1997,7 @@ to improve the performance</source>
 <context>
     <name>TitleHeader</name>
     <message>
+        <location filename="comic_vine/title_header.cpp" line="30"/>
         <source>SEARCH</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1549,14 +2005,17 @@ to improve the performance</source>
 <context>
     <name>UpdateLibraryDialog</name>
     <message>
+        <location filename="create_library_dialog.cpp" line="161"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="155"/>
         <source>Updating....</source>
         <translation>Atualizando....</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="180"/>
         <source>Update library</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1564,6 +2023,7 @@ to improve the performance</source>
 <context>
     <name>VolumeComicsModel</name>
     <message>
+        <location filename="comic_vine/model/volume_comics_model.cpp" line="120"/>
         <source>title</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1571,14 +2031,17 @@ to improve the performance</source>
 <context>
     <name>VolumesModel</name>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="118"/>
         <source>year</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="120"/>
         <source>issues</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="122"/>
         <source>publisher</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1586,18 +2049,17 @@ to improve the performance</source>
 <context>
     <name>YACReader::TrayIconController</name>
     <message>
+        <location filename="trayicon_controller.cpp" line="52"/>
         <source>&amp;Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Quit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="trayicon_controller.cpp" line="79"/>
         <source>Systray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="trayicon_controller.cpp" line="80"/>
         <source>YACReaderLibrary will keep running in the system tray. To terminate the program, choose &lt;b&gt;Quit&lt;/b&gt; in the context menu of the system tray icon.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1605,6 +2067,7 @@ to improve the performance</source>
 <context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1612,10 +2075,12 @@ to improve the performance</source>
 <context>
     <name>YACReaderDeletingProgress</name>
     <message>
+        <location filename="../custom_widgets/yacreader_deleting_progress.cpp" line="20"/>
         <source>Please wait, deleting in progress...</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_deleting_progress.cpp" line="35"/>
         <source>cancel</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1623,10 +2088,13 @@ to improve the performance</source>
 <context>
     <name>YACReaderFieldEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28"/>
         <source>Click to overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11"/>
         <source>Restore to default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1634,10 +2102,15 @@ to improve the performance</source>
 <context>
     <name>YACReaderFieldPlainTextEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50"/>
         <source>Click to overwrite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10"/>
         <source>Restore to default</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1645,18 +2118,22 @@ to improve the performance</source>
 <context>
     <name>YACReaderFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="15"/>
         <source>CoverFlow look</source>
         <translation>Olhar capa cheia</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="13"/>
         <source>How to show covers:</source>
         <translation>Como mostrar capas:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="16"/>
         <source>Stripe look</source>
         <translation>Olhar lista</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="17"/>
         <source>Overlapped Stripe look</source>
         <translation>Olhar lista sobreposta</translation>
     </message>
@@ -1664,94 +2141,117 @@ to improve the performance</source>
 <context>
     <name>YACReaderGLFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="23"/>
         <source>Stripe look</source>
         <translation>Olhar lista</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="26"/>
         <source>Overlapped Stripe look</source>
         <translation>Olhar lista sobreposta</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="18"/>
         <source>Presets:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="20"/>
         <source>Classic look</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="29"/>
         <source>Modern look</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="32"/>
         <source>Roulette look</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="76"/>
         <source>Show advanced settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="85"/>
         <source>Custom:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="88"/>
         <source>View angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="94"/>
         <source>Position</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="100"/>
         <source>Cover gap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="106"/>
         <source>Central gap</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="112"/>
         <source>Zoom</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="118"/>
         <source>Y offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="124"/>
         <source>Z offset</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="130"/>
         <source>Cover Angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="136"/>
         <source>Visibility</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="142"/>
         <source>Light</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="148"/>
         <source>Max angle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="180"/>
         <source>Low Performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="182"/>
         <source>High Performance</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="193"/>
         <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="201"/>
         <source>Performance:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1759,10 +2259,12 @@ to improve the performance</source>
 <context>
     <name>YACReaderNavigationController</name>
     <message>
+        <location filename="yacreader_navigation_controller.cpp" line="123"/>
         <source>No favorites</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="yacreader_navigation_controller.cpp" line="127"/>
         <source>You are not reading anything yet, come on!!</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1770,22 +2272,27 @@ to improve the performance</source>
 <context>
     <name>YACReaderOptionsDialog</name>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28"/>
         <source>Save</source>
         <translation>Salvar</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="29"/>
         <source>Cancel</source>
         <translation>Cancelar</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="34"/>
         <source>Edit shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="37"/>
         <source>Shortcuts</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="46"/>
         <source>Use hardware acceleration (restart needed)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1793,6 +2300,7 @@ to improve the performance</source>
 <context>
     <name>YACReaderSearchLineEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_search_line_edit.cpp" line="68"/>
         <source>type to search</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1800,26 +2308,32 @@ to improve the performance</source>
 <context>
     <name>YACReaderSideBar</name>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="27"/>
         <source>Libraries</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="28"/>
         <source>Folders</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="29"/>
         <source>Reading Lists</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="31"/>
         <source>LIBRARIES</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="32"/>
         <source>FOLDERS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="33"/>
         <source>READING LISTS</source>
         <translation type="unfinished"></translation>
     </message>

--- a/YACReaderLibrary/yacreaderlibrary_ru.ts
+++ b/YACReaderLibrary/yacreaderlibrary_ru.ts
@@ -4,6 +4,7 @@
 <context>
     <name>ActionsShortcutsModel</name>
     <message>
+        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="73"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
@@ -11,66 +12,82 @@
 <context>
     <name>AddLabelDialog</name>
     <message>
+        <location filename="add_label_dialog.cpp" line="14"/>
         <source>red</source>
         <translation>красный</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="19"/>
         <source>blue</source>
         <translation>синий</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="25"/>
         <source>dark</source>
         <translation>темный</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="18"/>
         <source>cyan</source>
         <translation>голубой</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="22"/>
         <source>pink</source>
         <translation>розовый</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="17"/>
         <source>green</source>
         <translation>зеленый</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="24"/>
         <source>light</source>
         <translation>серый</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="23"/>
         <source>white</source>
         <translation>белый</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="11"/>
         <source>Choose a color:</source>
         <translation>Выбрать цвет:</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="36"/>
         <source>accept</source>
         <translation>добавить</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="37"/>
         <source>cancel</source>
         <translation>отменить</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="15"/>
         <source>orange</source>
         <translation>оранжевый</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="21"/>
         <source>purple</source>
         <translation>пурпурный</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="20"/>
         <source>violet</source>
         <translation>фиолетовый</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="16"/>
         <source>yellow</source>
         <translation>желтый</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="8"/>
         <source>Label name:</source>
         <translation>Название ярлыка:</translation>
     </message>
@@ -78,22 +95,27 @@
 <context>
     <name>AddLibraryDialog</name>
     <message>
+        <location filename="add_library_dialog.cpp" line="26"/>
         <source>Add</source>
         <translation>Добавить</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="66"/>
         <source>Add an existing library</source>
         <translation>Добавить в существующую библиотеку</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="30"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="16"/>
         <source>Comics folder : </source>
         <translation>Папка комиксов : </translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="21"/>
         <source>Library name : </source>
         <translation>Имя библиотеки : </translation>
     </message>
@@ -101,18 +123,22 @@
 <context>
     <name>ApiKeyDialog</name>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="28"/>
         <source>Accept</source>
         <translation>Принять</translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="32"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="21"/>
         <source>Before you can connect to Comic Vine, you need your own API key. Please, get one free &lt;a href=&quot;http://www.comicvine.com/api/&quot;&gt;here&lt;/a&gt;</source>
         <translation>Для подключения к Comic Vine вам потребуется ваш личный API ключ. Приобретите его бесплатно вот &lt;a href=&quot;http://www.comicvine.com/api/&quot;&gt;здесь&lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="25"/>
         <source>Paste here your Comic Vine API key</source>
         <translation>Вставьте сюда ваш Comic Vine API ключ</translation>
     </message>
@@ -120,6 +146,7 @@
 <context>
     <name>ClassicComicsView</name>
     <message>
+        <location filename="classic_comics_view.cpp" line="90"/>
         <source>Hide comic flow</source>
         <translation>Показать/скрыть поток комиксов</translation>
     </message>
@@ -127,46 +154,57 @@
 <context>
     <name>ComicInfoView</name>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="279"/>
         <source>Authors</source>
         <translation>Авторы</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="309"/>
         <source>writer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="331"/>
         <source>penciller</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="353"/>
         <source>inker</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="375"/>
         <source>colorist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="397"/>
         <source>letterer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="419"/>
         <source>cover artist</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="434"/>
         <source>Publisher</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
         <source>color</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
         <source>b/w</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="502"/>
         <source>Characters</source>
         <translation type="unfinished"></translation>
     </message>
@@ -174,38 +212,52 @@
 <context>
     <name>ComicModel</name>
     <message>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>no</source>
         <translation>нет</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>yes</source>
         <translation>да</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="351"/>
         <source>Read</source>
         <translation>Прочитано</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="349"/>
         <source>Size</source>
         <translation>Размер</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="347"/>
         <source>Pages</source>
         <translation>Всего страниц</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="343"/>
         <source>Title</source>
         <translation>Заголовок</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="353"/>
         <source>Current Page</source>
         <translation>Текущая страница</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="345"/>
         <source>File Name</source>
         <translation>Имя файла</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="355"/>
+        <source>Publication Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="357"/>
         <source>Rating</source>
         <translation>Рейтинг</translation>
     </message>
@@ -213,50 +265,67 @@
 <context>
     <name>ComicVineDialog</name>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="58"/>
         <source>back</source>
         <translation>назад</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="59"/>
         <source>next</source>
         <translation>дальше</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="57"/>
         <source>skip</source>
         <translation>пропустить</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="61"/>
         <source>close</source>
         <translation>закрыть</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="467"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="503"/>
         <source>Retrieving tags for : %1</source>
         <translation>Получение тегов для : %1</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="814"/>
         <source>Looking for comic...</source>
         <translation>Поиск комикса...</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="60"/>
         <source>search</source>
         <translation>искать</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="143"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="257"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="773"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="807"/>
         <source>Looking for volume...</source>
         <translation>Поиск информации...</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="141"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="735"/>
         <source>comic %1 of %2 - %3</source>
         <translation>комикс %1 of %2 - %3</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="262"/>
         <source>%1 comics selected</source>
         <translation>%1 было выбрано</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="295"/>
         <source>Error connecting to ComicVine</source>
         <translation>Ошибка поключения к ComicVine</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="788"/>
         <source>Retrieving volume info...</source>
         <translation>Получение информации...</translation>
     </message>
@@ -264,34 +333,42 @@
 <context>
     <name>CreateLibraryDialog</name>
     <message>
+        <location filename="create_library_dialog.cpp" line="75"/>
         <source>Create new library</source>
         <translation>Создать новую библиотеку</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="31"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="27"/>
         <source>Create</source>
         <translation>Создать</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="53"/>
         <source>Create a library could take several minutes. You can stop the process and update the library later for completing the task.</source>
         <translation>Создание библиотеки может занять несколько минут. Вы можете остановить процесс и обновить библиотеку позже для завершения задачи.</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="95"/>
         <source>The selected path does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation>Выбранный путь отсутствует, либо неверен. Убедитесь , что у вас есть доступ к этой папке</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="17"/>
         <source>Comics folder : </source>
         <translation>Папка комиксов : </translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="22"/>
         <source>Library Name : </source>
         <translation>Имя библиотеки:</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="95"/>
         <source>Path not found</source>
         <translation>Путь не найден</translation>
     </message>
@@ -299,22 +376,27 @@
 <context>
     <name>EditShortcutsDialog</name>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>Shortcut in use</source>
         <translation>Горячая клавиша уже занята</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="21"/>
         <source>Restore defaults</source>
         <translation>Вернуть к первоначальным значениям</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="69"/>
         <source>Shortcuts settings</source>
         <translation>Горячие клавиши</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>The shortcut &quot;%1&quot; is already assigned to other function</source>
         <translation>Сочетание клавиш &quot;%1&quot; уже назначено для другой функции</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="22"/>
         <source>To change a shortcut, double click in the key combination and type the new keys.</source>
         <translation>Чтобы изменить горячую клавишу щелкните дважды по выбранной комбинации клавиш и введите новые сочетания клавиш.</translation>
     </message>
@@ -322,14 +404,18 @@
 <context>
     <name>EmptyFolderWidget</name>
     <message>
+        <location filename="empty_folder_widget.cpp" line="138"/>
         <source>Empty folder</source>
         <translation>Пустая папка</translation>
     </message>
     <message>
+        <location filename="empty_folder_widget.cpp" line="75"/>
+        <location filename="empty_folder_widget.cpp" line="140"/>
         <source>Subfolders in this folder</source>
         <translation>Подпапки в этой папке</translation>
     </message>
     <message>
+        <location filename="empty_folder_widget.cpp" line="138"/>
         <source>Drag and drop folders and comics here</source>
         <translation>Перетащите папки и комиксы сюда</translation>
     </message>
@@ -337,6 +423,7 @@
 <context>
     <name>EmptyLabelWidget</name>
     <message>
+        <location filename="empty_label_widget.cpp" line="11"/>
         <source>This label doesn&apos;t contain comics yet</source>
         <translation>Этот ярлык пока ничего не содержит</translation>
     </message>
@@ -344,6 +431,7 @@
 <context>
     <name>EmptyReadingListWidget</name>
     <message>
+        <location filename="empty_reading_list_widget.cpp" line="8"/>
         <source>This reading list does not contain any comics yet</source>
         <translation>Этот список чтения пока ничего не содержит</translation>
     </message>
@@ -351,30 +439,37 @@
 <context>
     <name>ExportComicsInfoDialog</name>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="14"/>
         <source>Output file : </source>
         <translation>Выходной файл (*.ydb) : </translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="66"/>
         <source>Destination database name</source>
         <translation>Имя этой базы данных</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="22"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="18"/>
         <source>Create</source>
         <translation>Создать</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="81"/>
         <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation>Выбранный путь для импортируемого файла отсутствует, либо неверен. Убедитесь , что у вас есть доступ к этой папке</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="57"/>
         <source>Export comics info</source>
         <translation>Экспортировать информацию комикса</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="81"/>
         <source>Problem found while writing</source>
         <translation>Обнаружена Ошибка записи</translation>
     </message>
@@ -382,30 +477,37 @@
 <context>
     <name>ExportLibraryDialog</name>
     <message>
+        <location filename="export_library_dialog.cpp" line="19"/>
         <source>Cancel</source>
         <translation>Отменить</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="15"/>
         <source>Create</source>
         <translation>Создать</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="71"/>
         <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation>Выбранный путь для импортируемого файла отсутствует, либо неверен. Убедитесь , что у вас есть доступ к этой папке</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="11"/>
         <source>Output folder : </source>
         <translation>Папка вывода : </translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="71"/>
         <source>Problem found while writing</source>
         <translation>Проблема при написании</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="60"/>
         <source>Create covers package</source>
         <translation>Создать комплект обложек</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="76"/>
         <source>Destination directory</source>
         <translation>Назначенная директория</translation>
     </message>
@@ -413,25 +515,46 @@
 <context>
     <name>FileComic</name>
     <message>
+        <location filename="../common/comic.cpp" line="568"/>
         <source>Format not supported</source>
         <translation>Формат не поддерживается</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="562"/>
         <source>7z not found</source>
         <translation>7z не найден</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="461"/>
         <source>Unknown error opening the file</source>
         <translation>Неизвестная ошибка при открытии файла</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="454"/>
         <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
         <translation>Ошибка контрольной суммы CRC на странице (%1): некоторые страницы будут отображаться неправильно</translation>
     </message>
 </context>
 <context>
+    <name>FolderContentView</name>
+    <message>
+        <location filename="qml/FolderContentView.qml" line="238"/>
+        <source>Continue Reading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FolderContentView6</name>
+    <message>
+        <location filename="qml/FolderContentView6.qml" line="240"/>
+        <source>Continue Reading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GridComicsView</name>
     <message>
+        <location filename="grid_comics_view.cpp" line="147"/>
         <source>Show info</source>
         <translation>Показать информацию</translation>
     </message>
@@ -439,10 +562,17 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Настройки</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
+        <source>System info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation>О программе</translation>
     </message>
@@ -450,22 +580,27 @@
 <context>
     <name>ImportComicsInfoDialog</name>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="24"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="20"/>
         <source>Import</source>
         <translation>Импортировать</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="16"/>
         <source>Info database location : </source>
         <translation>Путь к файлу (*.ydb) : </translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="14"/>
         <source>Import comics info</source>
         <translation>Импортировать информацию комикса</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="74"/>
         <source>Comics info file (*.ydb)</source>
         <translation>Инфо файл комикса (*.ydb)</translation>
     </message>
@@ -473,30 +608,37 @@
 <context>
     <name>ImportLibraryDialog</name>
     <message>
+        <location filename="import_library_dialog.cpp" line="26"/>
         <source>Destination folder : </source>
         <translation>Папка назначения : </translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="34"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="30"/>
         <source>Unpack</source>
         <translation>Распаковать</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="108"/>
         <source>Compresed library covers (*.clc)</source>
         <translation>Сжатая библиотека обложек (*.clc)</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="22"/>
         <source>Package location : </source>
         <translation>Местоположение комплекта : </translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="17"/>
         <source>Library Name : </source>
         <translation>Имя библиотеки : </translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="87"/>
         <source>Extract a catalog</source>
         <translation>Извлечь каталог</translation>
     </message>
@@ -504,249 +646,329 @@
 <context>
     <name>ImportWidget</name>
     <message>
+        <location filename="import_widget.cpp" line="150"/>
         <source>stop</source>
         <translation>Остановить</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="334"/>
         <source>Importing comics</source>
         <translation>Импорт комиксов</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="335"/>
         <source>&lt;p&gt;YACReaderLibrary is now creating a new library.&lt;/p&gt;&lt;p&gt;Create a library could take several minutes. You can stop the process and update the library later for completing the task.&lt;/p&gt;</source>
         <translation>&lt;p&gt;YACReaderLibrary сейчас создает библиотеку.&lt;/p&gt;&lt;p&gt; Создание библиотеки может занять несколько минут. Вы можете остановить процесс и обновить библиотеку позже для завершения задачи.&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="190"/>
         <source>Some of the comics being added...</source>
         <translation>Поиск новых комиксов...</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="346"/>
         <source>Updating the library</source>
         <translation>Обновление библиотеки</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="347"/>
         <source>&lt;p&gt;The current library is being updated. For faster updates, please, update your libraries frequently.&lt;/p&gt;&lt;p&gt;You can stop the process and continue updating this library later.&lt;/p&gt;</source>
         <translation>&lt;p&gt;Текущая библиотека обновляется. Для более быстрого обновления в дальнейшем старайтесь почаще обновлять вашу библиотеку после добавления новых комиксов.&lt;/p&gt;&lt;p&gt;Вы можете остановить этот процесс и продолжить обновление этой библиотеки позже.&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="358"/>
         <source>Upgrading the library</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="359"/>
         <source>&lt;p&gt;The current library is being upgraded, please wait.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="370"/>
+        <source>Scanning the library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="371"/>
+        <source>&lt;p&gt;Current library is being scanned for legacy XML metadata information.&lt;/p&gt;&lt;p&gt;This is only needed once, and only if the library was crated with YACReaderLibrary 9.8.2 or earlier.&lt;/p&gt;</source>
         <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LibraryWindow</name>
     <message>
+        <location filename="library_window.cpp" line="730"/>
         <source>Edit</source>
         <translation>Редактировать информацию</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2083"/>
         <source>The selected folder doesn&apos;t contain any library.</source>
         <translation>Выбранная папка не содержит ни одной библиотеки.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1269"/>
         <source>This library was created with a previous version of YACReaderLibrary. It needs to be updated. Update now?</source>
         <translation>Эта библиотека была создана с предыдущей версией YACReaderLibrary. Она должна быть обновлена. Обновить сейчас?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1060"/>
         <source>Comic</source>
         <translation>Комикс</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1575"/>
         <source>Folder name:</source>
         <translation>Имя папки:</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1610"/>
         <source>The selected folder and all its contents will be deleted from your disk. Are you sure?</source>
         <translation>Выбранная папка и все ее содержимое будет удалено с вашего жёсткого диска. Вы уверены?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="787"/>
         <source>Update current folder</source>
         <translation>Обновить выбранную папку</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2659"/>
         <source>Error opening the library</source>
         <translation>Ошибка открытия библиотеки</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="585"/>
         <source>Show/Hide marks</source>
         <translation>Показать/Спрятать пометки</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1993"/>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found</source>
         <translation>YACReader не найден</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="648"/>
         <source>Show comics server options dialog</source>
         <translation>Настройки сервера YACReader</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1636"/>
         <source>There was an issue trying to delete the selected folders. Please, check for write permissions and be sure that any applications are using these folders or any of the contained files.</source>
         <translation>Возникла проблема при удалении выбранных папок. Пожалуйста, проверьте права на запись и убедитесь что другие приложения не используют эти папки или файлы.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="532"/>
         <source>Remove current library from your collection</source>
         <translation>Удалить эту библиотеку из своей коллекции</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="554"/>
         <source>Set comic as read</source>
         <translation>Отметить комикс как прочитано</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1697"/>
         <source>Rename list name</source>
         <translation>Изменить имя списка</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="822"/>
         <source>Add selected comics to favorites list</source>
         <translation>Добавить выбранные комиксы в список избранного</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2139"/>
         <source>Remove and delete metadata</source>
         <translation>Удаление метаданных</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Old library</source>
         <translation>Библиотека из старой версии YACreader</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="742"/>
         <source>Update cover</source>
         <translation>Обновить обложки</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="813"/>
         <source>Rename any selected labels or lists</source>
         <translation>Переименовать выбранный ярлык/список чтения</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="685"/>
+        <location filename="library_window.cpp" line="1797"/>
         <source>Set as completed</source>
         <translation>Отметить как завершено</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1608"/>
         <source>There was an error accessing the folder&apos;s path</source>
         <translation>Ошибка доступа к пути папки</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1027"/>
         <source>Library</source>
         <translation>Библиотека</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="612"/>
         <source>Add new folder to the current library</source>
         <translation>Добавить новую папку в текущую библиотеку</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Comics will only be deleted from the current label/list. Are you sure?</source>
         <translation>Комиксы будут удалены только из выбранного списка/ярлыка. Вы уверены?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="526"/>
         <source>Rename current library</source>
         <translation>Переименовать эту библиотеку</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="593"/>
+        <location filename="library_window.cpp" line="594"/>
         <source>Fullscreen mode on/off</source>
         <translation>Полноэкранный режим включить/выключить</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1336"/>
         <source>This library was created with a newer version of YACReaderLibrary. Download the new version now?</source>
         <translation>Эта библиотека была создана новой версией YACReaderLibrary. Скачать новую версию сейчас?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1426"/>
+        <location filename="library_window.cpp" line="1464"/>
         <source>Moving comics...</source>
         <translation>Переместить комиксы...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="543"/>
         <source>Open current comic on YACReader</source>
         <translation>Открыть комикс в YACReader</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="520"/>
         <source>Update current library</source>
         <translation>Обновить эту библиотеку</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1409"/>
+        <location filename="library_window.cpp" line="1445"/>
         <source>Copying comics...</source>
         <translation>Скопировать комиксы...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library &apos;%1&apos; is no longer available. Do you want to remove it?</source>
         <translation>Библиотека &apos;%1&apos; больше не доступна. Вы хотите удалить ее?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="519"/>
         <source>Update library</source>
         <translation>Обновить библиотеку</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="674"/>
+        <location filename="library_window.cpp" line="1787"/>
         <source>Open folder...</source>
         <translation>Открыть папку...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Do you want remove </source>
         <translation>Вы хотите удалить библиотеку </translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="680"/>
+        <location filename="library_window.cpp" line="1794"/>
         <source>Set as uncompleted</source>
         <translation>Отметить как не завершено</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1608"/>
         <source>Error in path</source>
         <translation>Ошибка в пути</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="718"/>
         <source>Reset comic rating</source>
         <translation>Сбросить рейтинг комикса</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2654"/>
         <source>Error updating the library</source>
         <translation>Ошибка обновления библиотеки</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1046"/>
         <source>Folder</source>
         <translation>Папка</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1667"/>
         <source>The selected item will be deleted, your comics or folders will NOT be deleted from your disk. Are you sure?</source>
         <translation>Выбранные элементы будут удалены, ваши комиксы или папки НЕ БУДУТ удалены с вашего жёсткого диска. Вы уверены?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="628"/>
         <source>Expand all nodes</source>
         <translation>Раскрыть все папки</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="618"/>
         <source>Delete current folder from disk</source>
         <translation>Удалить выбранную папку с жёсткого диска</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1649"/>
+        <location filename="library_window.cpp" line="1698"/>
         <source>List name:</source>
         <translation>Имя списка:</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="817"/>
         <source>Add to...</source>
         <translation>Добавить в...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Library &apos;%1&apos; has been created with an older version of YACReaderLibrary. It must be created again. Do you want to create the library now?</source>
         <translation>Библиотека &apos;%1&apos; была создана старой версией YACReaderLibrary. Она должна быть вновь создана. Вы хотите создать библиотеку сейчас?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="507"/>
         <source>Pack covers</source>
         <translation>Запаковать обложки</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1916"/>
         <source>Save covers</source>
         <translation>Сохранить обложки</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="655"/>
+        <location filename="library_window.cpp" line="656"/>
         <source>Change between comics views</source>
         <translation>Изменение внешнего вида потока комиксов</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="801"/>
         <source>Remove current reading list from the library</source>
         <translation>Удалить выбранный ярлык/список чтения</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1648"/>
         <source>Add new reading lists</source>
         <translation>Добавить новый список чтения</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.
 
 You probably only need one library in your top level comics folder, you can browse any subfolders using the folders section in the left sidebar.
@@ -759,266 +981,370 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 YACReaderLibrary не помешает вам создать больше библиотек, но вы должны иметь не большое количество библиотек.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="553"/>
+        <location filename="library_window.cpp" line="690"/>
+        <location filename="library_window.cpp" line="1800"/>
         <source>Set as read</source>
         <translation>Отметить как прочитано</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2448"/>
         <source>Assign comics numbers</source>
         <translation>Порядковый номер</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="748"/>
         <source>Delete selected comics</source>
         <translation>Удалить выбранное</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="495"/>
+        <location filename="library_window.cpp" line="496"/>
         <source>Export comics info</source>
         <translation>Экспортировать информацию комикса</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="640"/>
         <source>Show options dialog</source>
         <translation>Настройки</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1604"/>
         <source>Please, select a folder first</source>
         <translation>Пожалуйста, сначала выберите папку</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="484"/>
         <source>Create a new library</source>
         <translation>Создать новую библиотеку</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library not available</source>
         <translation>Библиотека не доступна</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="501"/>
+        <location filename="library_window.cpp" line="502"/>
         <source>Import comics info</source>
         <translation>Импортировать информацию комикса</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2417"/>
         <source>There was an issue trying to delete the selected comics. Please, check for write permissions in the selected files or containing folder.</source>
         <translation>Возникла проблема при удалении выбранных комиксов. Пожалуйста, проверьте права на запись для выбранных файлов или содержащую их папку.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="792"/>
         <source>Add new reading list</source>
         <translation>Создать новый список чтения</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="548"/>
         <source>Save selected covers to...</source>
         <translation>Сохранить выбранные обложки в...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="542"/>
         <source>Open current comic</source>
         <translation>Открыть выбранный комикс</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="188"/>
         <source>YACReader Library</source>
         <translation>Библиотека YACReader</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="795"/>
         <source>Add a new reading list to the current library</source>
         <translation>Создать новый список чтения</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2649"/>
         <source>Error creating the library</source>
         <translation>Ошибка создания библиотеки</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.</source>
         <translation>Вы добавляете слишком много библиотек.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="784"/>
+        <location filename="library_window.cpp" line="1790"/>
         <source>Update folder</source>
         <translation>Обновить папку</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="513"/>
         <source>Unpack covers</source>
         <translation>Распаковать обложки</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1269"/>
         <source>Update needed</source>
         <translation>Необходимо обновление</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="490"/>
         <source>Open an existing library</source>
         <translation>Открыть существующую библиотеку</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="586"/>
         <source>Show or hide read marks</source>
         <translation>Показать или спрятать отметку прочтено</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2805"/>
         <source>Library name already exists</source>
         <translation>Имя папки уже используется</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2805"/>
         <source>There is another library with the name &apos;%1&apos;.</source>
         <translation>Уже существует другая папка с именем &apos;%1&apos;.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="798"/>
         <source>Remove reading list</source>
         <translation>Удалить список чтения</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="615"/>
+        <location filename="library_window.cpp" line="1610"/>
         <source>Delete folder</source>
         <translation>Удалить папку</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2449"/>
         <source>Assign numbers starting in:</source>
         <translation>Назначить порядковый номер начиная с:</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1336"/>
         <source>Download new version</source>
         <translation>Загрузить новую версию</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2694"/>
         <source>Delete comics</source>
         <translation>Удалить комиксы</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="609"/>
+        <location filename="library_window.cpp" line="1574"/>
         <source>Add new folder</source>
         <translation>Добавить новую папку</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="724"/>
         <source>Select all comics</source>
         <translation>Выбрать все комиксы</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="736"/>
         <source>Assign current order to comics</source>
         <translation>Назначить порядковый номер</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="508"/>
         <source>Pack the covers of the selected library</source>
         <translation>Запаковать обложки выбранной библиотеки</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="602"/>
         <source>Help, About YACReader</source>
         <translation>О программе</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="634"/>
         <source>Collapse all nodes</source>
         <translation>Свернуть все папки</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="819"/>
         <source>Favorites</source>
         <translation>Избранное</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="810"/>
         <source>Rename selected list</source>
         <translation>Переименовать выбранный список</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1667"/>
         <source>Delete list/label</source>
         <translation>Удалить список/ярлык</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="560"/>
         <source>Set comic as unread</source>
         <translation>Отметить комикс как не прочитано</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="771"/>
         <source>Edit shortcuts</source>
         <translation>Редактировать горячие клавиши</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="624"/>
         <source>Select root node</source>
         <translation>Домашняя папка</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1604"/>
         <source>No folder selected</source>
         <translation>Ни одна папка не была выбрана</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="514"/>
         <source>Unpack a catalog</source>
         <translation>Распаковать каталог</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2694"/>
         <source>All the selected comics will be deleted from your disk. Are you sure?</source>
         <translation>Все выбранные комиксы будут удалены с вашего жёсткого диска. Вы уверены?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="756"/>
         <source>Download tags from Comic Vine</source>
         <translation>Скачать теги из Comic Vine</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Remove comics</source>
         <translation>Убрать комиксы</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="807"/>
         <source>Add a new label to this library</source>
         <translation>Создать новый ярлык</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="559"/>
+        <location filename="library_window.cpp" line="695"/>
+        <location filename="library_window.cpp" line="1803"/>
         <source>Set as unread</source>
         <translation>Отметить как не прочитано</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2083"/>
         <source>Library not found</source>
         <translation>Библиотека не найдена</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="525"/>
         <source>Rename library</source>
         <translation>Переименовать библиотеку</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="531"/>
         <source>Remove library</source>
         <translation>Удалить библиотеку</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="712"/>
         <source>Open containing folder...</source>
         <translation>Открыть выбранную папку...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="804"/>
         <source>Add new label</source>
         <translation>Создать новый ярлык</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1636"/>
+        <location filename="library_window.cpp" line="2417"/>
         <source>Unable to delete</source>
         <translation>Не удалось удалить</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source> library?</source>
         <translation>?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="549"/>
         <source>Save covers of the selected comics as JPG files</source>
         <translation>Сохранить обложки выбранных комиксов как JPG файлы</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Are you sure?</source>
         <translation>Вы уверены?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="565"/>
+        <location filename="library_window.cpp" line="700"/>
+        <location filename="library_window.cpp" line="1806"/>
         <source>Set as manga</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="537"/>
+        <source>Rescan library for XML info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="538"/>
+        <source>Tries to find XML info embedded in comic files. You only need to do this if the library was created with 9.8.2 or earlier versions or if you are using third party software to embed XML info in the files.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="566"/>
         <source>Set issue as manga</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="571"/>
         <source>Set as normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="572"/>
         <source>Set issue as normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="705"/>
+        <location filename="library_window.cpp" line="1809"/>
         <source>Set as comic</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="760"/>
+        <source>Focus search line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="766"/>
+        <source>Focus comics view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="777"/>
+        <source>&amp;Quit</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1251"/>
         <source>Upgrade failed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1251"/>
         <source>There were errors during library upgrade in: </source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1993"/>
         <source>YACReader not found. YACReader should be installed in the same folder as YACReaderLibrary.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found. There might be a problem with your YACReader installation.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1026,6 +1352,7 @@ YACReaderLibrary не помешает вам создать больше биб
 <context>
     <name>LocalComicListModel</name>
     <message>
+        <location filename="comic_vine/model/local_comic_list_model.cpp" line="72"/>
         <source>file name</source>
         <translation>имя файла</translation>
     </message>
@@ -1033,30 +1360,37 @@ YACReaderLibrary не помешает вам создать больше биб
 <context>
     <name>LogWindow</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="14"/>
         <source>Log window</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="22"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="39"/>
         <source>&amp;Save</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="56"/>
         <source>C&amp;lear</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="73"/>
         <source>&amp;Copy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="90"/>
         <source>Level:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="136"/>
         <source>&amp;Auto scroll</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1064,18 +1398,22 @@ YACReaderLibrary не помешает вам создать больше биб
 <context>
     <name>NoLibrariesWidget</name>
     <message>
+        <location filename="no_libraries_widget.cpp" line="32"/>
         <source>create your first library</source>
         <translation>создайте свою первую библиотеку</translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="26"/>
         <source>You don&apos;t have any libraries yet</source>
         <translation>У вас нет ни одной библиотеки</translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="28"/>
         <source>&lt;p&gt;You can create a library in any folder, YACReaderLibrary will import all comics and folders from this folder. If you have created any library in the past you can open them.&lt;/p&gt;&lt;p&gt;Don&apos;t forget that you can use YACReader as a stand alone application for reading the comics on your computer.&lt;/p&gt;</source>
         <translation>&lt;p&gt;Вы можете создать библиотеку в любой папке, YACReaderLibrary будет импортировать все комиксы и папки из этой папки. Если вы уже ранее создавали библиотеки, их можно будет открыть.&lt; / p &gt; &lt;p&gt;Не забывайте, что Вы можете использовать YACReader в качестве отдельного приложения для чтения комиксов на вашем компьютере.&lt;/п&gt;</translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="34"/>
         <source>add an existing one</source>
         <translation>добавить уже существующую</translation>
     </message>
@@ -1083,70 +1421,87 @@ YACReaderLibrary не помешает вам создать больше биб
 <context>
     <name>OptionsDialog</name>
     <message>
+        <location filename="options_dialog.cpp" line="92"/>
         <source>Restore defautls</source>
         <translation>Вернуть к первоначальным значениям</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="103"/>
         <source>Background</source>
         <translation>Фоновое изображение</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="85"/>
         <source>Blur level</source>
         <translation>Уровень размытия</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="78"/>
         <source>Enable background image</source>
         <translation>Включить фоновое изображение</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="156"/>
         <source>Options</source>
         <translation>Настройки</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="72"/>
         <source>Comic Vine API key</source>
         <translation>Comic Vine API ключ</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="69"/>
         <source>Edit Comic Vine API key</source>
         <translation>Редактировать Comic Vine API ключ</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="80"/>
         <source>Opacity level</source>
         <translation>Уровень непрозрачности</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="148"/>
         <source>General</source>
         <translation>Основные</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="90"/>
         <source>Use selected comic cover as background</source>
         <translation>Обложка комикса фоновое изображение</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="144"/>
         <source>Comic Flow</source>
         <translation>Поток комиксов</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="146"/>
         <source>Grid view</source>
         <translation>Фоновое изображение</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="47"/>
         <source>Tray icon settings (experimental)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="50"/>
         <source>Close to tray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="51"/>
         <source>Start into the system tray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="106"/>
         <source>Display continue reading banner</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="111"/>
         <source>Continue reading</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1154,142 +1509,178 @@ YACReaderLibrary не помешает вам создать больше биб
 <context>
     <name>PropertiesDialog</name>
     <message>
+        <location filename="properties_dialog.cpp" line="240"/>
         <source>Day:</source>
         <translation>День:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="85"/>
         <source>Plot</source>
         <translation>Сюжет</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="177"/>
         <source>Size:</source>
         <translation>Размер:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="248"/>
         <source>Year:</source>
         <translation>Год:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="207"/>
         <source>Inker(s):</source>
         <translation>Контуровщик(и):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="84"/>
         <source>Publishing</source>
         <translation>Издатели</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="256"/>
         <source>Publisher:</source>
         <translation>Издатель:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="82"/>
         <source>General info</source>
         <translation>Общая информация</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="258"/>
         <source>Color/BW:</source>
         <translation>Цвет/BW:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="501"/>
         <source>Edit selected comics information</source>
         <translation>Редактировать информацию выбранного комикса</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="200"/>
         <source>Penciller(s):</source>
         <translation>Художник(и):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="210"/>
         <source>Colorist(s):</source>
         <translation>Колорист(ы):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="175"/>
         <source>Genre:</source>
         <translation>Жанр:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="158"/>
         <source>Issue number:</source>
         <translation>Номер выпуска</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="244"/>
         <source>Month:</source>
         <translation>Месяц:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="275"/>
         <source>Notes:</source>
         <translation>Заметки:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="273"/>
         <source>Synopsis:</source>
         <translation>Описание:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="143"/>
         <source>Title:</source>
         <translation>Заголовок:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Not found</source>
         <translation>Не найдено</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="274"/>
         <source>Characters:</source>
         <translation>Персонажи:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="83"/>
         <source>Authors</source>
         <translation>Авторы</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="259"/>
         <source>Age rating:</source>
         <translation>Возрастной рейтинг:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="173"/>
         <source>Story arc:</source>
         <translation>Сюжетная арка:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="197"/>
         <source>Writer(s):</source>
         <translation>Писатель(и):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Comic not found. You should update your library.</source>
         <translation>Комикс не найден. Обновите вашу библиотеку.</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="467"/>
         <source>Edit comic information</source>
         <translation>Редактировать информацию комикса</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="94"/>
         <source>Cover page</source>
         <translation>Страница обложки</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="220"/>
         <source>Cover Artist(s):</source>
         <translation>Художник(и) Обложки:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="369"/>
         <source>Comic Vine link: &lt;a style=&apos;color: #FFCB00; text-decoration:none; font-weight:bold;&apos; href=&quot;http://www.comicvine.com/comic/4000-%1/&quot;&gt; view &lt;/a&gt;</source>
         <translation>&lt;a style=&apos;color: ##666666; text-decoration:none; font-weight:bold;&apos; href=&quot;http://www.comicvine.com/comic/4000-%1/&quot;&gt; Открыть страницу этого комикса на сайте Comic Vine &lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="160"/>
         <source>Volume:</source>
         <translation>Объём :</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="257"/>
         <source>Format:</source>
         <translation>Формат:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="217"/>
         <source>Letterer(s):</source>
         <translation>Гравёр-шрифтовик(и):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="151"/>
+        <location filename="properties_dialog.cpp" line="168"/>
         <source>of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="164"/>
         <source>Arc number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="260"/>
         <source>Manga:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1297,34 +1688,42 @@ YACReaderLibrary не помешает вам создать больше биб
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>7z lib not found</source>
         <translation>Библиотека распаковщика 7z не найдена</translation>
     </message>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>unable to load 7z lib from ./utils</source>
         <translation>Не удается загрузить библиотеку распаковщика 7z из ./utils</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41"/>
         <source>Trace</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45"/>
         <source>Info</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47"/>
         <source>Warning</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49"/>
         <source>Error</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51"/>
         <source>Fatal</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1332,14 +1731,17 @@ YACReaderLibrary не помешает вам создать больше биб
 <context>
     <name>QsLogging::LogWindowModel</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="141"/>
         <source>Time</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="143"/>
         <source>Level</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="145"/>
         <source>Message</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1347,18 +1749,22 @@ YACReaderLibrary не помешает вам создать больше биб
 <context>
     <name>QsLogging::Window</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Pause</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Resume</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="236"/>
         <source>Save log</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="237"/>
         <source>Log file (*.log)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1366,18 +1772,22 @@ YACReaderLibrary не помешает вам создать больше биб
 <context>
     <name>RenameLibraryDialog</name>
     <message>
+        <location filename="rename_library_dialog.cpp" line="51"/>
         <source>Rename current library</source>
         <translation>Переименовать эту библиотеку</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="24"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="20"/>
         <source>Rename</source>
         <translation>Переименовать</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="15"/>
         <source>New Library Name : </source>
         <translation>Новое имя библиотеки:</translation>
     </message>
@@ -1385,14 +1795,18 @@ YACReaderLibrary не помешает вам создать больше биб
 <context>
     <name>ScraperResultsPaginator</name>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="54"/>
         <source>Number of %1 found : %2</source>
         <translation>Количество из %1 найдено : %2</translation>
     </message>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="32"/>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="55"/>
         <source>page %1 of %2</source>
         <translation>страница %1 из %2</translation>
     </message>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="30"/>
         <source>Number of volumes found : %1</source>
         <translation>Количество найденных томов : %1</translation>
     </message>
@@ -1400,10 +1814,12 @@ YACReaderLibrary не помешает вам создать больше биб
 <context>
     <name>SearchSingleComic</name>
     <message>
+        <location filename="comic_vine/search_single_comic.cpp" line="14"/>
         <source>Please provide some additional information.</source>
         <translation>Пожалуйста, введите инфомарцию для поиска.</translation>
     </message>
     <message>
+        <location filename="comic_vine/search_single_comic.cpp" line="19"/>
         <source>Series:</source>
         <translation>Серия:</translation>
     </message>
@@ -1411,10 +1827,12 @@ YACReaderLibrary не помешает вам создать больше биб
 <context>
     <name>SearchVolume</name>
     <message>
+        <location filename="comic_vine/search_volume.cpp" line="11"/>
         <source>Please provide some additional information.</source>
         <translation>Пожалуйста, введите инфомарцию для поиска.</translation>
     </message>
     <message>
+        <location filename="comic_vine/search_volume.cpp" line="14"/>
         <source>Series:</source>
         <translation>Серия:</translation>
     </message>
@@ -1422,22 +1840,27 @@ YACReaderLibrary не помешает вам создать больше биб
 <context>
     <name>SelectComic</name>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="95"/>
         <source>loading description</source>
         <translation>загрузка описания</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="38"/>
         <source>comics</source>
         <translation>комиксы</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="94"/>
         <source>loading cover</source>
         <translation>загрузка обложки</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="18"/>
         <source>Please, select the right comic info.</source>
         <translation>Пожалуйста, выберите правильную информацию об комиксе.</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="135"/>
         <source>description unavailable</source>
         <translation>описание недоступно</translation>
     </message>
@@ -1445,22 +1868,37 @@ YACReaderLibrary не помешает вам создать больше биб
 <context>
     <name>SelectVolume</name>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="145"/>
         <source>loading description</source>
         <translation>загрузка описания</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="35"/>
         <source>Please, select the right series for your comic.</source>
         <translation>Пожалуйста, выберите правильную серию для вашего комикса.</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="56"/>
+        <source>Filter:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="138"/>
+        <source>Nothing found, clear the filter if any.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="144"/>
         <source>loading cover</source>
         <translation>загрузка обложки</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="68"/>
         <source>volumes</source>
         <translation>тома</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="185"/>
         <source>description unavailable</source>
         <translation>описание недоступно</translation>
     </message>
@@ -1468,14 +1906,17 @@ YACReaderLibrary не помешает вам создать больше биб
 <context>
     <name>SeriesQuestion</name>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="15"/>
         <source>no</source>
         <translation>нет</translation>
     </message>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="14"/>
         <source>yes</source>
         <translation>да</translation>
     </message>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="12"/>
         <source>You are trying to get information for various comics at once, are they part of the same series?</source>
         <translation>Вы пытаетесь получить информацию для нескольких комиксов одновременно, являются ли они все частью одной серии?</translation>
     </message>
@@ -1483,40 +1924,49 @@ YACReaderLibrary не помешает вам создать больше биб
 <context>
     <name>ServerConfigDialog</name>
     <message>
+        <location filename="server_config_dialog.cpp" line="115"/>
         <source>Port</source>
         <translation>Порт</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="102"/>
         <source>YACReader is available for iOS devices. &lt;a href=&apos;http://ios.yacreader.com&apos; style=&apos;color:rgb(193, 148, 65)&apos;&gt; Discover it! &lt;/a&gt;</source>
         <translation>&lt;a href=&apos;http://ios.yacreader.com&apos; style=&apos;color:rgb(102,102,102)&apos;&gt;YACReader доступен для устройств с iOS.&lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="147"/>
         <source>enable the server</source>
         <translation>активировать сервер</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="92"/>
         <source>Server connectivity information</source>
         <translation>Информация о подключении</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="152"/>
         <source>display less information about folders in the browser
 to improve the performance</source>
         <translation>отображать меньше информации о папках в браузере
 для улучшения производительности</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="96"/>
         <source>Scan it!</source>
         <translation>Сканируйте!</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="86"/>
         <source>set port</source>
         <translation>указать порт</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="111"/>
         <source>Choose an IP address</source>
         <translation>Выбрать IP адрес</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="268"/>
         <source>Could not load libqrencode.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1524,22 +1974,27 @@ to improve the performance</source>
 <context>
     <name>SortVolumeComics</name>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="87"/>
         <source>remove selected comics</source>
         <translation>удалить выбранные комиксы</translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="21"/>
         <source>sort comics to match comic information</source>
         <translation>сортировать комиксы, чтобы соответствовать информации комиксов</translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="88"/>
         <source>restore all removed comics</source>
         <translation>восстановить все удаленные комиксы</translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="58"/>
         <source>issues</source>
         <translation>выпуск</translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="18"/>
         <source>Please, sort the list of comics on the left until it matches the comics&apos; information.</source>
         <translation>Пожалуйста, отсортируйте список комиксов слева, пока он не будет соответствовать информации комикса.</translation>
     </message>
@@ -1547,6 +2002,7 @@ to improve the performance</source>
 <context>
     <name>TitleHeader</name>
     <message>
+        <location filename="comic_vine/title_header.cpp" line="30"/>
         <source>SEARCH</source>
         <translation>ПОИСК</translation>
     </message>
@@ -1554,14 +2010,17 @@ to improve the performance</source>
 <context>
     <name>UpdateLibraryDialog</name>
     <message>
+        <location filename="create_library_dialog.cpp" line="180"/>
         <source>Update library</source>
         <translation>Обновить библиотеку</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="161"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="155"/>
         <source>Updating....</source>
         <translation>Обновление...</translation>
     </message>
@@ -1569,6 +2028,7 @@ to improve the performance</source>
 <context>
     <name>VolumeComicsModel</name>
     <message>
+        <location filename="comic_vine/model/volume_comics_model.cpp" line="120"/>
         <source>title</source>
         <translation>название</translation>
     </message>
@@ -1576,14 +2036,17 @@ to improve the performance</source>
 <context>
     <name>VolumesModel</name>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="118"/>
         <source>year</source>
         <translation>год</translation>
     </message>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="120"/>
         <source>issues</source>
         <translation>выпуск</translation>
     </message>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="122"/>
         <source>publisher</source>
         <translation>издатель</translation>
     </message>
@@ -1591,18 +2054,17 @@ to improve the performance</source>
 <context>
     <name>YACReader::TrayIconController</name>
     <message>
+        <location filename="trayicon_controller.cpp" line="52"/>
         <source>&amp;Restore</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>&amp;Quit</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="trayicon_controller.cpp" line="79"/>
         <source>Systray</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="trayicon_controller.cpp" line="80"/>
         <source>YACReaderLibrary will keep running in the system tray. To terminate the program, choose &lt;b&gt;Quit&lt;/b&gt; in the context menu of the system tray icon.</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1610,6 +2072,7 @@ to improve the performance</source>
 <context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1617,10 +2080,12 @@ to improve the performance</source>
 <context>
     <name>YACReaderDeletingProgress</name>
     <message>
+        <location filename="../custom_widgets/yacreader_deleting_progress.cpp" line="35"/>
         <source>cancel</source>
         <translation>отменить</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_deleting_progress.cpp" line="20"/>
         <source>Please wait, deleting in progress...</source>
         <translation>Пожалуйста подождите, удаление в процессе...</translation>
     </message>
@@ -1628,10 +2093,13 @@ to improve the performance</source>
 <context>
     <name>YACReaderFieldEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11"/>
         <source>Restore to default</source>
         <translation>Вернуть к первоначальным значениям</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28"/>
         <source>Click to overwrite</source>
         <translation>Изменить</translation>
     </message>
@@ -1639,10 +2107,15 @@ to improve the performance</source>
 <context>
     <name>YACReaderFieldPlainTextEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10"/>
         <source>Restore to default</source>
         <translation>Вернуть к первоначальным значениям</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50"/>
         <source>Click to overwrite</source>
         <translation>Изменить</translation>
     </message>
@@ -1650,18 +2123,22 @@ to improve the performance</source>
 <context>
     <name>YACReaderFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="15"/>
         <source>CoverFlow look</source>
         <translation>Рулеткой</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="13"/>
         <source>How to show covers:</source>
         <translation>Выбрать внешний вид потока обложек:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="16"/>
         <source>Stripe look</source>
         <translation>Вид полосами</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="17"/>
         <source>Overlapped Stripe look</source>
         <translation>Вид перекрывающимися полосами</translation>
     </message>
@@ -1669,94 +2146,117 @@ to improve the performance</source>
 <context>
     <name>YACReaderGLFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="112"/>
         <source>Zoom</source>
         <translation>Масштабировать</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="142"/>
         <source>Light</source>
         <translation>Осветить</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="76"/>
         <source>Show advanced settings</source>
         <translation>Показать дополнительные настройки</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="32"/>
         <source>Roulette look</source>
         <translation>Вид рулеткой</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="130"/>
         <source>Cover Angle</source>
         <translation>Охватить угол</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="23"/>
         <source>Stripe look</source>
         <translation>Вид полосами</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="94"/>
         <source>Position</source>
         <translation>Позиция</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="124"/>
         <source>Z offset</source>
         <translation>Смещение по Z</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="118"/>
         <source>Y offset</source>
         <translation>Смещение по Y</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="106"/>
         <source>Central gap</source>
         <translation>Сфокусировать разрыв</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="18"/>
         <source>Presets:</source>
         <translation>Предустановки:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="26"/>
         <source>Overlapped Stripe look</source>
         <translation>Вид перекрывающимися полосами</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="29"/>
         <source>Modern look</source>
         <translation>Современный вид</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="88"/>
         <source>View angle</source>
         <translation>Угол зрения</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="148"/>
         <source>Max angle</source>
         <translation>Максимальный угол</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="85"/>
         <source>Custom:</source>
         <translation>Пользовательский:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="20"/>
         <source>Classic look</source>
         <translation>Классический вид</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="100"/>
         <source>Cover gap</source>
         <translation>Охватить разрыв</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="182"/>
         <source>High Performance</source>
         <translation>Максимальная производительность</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="201"/>
         <source>Performance:</source>
         <translation>Производительность:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="193"/>
         <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
         <translation>Использовать VSync (повысить качество изображения в полноэкранном режиме , хуже производительность)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="136"/>
         <source>Visibility</source>
         <translation>Прозрачность</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="180"/>
         <source>Low Performance</source>
         <translation>Минимальная производительность</translation>
     </message>
@@ -1764,10 +2264,12 @@ to improve the performance</source>
 <context>
     <name>YACReaderNavigationController</name>
     <message>
+        <location filename="yacreader_navigation_controller.cpp" line="127"/>
         <source>You are not reading anything yet, come on!!</source>
         <translation>Вы пока ничего не читаете. Может самое время почитать?</translation>
     </message>
     <message>
+        <location filename="yacreader_navigation_controller.cpp" line="123"/>
         <source>No favorites</source>
         <translation>Нет избранного</translation>
     </message>
@@ -1775,22 +2277,27 @@ to improve the performance</source>
 <context>
     <name>YACReaderOptionsDialog</name>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28"/>
         <source>Save</source>
         <translation>Сохранить</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="46"/>
         <source>Use hardware acceleration (restart needed)</source>
         <translation>Использовать аппаратное ускорение (необходима перезагрузка)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="29"/>
         <source>Cancel</source>
         <translation>Отмена</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="37"/>
         <source>Shortcuts</source>
         <translation>Горячие клавиши</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="34"/>
         <source>Edit shortcuts</source>
         <translation>Редактировать горячие клавиши</translation>
     </message>
@@ -1798,6 +2305,7 @@ to improve the performance</source>
 <context>
     <name>YACReaderSearchLineEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_search_line_edit.cpp" line="68"/>
         <source>type to search</source>
         <translation>Начать поиск</translation>
     </message>
@@ -1805,26 +2313,32 @@ to improve the performance</source>
 <context>
     <name>YACReaderSideBar</name>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="29"/>
         <source>Reading Lists</source>
         <translation>Списки чтения</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="31"/>
         <source>LIBRARIES</source>
         <translation>БИБЛИОТЕКИ</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="27"/>
         <source>Libraries</source>
         <translation>Библиотеки</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="32"/>
         <source>FOLDERS</source>
         <translation>ПАПКИ</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="28"/>
         <source>Folders</source>
         <translation>Папки</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="33"/>
         <source>READING LISTS</source>
         <translation>СПИСКИ ЧТЕНИЯ</translation>
     </message>

--- a/YACReaderLibrary/yacreaderlibrary_tr.ts
+++ b/YACReaderLibrary/yacreaderlibrary_tr.ts
@@ -4,6 +4,7 @@
 <context>
     <name>ActionsShortcutsModel</name>
     <message>
+        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="73"/>
         <source>None</source>
         <translation>Hiçbiri</translation>
     </message>
@@ -11,66 +12,82 @@
 <context>
     <name>AddLabelDialog</name>
     <message>
+        <location filename="add_label_dialog.cpp" line="37"/>
         <source>cancel</source>
         <translation>vazgeç</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="8"/>
         <source>Label name:</source>
         <translation>Etiket adı:</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="11"/>
         <source>Choose a color:</source>
         <translation>Renk seçiniz:</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="14"/>
         <source>red</source>
         <translation>kırmızı</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="15"/>
         <source>orange</source>
         <translation>turuncu</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="16"/>
         <source>yellow</source>
         <translation>sarı</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="17"/>
         <source>green</source>
         <translation>yeşil</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="18"/>
         <source>cyan</source>
         <translation>camgöbeği</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="19"/>
         <source>blue</source>
         <translation>mavi</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="20"/>
         <source>violet</source>
         <translation>menekşe</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="21"/>
         <source>purple</source>
         <translation>mor</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="22"/>
         <source>pink</source>
         <translation>pembe</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="23"/>
         <source>white</source>
         <translation>beyaz</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="24"/>
         <source>light</source>
         <translation>açık</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="25"/>
         <source>dark</source>
         <translation>koyu</translation>
     </message>
     <message>
+        <location filename="add_label_dialog.cpp" line="36"/>
         <source>accept</source>
         <translation>kabul et</translation>
     </message>
@@ -78,22 +95,27 @@
 <context>
     <name>AddLibraryDialog</name>
     <message>
+        <location filename="add_library_dialog.cpp" line="26"/>
         <source>Add</source>
         <translation>Ekle</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="66"/>
         <source>Add an existing library</source>
         <translation>Kütüphaneye ekle</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="30"/>
         <source>Cancel</source>
         <translation>Vazgeç</translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="16"/>
         <source>Comics folder : </source>
         <translation>Çizgi roman klasörü : </translation>
     </message>
     <message>
+        <location filename="add_library_dialog.cpp" line="21"/>
         <source>Library name : </source>
         <translation>Kütüphane adı : </translation>
     </message>
@@ -101,18 +123,22 @@
 <context>
     <name>ApiKeyDialog</name>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="32"/>
         <source>Cancel</source>
         <translation>Vazgeç</translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="21"/>
         <source>Before you can connect to Comic Vine, you need your own API key. Please, get one free &lt;a href=&quot;http://www.comicvine.com/api/&quot;&gt;here&lt;/a&gt;</source>
         <translation>Comic Vine&apos;a bağlanmadan önce kendi API anahtarınıza ihtiyacınız var. Lütfen &lt;a href=&quot;http://www.comicvine.com/api/&quot;&gt;buradan&lt;/a&gt; ücretsiz bir tane edinin</translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="25"/>
         <source>Paste here your Comic Vine API key</source>
         <translation>Comic Vine API anahtarınızı buraya yapıştırın</translation>
     </message>
     <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="28"/>
         <source>Accept</source>
         <translation>Kabul et</translation>
     </message>
@@ -120,6 +146,7 @@
 <context>
     <name>ClassicComicsView</name>
     <message>
+        <location filename="classic_comics_view.cpp" line="90"/>
         <source>Hide comic flow</source>
         <translation>Çizgi roman akışını gizle</translation>
     </message>
@@ -127,46 +154,57 @@
 <context>
     <name>ComicInfoView</name>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="279"/>
         <source>Authors</source>
         <translation>Yazarlar</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="309"/>
         <source>writer</source>
         <translation>yazar</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="331"/>
         <source>penciller</source>
         <translation>kalemci</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="353"/>
         <source>inker</source>
         <translation>mürekkepçi</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="375"/>
         <source>colorist</source>
         <translation>renklendiren</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="397"/>
         <source>letterer</source>
         <translation>metinlendiren</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="419"/>
         <source>cover artist</source>
         <translation>kapak sanatçısı</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="434"/>
         <source>Publisher</source>
         <translation>Yayıncı</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
         <source>color</source>
         <translation>renk</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
         <source>b/w</source>
         <translation>s/b</translation>
     </message>
     <message>
+        <location filename="qml/ComicInfoView.qml" line="502"/>
         <source>Characters</source>
         <translation>Karakterler</translation>
     </message>
@@ -174,38 +212,52 @@
 <context>
     <name>ComicModel</name>
     <message>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>no</source>
         <translation>hayır</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>yes</source>
         <translation>evet</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="351"/>
         <source>Read</source>
         <translation>Oku</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="349"/>
         <source>Size</source>
         <translation>Boyut</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="347"/>
         <source>Pages</source>
         <translation>Sayfalar</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="343"/>
         <source>Title</source>
         <translation>Başlık</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="345"/>
         <source>File Name</source>
         <translation>Dosya Adı</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="353"/>
         <source>Current Page</source>
         <translation>Geçreli Sayfa</translation>
     </message>
     <message>
+        <location filename="db/comic_model.cpp" line="355"/>
+        <source>Publication Date</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="357"/>
         <source>Rating</source>
         <translation>Reyting</translation>
     </message>
@@ -213,50 +265,67 @@
 <context>
     <name>ComicVineDialog</name>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="57"/>
         <source>skip</source>
         <translation>geç</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="58"/>
         <source>back</source>
         <translation>geri</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="59"/>
         <source>next</source>
         <translation>sonraki</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="60"/>
         <source>search</source>
         <translation>ara</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="61"/>
         <source>close</source>
         <translation>kapat</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="143"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="257"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="773"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="807"/>
         <source>Looking for volume...</source>
         <translation>Sayılar aranıyor...</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="141"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="735"/>
         <source>comic %1 of %2 - %3</source>
         <translation>çizgi roman %1 / %2 - %3</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="262"/>
         <source>%1 comics selected</source>
         <translation>%1 çizgi roman seçildi</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="295"/>
         <source>Error connecting to ComicVine</source>
         <translation>ComicVine sitesine bağlanılırken hata</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="467"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="503"/>
         <source>Retrieving tags for : %1</source>
         <translation>%1 için etiketler alınıyor</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="788"/>
         <source>Retrieving volume info...</source>
         <translation>Sayı bilgileri alınıyor...</translation>
     </message>
     <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="814"/>
         <source>Looking for comic...</source>
         <translation>Çizgi romanlar aranıyor...</translation>
     </message>
@@ -264,34 +333,42 @@
 <context>
     <name>CreateLibraryDialog</name>
     <message>
+        <location filename="create_library_dialog.cpp" line="75"/>
         <source>Create new library</source>
         <translation>Yeni kütüphane oluştur</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="31"/>
         <source>Cancel</source>
         <translation>Vazgeç</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="27"/>
         <source>Create</source>
         <translation>Oluştur</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="53"/>
         <source>Create a library could take several minutes. You can stop the process and update the library later for completing the task.</source>
         <translation>Yeni kütüphanenin oluşturulması birkaç dakika sürecek.</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="95"/>
         <source>The selected path does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation>Seçilen dizine yazma iznimiz yok yazma izni olduğundan emin ol</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="17"/>
         <source>Comics folder : </source>
         <translation>Çizgi roman klasörü : </translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="22"/>
         <source>Library Name : </source>
         <translation>Kütüphane Adı : </translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="95"/>
         <source>Path not found</source>
         <translation>Dizin bulunamadı</translation>
     </message>
@@ -299,22 +376,27 @@
 <context>
     <name>EditShortcutsDialog</name>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="21"/>
         <source>Restore defaults</source>
         <translation>Varsayılanları geri yükle</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="22"/>
         <source>To change a shortcut, double click in the key combination and type the new keys.</source>
         <translation>Bir kısayolu değiştirmek için tuş kombinasyonuna çift tıklayın ve yeni tuşları girin.</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="69"/>
         <source>Shortcuts settings</source>
         <translation>Kısayol ayarları</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>Shortcut in use</source>
         <translation>Kısayol kullanımda</translation>
     </message>
     <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="94"/>
         <source>The shortcut &quot;%1&quot; is already assigned to other function</source>
         <translation>&quot;%1&quot; kısayalou zaten başka bir işlev tarafından kullanılıyor</translation>
     </message>
@@ -322,14 +404,18 @@
 <context>
     <name>EmptyFolderWidget</name>
     <message>
+        <location filename="empty_folder_widget.cpp" line="75"/>
+        <location filename="empty_folder_widget.cpp" line="140"/>
         <source>Subfolders in this folder</source>
         <translation>Bu klasörde alt klasörler</translation>
     </message>
     <message>
+        <location filename="empty_folder_widget.cpp" line="138"/>
         <source>Empty folder</source>
         <translation>Boş klasör</translation>
     </message>
     <message>
+        <location filename="empty_folder_widget.cpp" line="138"/>
         <source>Drag and drop folders and comics here</source>
         <translation>Klasörleri ve çizgi romanları sürükleyip buraya bırakın</translation>
     </message>
@@ -337,6 +423,7 @@
 <context>
     <name>EmptyLabelWidget</name>
     <message>
+        <location filename="empty_label_widget.cpp" line="11"/>
         <source>This label doesn&apos;t contain comics yet</source>
         <translation>Bu etiket henüz çizgi roman içermiyor</translation>
     </message>
@@ -344,6 +431,7 @@
 <context>
     <name>EmptyReadingListWidget</name>
     <message>
+        <location filename="empty_reading_list_widget.cpp" line="8"/>
         <source>This reading list does not contain any comics yet</source>
         <translation>Bu okuma listesi henüz çizgi roman içermiyor</translation>
     </message>
@@ -351,30 +439,37 @@
 <context>
     <name>ExportComicsInfoDialog</name>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="14"/>
         <source>Output file : </source>
         <translation>Çıkış dosyası : </translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="66"/>
         <source>Destination database name</source>
         <translation>Hedef adı</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="22"/>
         <source>Cancel</source>
         <translation>Vazgeç</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="18"/>
         <source>Create</source>
         <translation>Oluştur</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="81"/>
         <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation>Seçilen dizine yazma iznimiz yok yazma izni olduğundan emin ol</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="57"/>
         <source>Export comics info</source>
         <translation>Çizgi roman bilgilerini göster</translation>
     </message>
     <message>
+        <location filename="export_comics_info_dialog.cpp" line="81"/>
         <source>Problem found while writing</source>
         <translation>Yazma sırasında bir problem oldu</translation>
     </message>
@@ -382,30 +477,37 @@
 <context>
     <name>ExportLibraryDialog</name>
     <message>
+        <location filename="export_library_dialog.cpp" line="19"/>
         <source>Cancel</source>
         <translation>Vazgeç</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="15"/>
         <source>Create</source>
         <translation>Yeni bir  tane yap</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="71"/>
         <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
         <translation>Seçilen konuma yeni bir kütüphane yazılamıyor</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="11"/>
         <source>Output folder : </source>
         <translation>Çıktı klasörü : </translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="71"/>
         <source>Problem found while writing</source>
         <translation>Yazım aşamasında bir problem bulundu</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="60"/>
         <source>Create covers package</source>
         <translation>Kapak paketi oluştur</translation>
     </message>
     <message>
+        <location filename="export_library_dialog.cpp" line="76"/>
         <source>Destination directory</source>
         <translation>Hedef dizin</translation>
     </message>
@@ -413,25 +515,46 @@
 <context>
     <name>FileComic</name>
     <message>
+        <location filename="../common/comic.cpp" line="562"/>
         <source>7z not found</source>
         <translation>7z bulunamadı</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="454"/>
         <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
         <translation>CRC hatası, sayfada (%1): bazı sayfalar düzgün görüntülenmeyecek</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="461"/>
         <source>Unknown error opening the file</source>
         <translation>Dosya açılırken bilinmeyen hata</translation>
     </message>
     <message>
+        <location filename="../common/comic.cpp" line="568"/>
         <source>Format not supported</source>
         <translation>Dosya biçimi desteklenmiyor</translation>
     </message>
 </context>
 <context>
+    <name>FolderContentView</name>
+    <message>
+        <location filename="qml/FolderContentView.qml" line="238"/>
+        <source>Continue Reading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FolderContentView6</name>
+    <message>
+        <location filename="qml/FolderContentView6.qml" line="240"/>
+        <source>Continue Reading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GridComicsView</name>
     <message>
+        <location filename="grid_comics_view.cpp" line="147"/>
         <source>Show info</source>
         <translation>Bilgi göster</translation>
     </message>
@@ -439,10 +562,17 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
         <translation>Yardım</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
+        <source>System info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation>Hakkında</translation>
     </message>
@@ -450,22 +580,27 @@
 <context>
     <name>ImportComicsInfoDialog</name>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="24"/>
         <source>Cancel</source>
         <translation>Vazgeç</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="20"/>
         <source>Import</source>
         <translation>Çıkart</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="16"/>
         <source>Info database location : </source>
         <translation>Bilgi veritabanı konumu : </translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="14"/>
         <source>Import comics info</source>
         <translation>Çizgi roman bilgilerini çıkart</translation>
     </message>
     <message>
+        <location filename="import_comics_info_dialog.cpp" line="74"/>
         <source>Comics info file (*.ydb)</source>
         <translation>Çizgi roman bilgi dosyası (*.ydb)</translation>
     </message>
@@ -473,30 +608,37 @@
 <context>
     <name>ImportLibraryDialog</name>
     <message>
+        <location filename="import_library_dialog.cpp" line="26"/>
         <source>Destination folder : </source>
         <translation>Hedef klasör : </translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="34"/>
         <source>Cancel</source>
         <translation>Vazgeç</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="30"/>
         <source>Unpack</source>
         <translation>Paketten çıkar</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="108"/>
         <source>Compresed library covers (*.clc)</source>
         <translation>Sıkıştırılmış kütüphane kapakları (*.clc)</translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="22"/>
         <source>Package location : </source>
         <translation>Paket konumu : </translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="17"/>
         <source>Library Name : </source>
         <translation>Kütüphane Adı : </translation>
     </message>
     <message>
+        <location filename="import_library_dialog.cpp" line="87"/>
         <source>Extract a catalog</source>
         <translation>Katalog ayıkla</translation>
     </message>
@@ -504,482 +646,657 @@
 <context>
     <name>ImportWidget</name>
     <message>
+        <location filename="import_widget.cpp" line="150"/>
         <source>stop</source>
         <translation>dur</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="334"/>
         <source>Importing comics</source>
         <translation>önemli çizgi romanlar</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="335"/>
         <source>&lt;p&gt;YACReaderLibrary is now creating a new library.&lt;/p&gt;&lt;p&gt;Create a library could take several minutes. You can stop the process and update the library later for completing the task.&lt;/p&gt;</source>
         <translation>&lt;p&gt;YACReaderKütüphane şu anda yeni bir kütüphane oluşturuyor&lt;/p&gt;&lt;p&gt;Kütüphanenin oluşturulması birkaç dakika alacak.&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="190"/>
         <source>Some of the comics being added...</source>
         <translation>Bazı çizgi romanlar önceden eklenmiş...</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="346"/>
         <source>Updating the library</source>
         <translation>Kütüphaneyi güncelle</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="347"/>
         <source>&lt;p&gt;The current library is being updated. For faster updates, please, update your libraries frequently.&lt;/p&gt;&lt;p&gt;You can stop the process and continue updating this library later.&lt;/p&gt;</source>
         <translation>&lt;p&gt;Kütüphane güncelleniyor&lt;/p&gt;&lt;p&gt;Güncellemeyi daha sonra iptal edebilirsin.&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="358"/>
         <source>Upgrading the library</source>
         <translation>Kütüphane güncelleniyor</translation>
     </message>
     <message>
+        <location filename="import_widget.cpp" line="359"/>
         <source>&lt;p&gt;The current library is being upgraded, please wait.&lt;/p&gt;</source>
         <translation>&lt;p&gt;Mevcut kütüphane güncelleniyor, lütfen bekleyin.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="370"/>
+        <source>Scanning the library</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="371"/>
+        <source>&lt;p&gt;Current library is being scanned for legacy XML metadata information.&lt;/p&gt;&lt;p&gt;This is only needed once, and only if the library was crated with YACReaderLibrary 9.8.2 or earlier.&lt;/p&gt;</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
     <name>LibraryWindow</name>
     <message>
+        <location filename="library_window.cpp" line="730"/>
         <source>Edit</source>
         <translation>Düzenle</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2083"/>
         <source>The selected folder doesn&apos;t contain any library.</source>
         <translation>Seçilen dosya kütüphanede yok.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1269"/>
         <source>This library was created with a previous version of YACReaderLibrary. It needs to be updated. Update now?</source>
         <translation>Bu kütüphane YACReaderKütüphabenin bir önceki versiyonun oluşturulmuş, güncellemeye ihtiyacın var. Şimdi güncellemek ister misin ?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2659"/>
         <source>Error opening the library</source>
         <translation>Haa kütüphanesini aç</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="585"/>
         <source>Show/Hide marks</source>
         <translation>Altçizgileri aç/kapa</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="648"/>
         <source>Show comics server options dialog</source>
         <translation>Çizgi romanların server ayarlarını göster</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="532"/>
         <source>Remove current library from your collection</source>
         <translation>Kütüphaneyi koleksiyonundan kaldır</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="554"/>
         <source>Set comic as read</source>
         <translation>Çizgi romanı okundu olarak işaretle</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2139"/>
         <source>Remove and delete metadata</source>
         <translation>Metadata&apos;yı kaldır ve sil</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Old library</source>
         <translation>Eski kütüphane</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="742"/>
         <source>Update cover</source>
         <translation>Kapağı güncelle</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1027"/>
         <source>Library</source>
         <translation>Kütüphane</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="526"/>
         <source>Rename current library</source>
         <translation>Kütüphaneyi adlandır</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="593"/>
+        <location filename="library_window.cpp" line="594"/>
         <source>Fullscreen mode on/off</source>
         <translation>Tam ekran modu açık/kapalı</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1336"/>
         <source>This library was created with a newer version of YACReaderLibrary. Download the new version now?</source>
         <translation>Bu kütüphane YACRKütüphanenin üst bir versiyonunda oluşturulmu. Yeni versiyonu indirmek ister misiniz ?
 </translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="543"/>
         <source>Open current comic on YACReader</source>
         <translation>YACReader&apos;ı geçerli çizgi roman okuyucsu seç</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="520"/>
         <source>Update current library</source>
         <translation>Kütüphaneyi güncelle</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library &apos;%1&apos; is no longer available. Do you want to remove it?</source>
         <translation>Kütüphane &apos;%1&apos;ulaşılabilir değil.  Kaldırmak ister misin?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="519"/>
         <source>Update library</source>
         <translation>Kütüphaneyi güncelle</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="674"/>
+        <location filename="library_window.cpp" line="1787"/>
         <source>Open folder...</source>
         <translation>Dosyayı aç...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Do you want remove </source>
         <translation>Kaldırmak ister misin</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2654"/>
         <source>Error updating the library</source>
         <translation>Kütüphane güncelleme sorunu</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="628"/>
         <source>Expand all nodes</source>
         <translation>Tüm düğümleri büyüt</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Library &apos;%1&apos; has been created with an older version of YACReaderLibrary. It must be created again. Do you want to create the library now?</source>
         <translation>Kütüphane &apos;%1 YACRKütüphanenin eski bir sürümünde oluşturulmuş, Kütüphaneyi yeniden oluşturmak ister misin?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="507"/>
         <source>Pack covers</source>
         <translation>Paket kapakları</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="553"/>
+        <location filename="library_window.cpp" line="690"/>
+        <location filename="library_window.cpp" line="1800"/>
         <source>Set as read</source>
         <translation>Okundu olarak işaretle</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="748"/>
         <source>Delete selected comics</source>
         <translation>Seçili çizgi romanları sil</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="495"/>
+        <location filename="library_window.cpp" line="496"/>
         <source>Export comics info</source>
         <translation>Çizgi roman bilgilerini çıkart</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="640"/>
         <source>Show options dialog</source>
         <translation>Ayarları göster</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="484"/>
         <source>Create a new library</source>
         <translation>Yeni kütüphane oluştur</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library not available</source>
         <translation>Kütüphane ulaşılabilir değil</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="501"/>
+        <location filename="library_window.cpp" line="502"/>
         <source>Import comics info</source>
         <translation>Çizgi roman bilgilerini içe aktar</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="542"/>
         <source>Open current comic</source>
         <translation>Seçili çizgi romanı aç</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="188"/>
         <source>YACReader Library</source>
         <translation>YACReader Kütüphane</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2649"/>
         <source>Error creating the library</source>
         <translation>Kütüphane oluşturma sorunu</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="513"/>
         <source>Unpack covers</source>
         <translation>Kapakları aç</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1269"/>
         <source>Update needed</source>
         <translation>Güncelleme gerekli</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="490"/>
         <source>Open an existing library</source>
         <translation>Çıkış kütüphanesini aç</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2805"/>
         <source>Library name already exists</source>
         <translation>Kütüphane ismi zaten alınmış</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2805"/>
         <source>There is another library with the name &apos;%1&apos;.</source>
         <translation>Bu başka bir kütüphanenin adı &apos;%1&apos;.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1336"/>
         <source>Download new version</source>
         <translation>Yeni versiyonu indir</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2694"/>
         <source>Delete comics</source>
         <translation>Çizgi romanları sil</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="724"/>
         <source>Select all comics</source>
         <translation>Tüm çizgi romanları seç</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="508"/>
         <source>Pack the covers of the selected library</source>
         <translation>Kütüphanede ki kapakları paketle</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="602"/>
         <source>Help, About YACReader</source>
         <translation>Yardım, Bigli, YACReader</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="560"/>
         <source>Set comic as unread</source>
         <translation>Çizgi Romanı okunmadı olarak seç</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="624"/>
         <source>Select root node</source>
         <translation>Kökü seçin</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="514"/>
         <source>Unpack a catalog</source>
         <translation>Kataloğu çkart</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2694"/>
         <source>All the selected comics will be deleted from your disk. Are you sure?</source>
         <translation>Seçilen tüm çizgi romanlar diskten silinecek emin misin ?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="559"/>
+        <location filename="library_window.cpp" line="695"/>
+        <location filename="library_window.cpp" line="1803"/>
         <source>Set as unread</source>
         <translation>Hepsini okunmadı işaretle</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2083"/>
         <source>Library not found</source>
         <translation>Kütüphane bulunamadı</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="525"/>
         <source>Rename library</source>
         <translation>Kütüphaneyi yeniden adlandır</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="531"/>
         <source>Remove library</source>
         <translation>Kütüphaneyi sil</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="712"/>
         <source>Open containing folder...</source>
         <translation>Klasör açılıyor...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source> library?</source>
         <translation> kütüphane?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Are you sure?</source>
         <translation>Emin misin?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="548"/>
         <source>Save selected covers to...</source>
         <translation>Seçilen kapakları şuraya kaydet...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="537"/>
+        <source>Rescan library for XML info</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="538"/>
+        <source>Tries to find XML info embedded in comic files. You only need to do this if the library was created with 9.8.2 or earlier versions or if you are using third party software to embed XML info in the files.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="549"/>
         <source>Save covers of the selected comics as JPG files</source>
         <translation>Seçilen çizgi romanların kapaklarını JPG dosyaları olarak kaydet</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="565"/>
+        <location filename="library_window.cpp" line="700"/>
+        <location filename="library_window.cpp" line="1806"/>
         <source>Set as manga</source>
         <translation>Manga olarak ayarla</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="566"/>
         <source>Set issue as manga</source>
         <translation>Sayıyı manga olarak ayarla</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="571"/>
         <source>Set as normal</source>
         <translation>Normal olarak ayarla</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="572"/>
         <source>Set issue as normal</source>
         <translation>Sayıyı normal olarak ayarla</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="586"/>
         <source>Show or hide read marks</source>
         <translation>Okundu işaretlerini göster yada gizle</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="609"/>
+        <location filename="library_window.cpp" line="1574"/>
         <source>Add new folder</source>
         <translation>Yeni klasör ekle</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="612"/>
         <source>Add new folder to the current library</source>
         <translation>Geçerli kitaplığa yeni klasör ekle</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="615"/>
+        <location filename="library_window.cpp" line="1610"/>
         <source>Delete folder</source>
         <translation>Klasörü sil</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="618"/>
         <source>Delete current folder from disk</source>
         <translation>Geçerli klasörü diskten sil</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="634"/>
         <source>Collapse all nodes</source>
         <translation>Tüm düğümleri kapat</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="655"/>
+        <location filename="library_window.cpp" line="656"/>
         <source>Change between comics views</source>
         <translation>Çizgi roman görünümleri arasında değiştir</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="680"/>
+        <location filename="library_window.cpp" line="1794"/>
         <source>Set as uncompleted</source>
         <translation>Tamamlanmamış olarak ayarla</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="685"/>
+        <location filename="library_window.cpp" line="1797"/>
         <source>Set as completed</source>
         <translation>Tamamlanmış olarak ayarla</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="705"/>
+        <location filename="library_window.cpp" line="1809"/>
         <source>Set as comic</source>
         <translation>Çizgi roman olarak ayarla</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="718"/>
         <source>Reset comic rating</source>
         <translation>Çizgi roman reytingini sıfırla</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="736"/>
         <source>Assign current order to comics</source>
         <translation>Geçerli sırayı çizgi romanlara ata</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="756"/>
         <source>Download tags from Comic Vine</source>
         <translation>Etiketleri Comic Vine sitesinden indir</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="760"/>
+        <source>Focus search line</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="766"/>
+        <source>Focus comics view</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="771"/>
         <source>Edit shortcuts</source>
         <translation>Kısayolları düzenle</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="777"/>
+        <source>&amp;Quit</source>
+        <translation type="unfinished">&amp;Çıkış</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="784"/>
+        <location filename="library_window.cpp" line="1790"/>
         <source>Update folder</source>
         <translation>Klasörü güncelle</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="787"/>
         <source>Update current folder</source>
         <translation>Geçerli klasörü güncelle</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="792"/>
         <source>Add new reading list</source>
         <translation>Yeni okuma listesi ekle</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="795"/>
         <source>Add a new reading list to the current library</source>
         <translation>Geçerli kitaplığa yeni bir okuma listesi ekle</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="798"/>
         <source>Remove reading list</source>
         <translation>Okuma listesini kaldır</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="801"/>
         <source>Remove current reading list from the library</source>
         <translation>Geçerli okuma listesini kütüphaneden kaldır</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="804"/>
         <source>Add new label</source>
         <translation>Yeni etiket ekle</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="807"/>
         <source>Add a new label to this library</source>
         <translation>Bu kitaplığa yeni bir etiket ekle</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="810"/>
         <source>Rename selected list</source>
         <translation>Seçilen listeyi yeniden adlandır</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="813"/>
         <source>Rename any selected labels or lists</source>
         <translation>Seçilen etiketleri ya da listeleri yeniden adlandır</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="817"/>
         <source>Add to...</source>
         <translation>Şuraya ekle...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="819"/>
         <source>Favorites</source>
         <translation>Favoriler</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="822"/>
         <source>Add selected comics to favorites list</source>
         <translation>Seçilen çizgi romanları favoriler listesine ekle</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1046"/>
         <source>Folder</source>
         <translation>Klasör</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1060"/>
         <source>Comic</source>
         <translation>Çizgi roman</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1251"/>
         <source>Upgrade failed</source>
         <translation>Yükseltme başarısız oldu</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1251"/>
         <source>There were errors during library upgrade in: </source>
         <translation>Kütüphane yükseltmesi sırasında hatalar oluştu: </translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1409"/>
+        <location filename="library_window.cpp" line="1445"/>
         <source>Copying comics...</source>
         <translation>Çizgi romanlar kopyalanıyor...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1426"/>
+        <location filename="library_window.cpp" line="1464"/>
         <source>Moving comics...</source>
         <translation>Çizgi romanlar taşınıyor...</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1575"/>
         <source>Folder name:</source>
         <translation>Klasör adı:</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1604"/>
         <source>No folder selected</source>
         <translation>Hiçbir klasör seçilmedi</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1604"/>
         <source>Please, select a folder first</source>
         <translation>Lütfen, önce bir klasör seçiniz</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1608"/>
         <source>Error in path</source>
         <translation>Yolda hata</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1608"/>
         <source>There was an error accessing the folder&apos;s path</source>
         <translation>Klasörün yoluna erişilirken hata oluştu</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1610"/>
         <source>The selected folder and all its contents will be deleted from your disk. Are you sure?</source>
         <translation>Seçilen klasör ve tüm içeriği diskinizden silinecek. Emin misin?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1636"/>
+        <location filename="library_window.cpp" line="2417"/>
         <source>Unable to delete</source>
         <translation>Silinemedi</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1636"/>
         <source>There was an issue trying to delete the selected folders. Please, check for write permissions and be sure that any applications are using these folders or any of the contained files.</source>
         <translation>Seçili klasörleri silmeye çalışırken bir sorun oluştu. Lütfen yazma izinlerini kontrol edin ve herhangi bir uygulamanın bu klasörleri veya içerdiği dosyalardan herhangi birini kullandığından emin olun.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1648"/>
         <source>Add new reading lists</source>
         <translation>Yeni okuma listeleri ekle</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1649"/>
+        <location filename="library_window.cpp" line="1698"/>
         <source>List name:</source>
         <translation>Liste adı:</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1667"/>
         <source>Delete list/label</source>
         <translation>Listeyi/Etiketi sil</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1667"/>
         <source>The selected item will be deleted, your comics or folders will NOT be deleted from your disk. Are you sure?</source>
         <translation>Seçilen öğe silinecek, çizgi romanlarınız veya klasörleriniz diskinizden SİLİNMEYECEKTİR. Emin misin?</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1697"/>
         <source>Rename list name</source>
         <translation>Listeyi yeniden adlandır</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1916"/>
         <source>Save covers</source>
         <translation>Kapakları kaydet</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.</source>
         <translation>Çok fazla kütüphane ekliyorsunuz.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.
 
 You probably only need one library in your top level comics folder, you can browse any subfolders using the folders section in the left sidebar.
@@ -992,34 +1309,43 @@ Muhtemelen üst düzey çizgi roman klasörünüzde yalnızca bir kütüphaneye 
 YACReaderLibrary daha fazla kütüphane oluşturmanıza engel olmaz ancak kütüphane sayısını düşük tutmalısınız.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1993"/>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found</source>
         <translation>YACReader bulunamadı</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1993"/>
         <source>YACReader not found. YACReader should be installed in the same folder as YACReaderLibrary.</source>
         <translation>YACReader bulunamadı. YACReader, YACReaderLibrary ile aynı klasöre kurulmalıdır.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found. There might be a problem with your YACReader installation.</source>
         <translation>YACReader bulunamadı. YACReader kurulumunuzda bir sorun olabilir.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2417"/>
         <source>There was an issue trying to delete the selected comics. Please, check for write permissions in the selected files or containing folder.</source>
         <translation>Seçilen çizgi romanlar silinmeye çalışılırken bir sorun oluştu. Lütfen seçilen dosyalarda veya klasörleri içeren yazma izinlerini kontrol edin.</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2448"/>
         <source>Assign comics numbers</source>
         <translation>Çizgi roman numaraları ata</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2449"/>
         <source>Assign numbers starting in:</source>
         <translation>Şunlardan başlayarak numaralar ata:</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Remove comics</source>
         <translation>Çizgi romanları kaldır</translation>
     </message>
     <message>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Comics will only be deleted from the current label/list. Are you sure?</source>
         <translation>Çizgi romanlar yalnızca mevcut etiketten/listeden silinecektir. Emin misin?</translation>
     </message>
@@ -1027,6 +1353,7 @@ YACReaderLibrary daha fazla kütüphane oluşturmanıza engel olmaz ancak kütü
 <context>
     <name>LocalComicListModel</name>
     <message>
+        <location filename="comic_vine/model/local_comic_list_model.cpp" line="72"/>
         <source>file name</source>
         <translation>dosya adı</translation>
     </message>
@@ -1034,30 +1361,37 @@ YACReaderLibrary daha fazla kütüphane oluşturmanıza engel olmaz ancak kütü
 <context>
     <name>LogWindow</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="14"/>
         <source>Log window</source>
         <translation>Günlük penceresi</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="22"/>
         <source>&amp;Pause</source>
         <translation>&amp;Duraklak</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="39"/>
         <source>&amp;Save</source>
         <translation>&amp;Kaydet</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="56"/>
         <source>C&amp;lear</source>
         <translation>&amp;Temizle</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="73"/>
         <source>&amp;Copy</source>
         <translation>&amp;Kopyala</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="90"/>
         <source>Level:</source>
         <translation>Düzey:</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="136"/>
         <source>&amp;Auto scroll</source>
         <translation>&amp;Otomatik kaydır</translation>
     </message>
@@ -1065,18 +1399,22 @@ YACReaderLibrary daha fazla kütüphane oluşturmanıza engel olmaz ancak kütü
 <context>
     <name>NoLibrariesWidget</name>
     <message>
+        <location filename="no_libraries_widget.cpp" line="32"/>
         <source>create your first library</source>
         <translation>İlk kütüphaneni oluştur</translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="26"/>
         <source>You don&apos;t have any libraries yet</source>
         <translation>Henüz bir kütüphaneye sahip değilsin</translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="28"/>
         <source>&lt;p&gt;You can create a library in any folder, YACReaderLibrary will import all comics and folders from this folder. If you have created any library in the past you can open them.&lt;/p&gt;&lt;p&gt;Don&apos;t forget that you can use YACReader as a stand alone application for reading the comics on your computer.&lt;/p&gt;</source>
         <translation>&lt;p&gt;Yeni bir kütüphane oluşturabilmeniçin kütüphane&lt;/p&gt;&lt;p&gt;No olvides que puedes usar YACReader como una aplicación independiente para leer los cómics en tu ordenador.&lt;/p&gt;</translation>
     </message>
     <message>
+        <location filename="no_libraries_widget.cpp" line="34"/>
         <source>add an existing one</source>
         <translation>Var olan bir tane ekle</translation>
     </message>
@@ -1084,70 +1422,87 @@ YACReaderLibrary daha fazla kütüphane oluşturmanıza engel olmaz ancak kütü
 <context>
     <name>OptionsDialog</name>
     <message>
+        <location filename="options_dialog.cpp" line="156"/>
         <source>Options</source>
         <translation>Ayarlar</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="47"/>
         <source>Tray icon settings (experimental)</source>
         <translation>Tepsi simgesi ayarları (deneysel)</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="50"/>
         <source>Close to tray</source>
         <translation>Tepsiyi kapat</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="51"/>
         <source>Start into the system tray</source>
         <translation>Sistem tepsisinde başlat</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="69"/>
         <source>Edit Comic Vine API key</source>
         <translation>Comic Vine API anahtarını düzenle</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="72"/>
         <source>Comic Vine API key</source>
         <translation>Comic Vine API anahtarı</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="78"/>
         <source>Enable background image</source>
         <translation>Arka plan resmini etkinleştir</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="80"/>
         <source>Opacity level</source>
         <translation>Matlık düzeyi</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="85"/>
         <source>Blur level</source>
         <translation>Bulanıklık düzeyi</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="90"/>
         <source>Use selected comic cover as background</source>
         <translation>Seçilen çizgi roman kapanığı arka plan olarak kullan</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="92"/>
         <source>Restore defautls</source>
         <translation>Varsayılanları geri yükle</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="103"/>
         <source>Background</source>
         <translation>Arka plan</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="106"/>
         <source>Display continue reading banner</source>
         <translation>Okuma devam et bannerını göster</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="111"/>
         <source>Continue reading</source>
         <translation>Okumaya devam et</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="144"/>
         <source>Comic Flow</source>
         <translation>Çizgi Roman Akışı</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="146"/>
         <source>Grid view</source>
         <translation>Izgara görünümü</translation>
     </message>
     <message>
+        <location filename="options_dialog.cpp" line="148"/>
         <source>General</source>
         <translation>Genel</translation>
     </message>
@@ -1155,142 +1510,178 @@ YACReaderLibrary daha fazla kütüphane oluşturmanıza engel olmaz ancak kütü
 <context>
     <name>PropertiesDialog</name>
     <message>
+        <location filename="properties_dialog.cpp" line="240"/>
         <source>Day:</source>
         <translation>Gün:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="85"/>
         <source>Plot</source>
         <translation>Argumento</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="177"/>
         <source>Size:</source>
         <translation>Boyut:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="248"/>
         <source>Year:</source>
         <translation>Yıl:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="207"/>
         <source>Inker(s):</source>
         <translation>Mürekkep(ler):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="84"/>
         <source>Publishing</source>
         <translation>Yayın</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="256"/>
         <source>Publisher:</source>
         <translation>Yayıncı:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="82"/>
         <source>General info</source>
         <translation>Genel bilgi</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="258"/>
         <source>Color/BW:</source>
         <translation>Renk/BW:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="501"/>
         <source>Edit selected comics information</source>
         <translation>Seçilen çizgi roman bilgilerini düzenle</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="200"/>
         <source>Penciller(s):</source>
         <translation>Çizenler:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="210"/>
         <source>Colorist(s):</source>
         <translation>Renklendiren:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="158"/>
         <source>Issue number:</source>
         <translation>Yayın numarası:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="244"/>
         <source>Month:</source>
         <translation>Ay:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="275"/>
         <source>Notes:</source>
         <translation>Notlar:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="273"/>
         <source>Synopsis:</source>
         <translation>Özet:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="143"/>
         <source>Title:</source>
         <translation>Başlık:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Not found</source>
         <translation>Bulunamad</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="274"/>
         <source>Characters:</source>
         <translation>Karakterler:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="83"/>
         <source>Authors</source>
         <translation>Yazarlar</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="259"/>
         <source>Age rating:</source>
         <translation>Yaş sınırı:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="173"/>
         <source>Story arc:</source>
         <translation>Hiakye:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="197"/>
         <source>Writer(s):</source>
         <translation>Yazarlar:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Comic not found. You should update your library.</source>
         <translation>Çizgi roman bulunamadı. Kütüphaneyi güncellemelisin.</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="467"/>
         <source>Edit comic information</source>
         <translation>Çizgi roman bilgisini düzenle</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="94"/>
         <source>Cover page</source>
         <translation>Kapak sayfası</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="220"/>
         <source>Cover Artist(s):</source>
         <translation>Kapak artisti:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="160"/>
         <source>Volume:</source>
         <translation>Cilt:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="257"/>
         <source>Format:</source>
         <translation>Formato:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="217"/>
         <source>Letterer(s):</source>
         <translation>Mesaj(lar):</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="151"/>
+        <location filename="properties_dialog.cpp" line="168"/>
         <source>of:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="164"/>
         <source>Arc number:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="175"/>
         <source>Genre:</source>
         <translation>Tür:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="260"/>
         <source>Manga:</source>
         <translation>Manga:</translation>
     </message>
     <message>
+        <location filename="properties_dialog.cpp" line="369"/>
         <source>Comic Vine link: &lt;a style=&apos;color: #FFCB00; text-decoration:none; font-weight:bold;&apos; href=&quot;http://www.comicvine.com/comic/4000-%1/&quot;&gt; view &lt;/a&gt;</source>
         <translation>Comic Vine bağlantısı: &lt;a style=&apos;color: #FFCB00; text-decoration:none; font-weight:bold;&apos; href=&quot;http://www.comicvine.com/comic/4000-%1/&quot;&gt; görüntüle &lt;/a&gt;</translation>
     </message>
@@ -1298,34 +1689,42 @@ YACReaderLibrary daha fazla kütüphane oluşturmanıza engel olmaz ancak kütü
 <context>
     <name>QObject</name>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>7z lib not found</source>
         <translation>7z lib bulunamadı</translation>
     </message>
     <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
         <source>unable to load 7z lib from ./utils</source>
         <translation>./utils&apos;den 7z lib yüklenemiyor</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41"/>
         <source>Trace</source>
         <translation>İz</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43"/>
         <source>Debug</source>
         <translation>Hata ayıklama</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45"/>
         <source>Info</source>
         <translation>Bilgi</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47"/>
         <source>Warning</source>
         <translation>Uyarı</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49"/>
         <source>Error</source>
         <translation>Hata</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51"/>
         <source>Fatal</source>
         <translation>Ölümcül</translation>
     </message>
@@ -1333,14 +1732,17 @@ YACReaderLibrary daha fazla kütüphane oluşturmanıza engel olmaz ancak kütü
 <context>
     <name>QsLogging::LogWindowModel</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="141"/>
         <source>Time</source>
         <translation>Süre</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="143"/>
         <source>Level</source>
         <translation>Düzel</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="145"/>
         <source>Message</source>
         <translation>Mesaj</translation>
     </message>
@@ -1348,18 +1750,22 @@ YACReaderLibrary daha fazla kütüphane oluşturmanıza engel olmaz ancak kütü
 <context>
     <name>QsLogging::Window</name>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Pause</source>
         <translation>&amp;Duraklak</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
         <source>&amp;Resume</source>
         <translation>&amp;Sürdür</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="236"/>
         <source>Save log</source>
         <translation>Günlük tut</translation>
     </message>
     <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="237"/>
         <source>Log file (*.log)</source>
         <translation>Günlük dosyası (*.log)</translation>
     </message>
@@ -1367,18 +1773,22 @@ YACReaderLibrary daha fazla kütüphane oluşturmanıza engel olmaz ancak kütü
 <context>
     <name>RenameLibraryDialog</name>
     <message>
+        <location filename="rename_library_dialog.cpp" line="51"/>
         <source>Rename current library</source>
         <translation>Kütüphaneyi yeniden adlandır</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="24"/>
         <source>Cancel</source>
         <translation>Vazgeç</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="20"/>
         <source>Rename</source>
         <translation>Yeniden adlandır</translation>
     </message>
     <message>
+        <location filename="rename_library_dialog.cpp" line="15"/>
         <source>New Library Name : </source>
         <translation>Yeni Kütüphane Adı : </translation>
     </message>
@@ -1386,14 +1796,18 @@ YACReaderLibrary daha fazla kütüphane oluşturmanıza engel olmaz ancak kütü
 <context>
     <name>ScraperResultsPaginator</name>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="30"/>
         <source>Number of volumes found : %1</source>
         <translation>Bulunan bölüm sayısı: %1</translation>
     </message>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="32"/>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="55"/>
         <source>page %1 of %2</source>
         <translation>sayfa %1 / %2</translation>
     </message>
     <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="54"/>
         <source>Number of %1 found : %2</source>
         <translation>Sayı %1, bulunan : %2</translation>
     </message>
@@ -1401,10 +1815,12 @@ YACReaderLibrary daha fazla kütüphane oluşturmanıza engel olmaz ancak kütü
 <context>
     <name>SearchSingleComic</name>
     <message>
+        <location filename="comic_vine/search_single_comic.cpp" line="14"/>
         <source>Please provide some additional information.</source>
         <translation>Lütfen bazı ek bilgiler sağlayın.</translation>
     </message>
     <message>
+        <location filename="comic_vine/search_single_comic.cpp" line="19"/>
         <source>Series:</source>
         <translation>Seriler:</translation>
     </message>
@@ -1412,10 +1828,12 @@ YACReaderLibrary daha fazla kütüphane oluşturmanıza engel olmaz ancak kütü
 <context>
     <name>SearchVolume</name>
     <message>
+        <location filename="comic_vine/search_volume.cpp" line="11"/>
         <source>Please provide some additional information.</source>
         <translation>Lütfen bazı ek bilgiler sağlayın.</translation>
     </message>
     <message>
+        <location filename="comic_vine/search_volume.cpp" line="14"/>
         <source>Series:</source>
         <translation>Seriler:</translation>
     </message>
@@ -1423,22 +1841,27 @@ YACReaderLibrary daha fazla kütüphane oluşturmanıza engel olmaz ancak kütü
 <context>
     <name>SelectComic</name>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="18"/>
         <source>Please, select the right comic info.</source>
         <translation>Lütfen, doğru çizgi roman bilgisini seçin.</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="38"/>
         <source>comics</source>
         <translation>çizgi roman</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="94"/>
         <source>loading cover</source>
         <translation>kapak yükleniyor</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="95"/>
         <source>loading description</source>
         <translation>açıklama yükleniyor</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_comic.cpp" line="135"/>
         <source>description unavailable</source>
         <translation>açıklama bulunamadı</translation>
     </message>
@@ -1446,22 +1869,37 @@ YACReaderLibrary daha fazla kütüphane oluşturmanıza engel olmaz ancak kütü
 <context>
     <name>SelectVolume</name>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="35"/>
         <source>Please, select the right series for your comic.</source>
         <translation>Çizgi romanınız için doğru seriyi seçin.</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="56"/>
+        <source>Filter:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="68"/>
         <source>volumes</source>
         <translation>sayı</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="138"/>
+        <source>Nothing found, clear the filter if any.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="144"/>
         <source>loading cover</source>
         <translation>kapak yükleniyor</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="145"/>
         <source>loading description</source>
         <translation>açıklama yükleniyor</translation>
     </message>
     <message>
+        <location filename="comic_vine/select_volume.cpp" line="185"/>
         <source>description unavailable</source>
         <translation>açıklama bulunamadı</translation>
     </message>
@@ -1469,14 +1907,17 @@ YACReaderLibrary daha fazla kütüphane oluşturmanıza engel olmaz ancak kütü
 <context>
     <name>SeriesQuestion</name>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="15"/>
         <source>no</source>
         <translation>hayır</translation>
     </message>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="14"/>
         <source>yes</source>
         <translation>evet</translation>
     </message>
     <message>
+        <location filename="comic_vine/series_question.cpp" line="12"/>
         <source>You are trying to get information for various comics at once, are they part of the same series?</source>
         <translation>Aynı anda çeşitli çizgi romanlar için bilgi almaya çalışıyorsunuz, bunlar aynı serinin parçası mı?</translation>
     </message>
@@ -1484,40 +1925,49 @@ YACReaderLibrary daha fazla kütüphane oluşturmanıza engel olmaz ancak kütü
 <context>
     <name>ServerConfigDialog</name>
     <message>
+        <location filename="server_config_dialog.cpp" line="115"/>
         <source>Port</source>
         <translation>Port</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="147"/>
         <source>enable the server</source>
         <translation>erişilebilir server</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="86"/>
         <source>set port</source>
         <translation>Port Ayarla</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="92"/>
         <source>Server connectivity information</source>
         <translation>Sunucu bağlantı bilgileri</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="96"/>
         <source>Scan it!</source>
         <translation>Tara!</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="102"/>
         <source>YACReader is available for iOS devices. &lt;a href=&apos;http://ios.yacreader.com&apos; style=&apos;color:rgb(193, 148, 65)&apos;&gt; Discover it! &lt;/a&gt;</source>
         <translation>YACReader, iOS cihazlar için kullanılabilir. &lt;a href=&apos;http://ios.yacreader.com&apos; style=&apos;color:rgb(193, 148, 65)&apos;&gt; Keşfedin! &lt;/a&gt;</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="111"/>
         <source>Choose an IP address</source>
         <translation>IP adresi seçin</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="152"/>
         <source>display less information about folders in the browser
 to improve the performance</source>
         <translation>tarayıcıda klasörler hakkında daha az bilgi göster
 performansı iyileştirmek için</translation>
     </message>
     <message>
+        <location filename="server_config_dialog.cpp" line="268"/>
         <source>Could not load libqrencode.</source>
         <translation>libqrencode yüklenemedi.</translation>
     </message>
@@ -1525,22 +1975,27 @@ performansı iyileştirmek için</translation>
 <context>
     <name>SortVolumeComics</name>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="18"/>
         <source>Please, sort the list of comics on the left until it matches the comics&apos; information.</source>
         <translation>Lütfen, çizgi romanların bilgileriyle eşleşene kadar soldaki çizgi roman listesini sıralayın.</translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="21"/>
         <source>sort comics to match comic information</source>
         <translation>çizgi roman bilgilerini eşleştirmek için çizgi romanları sıralayın</translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="58"/>
         <source>issues</source>
         <translation>sayı</translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="87"/>
         <source>remove selected comics</source>
         <translation>seçilen çizgi romanları kaldır</translation>
     </message>
     <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="88"/>
         <source>restore all removed comics</source>
         <translation>tüm seçilen çizgi romanları geri yükle</translation>
     </message>
@@ -1548,6 +2003,7 @@ performansı iyileştirmek için</translation>
 <context>
     <name>TitleHeader</name>
     <message>
+        <location filename="comic_vine/title_header.cpp" line="30"/>
         <source>SEARCH</source>
         <translation>ARA</translation>
     </message>
@@ -1555,14 +2011,17 @@ performansı iyileştirmek için</translation>
 <context>
     <name>UpdateLibraryDialog</name>
     <message>
+        <location filename="create_library_dialog.cpp" line="180"/>
         <source>Update library</source>
         <translation>Kütüphaneyi güncelle</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="161"/>
         <source>Cancel</source>
         <translation>Vazgeç</translation>
     </message>
     <message>
+        <location filename="create_library_dialog.cpp" line="155"/>
         <source>Updating....</source>
         <translation>Güncelleniyor...</translation>
     </message>
@@ -1570,6 +2029,7 @@ performansı iyileştirmek için</translation>
 <context>
     <name>VolumeComicsModel</name>
     <message>
+        <location filename="comic_vine/model/volume_comics_model.cpp" line="120"/>
         <source>title</source>
         <translation>başlık</translation>
     </message>
@@ -1577,14 +2037,17 @@ performansı iyileştirmek için</translation>
 <context>
     <name>VolumesModel</name>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="118"/>
         <source>year</source>
         <translation>yıl</translation>
     </message>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="120"/>
         <source>issues</source>
         <translation>sayı</translation>
     </message>
     <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="122"/>
         <source>publisher</source>
         <translation>yayıncı</translation>
     </message>
@@ -1592,18 +2055,21 @@ performansı iyileştirmek için</translation>
 <context>
     <name>YACReader::TrayIconController</name>
     <message>
+        <location filename="trayicon_controller.cpp" line="52"/>
         <source>&amp;Restore</source>
         <translation>&amp;Geri Yükle</translation>
     </message>
     <message>
         <source>&amp;Quit</source>
-        <translation>&amp;Çıkış</translation>
+        <translation type="vanished">&amp;Çıkış</translation>
     </message>
     <message>
+        <location filename="trayicon_controller.cpp" line="79"/>
         <source>Systray</source>
         <translation>Sistem tepsisi</translation>
     </message>
     <message>
+        <location filename="trayicon_controller.cpp" line="80"/>
         <source>YACReaderLibrary will keep running in the system tray. To terminate the program, choose &lt;b&gt;Quit&lt;/b&gt; in the context menu of the system tray icon.</source>
         <translation>YACReaderLibrary sistem tepsisinde çalışmaya devam edecektir. Programı sonlandırmak için sistem tepsisi simgesinin bağlam menüsünden &lt;b&gt;Çık&lt;/b&gt;&apos;ı seçin.</translation>
     </message>
@@ -1611,6 +2077,7 @@ performansı iyileştirmek için</translation>
 <context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation>Kapat</translation>
     </message>
@@ -1618,10 +2085,12 @@ performansı iyileştirmek için</translation>
 <context>
     <name>YACReaderDeletingProgress</name>
     <message>
+        <location filename="../custom_widgets/yacreader_deleting_progress.cpp" line="35"/>
         <source>cancel</source>
         <translation>vazgeç</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_deleting_progress.cpp" line="20"/>
         <source>Please wait, deleting in progress...</source>
         <translation>Lütfen bekleyin, silme işlemi yapılıyor...</translation>
     </message>
@@ -1629,10 +2098,13 @@ performansı iyileştirmek için</translation>
 <context>
     <name>YACReaderFieldEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11"/>
         <source>Restore to default</source>
         <translation>Varsayılana dön</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28"/>
         <source>Click to overwrite</source>
         <translation>Üstüne yazmak için tıkla</translation>
     </message>
@@ -1640,10 +2112,15 @@ performansı iyileştirmek için</translation>
 <context>
     <name>YACReaderFieldPlainTextEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10"/>
         <source>Restore to default</source>
         <translation>Varsayılana dön</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50"/>
         <source>Click to overwrite</source>
         <translation>Üstüne yazmak için tıkla</translation>
     </message>
@@ -1651,18 +2128,22 @@ performansı iyileştirmek için</translation>
 <context>
     <name>YACReaderFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="15"/>
         <source>CoverFlow look</source>
         <translation>Kapak akışı görünümü</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="13"/>
         <source>How to show covers:</source>
         <translation>Kapaklar nasıl gözüksün:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="16"/>
         <source>Stripe look</source>
         <translation>Şerit görünüm</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_flow_config_widget.cpp" line="17"/>
         <source>Overlapped Stripe look</source>
         <translation>Çakışan şerit görünüm</translation>
     </message>
@@ -1670,94 +2151,117 @@ performansı iyileştirmek için</translation>
 <context>
     <name>YACReaderGLFlowConfigWidget</name>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="112"/>
         <source>Zoom</source>
         <translation>Zoom</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="142"/>
         <source>Light</source>
         <translation>Işık</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="76"/>
         <source>Show advanced settings</source>
         <translation>Daha fazla ayar göster</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="32"/>
         <source>Roulette look</source>
         <translation>Rulet görünüm</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="130"/>
         <source>Cover Angle</source>
         <translation>Kapak Açısı</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="23"/>
         <source>Stripe look</source>
         <translation>Strip görünüm</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="94"/>
         <source>Position</source>
         <translation>Pozisyon</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="124"/>
         <source>Z offset</source>
         <translation>Z dengesi</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="118"/>
         <source>Y offset</source>
         <translation>Y dengesi</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="106"/>
         <source>Central gap</source>
         <translation>Boş merkez</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="18"/>
         <source>Presets:</source>
         <translation>Hazırlayan:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="26"/>
         <source>Overlapped Stripe look</source>
         <translation>Çakışan şerit görünüm</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="29"/>
         <source>Modern look</source>
         <translation>Modern görünüm</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="88"/>
         <source>View angle</source>
         <translation>Bakış açısı</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="148"/>
         <source>Max angle</source>
         <translation>Maksimum açı</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="85"/>
         <source>Custom:</source>
         <translation>Kişisel:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="20"/>
         <source>Classic look</source>
         <translation>Klasik görünüm</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="100"/>
         <source>Cover gap</source>
         <translation>Kapak boşluğu</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="182"/>
         <source>High Performance</source>
         <translation>Yüksek Performans</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="201"/>
         <source>Performance:</source>
         <translation>Performans:</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="193"/>
         <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
         <translation>VSync kullan</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="136"/>
         <source>Visibility</source>
         <translation>Görünülebilirlik</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_gl_flow_config_widget.cpp" line="180"/>
         <source>Low Performance</source>
         <translation>Düşük Performans</translation>
     </message>
@@ -1765,10 +2269,12 @@ performansı iyileştirmek için</translation>
 <context>
     <name>YACReaderNavigationController</name>
     <message>
+        <location filename="yacreader_navigation_controller.cpp" line="123"/>
         <source>No favorites</source>
         <translation>Favoriler boş</translation>
     </message>
     <message>
+        <location filename="yacreader_navigation_controller.cpp" line="127"/>
         <source>You are not reading anything yet, come on!!</source>
         <translation>Henüz bir şey okumuyorsun, hadi ama!</translation>
     </message>
@@ -1776,22 +2282,27 @@ performansı iyileştirmek için</translation>
 <context>
     <name>YACReaderOptionsDialog</name>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28"/>
         <source>Save</source>
         <translation>Kaydet</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="46"/>
         <source>Use hardware acceleration (restart needed)</source>
         <translation>Yüksek donanımlı kullan (yeniden başlatmak gerekli)</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="29"/>
         <source>Cancel</source>
         <translation>Vazgeç</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="34"/>
         <source>Edit shortcuts</source>
         <translation>Kısayolları düzenle</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="37"/>
         <source>Shortcuts</source>
         <translation>Kısayollar</translation>
     </message>
@@ -1799,6 +2310,7 @@ performansı iyileştirmek için</translation>
 <context>
     <name>YACReaderSearchLineEdit</name>
     <message>
+        <location filename="../custom_widgets/yacreader_search_line_edit.cpp" line="68"/>
         <source>type to search</source>
         <translation>aramak için yazınız</translation>
     </message>
@@ -1806,26 +2318,32 @@ performansı iyileştirmek için</translation>
 <context>
     <name>YACReaderSideBar</name>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="31"/>
         <source>LIBRARIES</source>
         <translation>KÜTÜPHANELER</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="32"/>
         <source>FOLDERS</source>
         <translation>DOSYALAR</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="27"/>
         <source>Libraries</source>
         <translation>Kütüphaneler</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="28"/>
         <source>Folders</source>
         <translation>Klasör</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="29"/>
         <source>Reading Lists</source>
         <translation>Okuma Listeleri</translation>
     </message>
     <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="33"/>
         <source>READING LISTS</source>
         <translation>OKUMA LİSTELERİ</translation>
     </message>

--- a/YACReaderLibrary/yacreaderlibrary_zh_CN.ts
+++ b/YACReaderLibrary/yacreaderlibrary_zh_CN.ts
@@ -153,54 +153,112 @@
     </message>
 </context>
 <context>
+    <name>ComicInfoView</name>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="279"/>
+        <source>Authors</source>
+        <translation type="unfinished">作者</translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="309"/>
+        <source>writer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="331"/>
+        <source>penciller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="353"/>
+        <source>inker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="375"/>
+        <source>colorist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="397"/>
+        <source>letterer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="419"/>
+        <source>cover artist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="434"/>
+        <source>Publisher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
+        <source>color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
+        <source>b/w</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="502"/>
+        <source>Characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ComicModel</name>
     <message>
-        <location filename="db/comic_model.cpp" line="303"/>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>yes</source>
         <translation>是</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="303"/>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>no</source>
         <translation>否</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="335"/>
+        <location filename="db/comic_model.cpp" line="343"/>
         <source>Title</source>
         <translation>标题</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="337"/>
+        <location filename="db/comic_model.cpp" line="345"/>
         <source>File Name</source>
         <translation>文件名</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="339"/>
+        <location filename="db/comic_model.cpp" line="347"/>
         <source>Pages</source>
         <translation>页数</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="341"/>
+        <location filename="db/comic_model.cpp" line="349"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="343"/>
+        <location filename="db/comic_model.cpp" line="351"/>
         <source>Read</source>
         <translation>阅读</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="345"/>
+        <location filename="db/comic_model.cpp" line="353"/>
         <source>Current Page</source>
         <translation>当前页</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="347"/>
+        <location filename="db/comic_model.cpp" line="355"/>
         <source>Publication Date</source>
         <translation>发行日期</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="349"/>
+        <location filename="db/comic_model.cpp" line="357"/>
         <source>Rating</source>
         <translation>评分</translation>
     </message>
@@ -208,68 +266,67 @@
 <context>
     <name>ComicVineDialog</name>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="50"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="57"/>
         <source>skip</source>
         <translation>忽略</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="51"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="58"/>
         <source>back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="52"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="59"/>
         <source>next</source>
         <translation>下一步</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="53"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="60"/>
         <source>search</source>
         <translation>搜索</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="54"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="61"/>
         <source>close</source>
         <translation>关闭</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="130"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="140"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="252"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="759"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="793"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="143"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="257"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="773"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="807"/>
         <source>Looking for volume...</source>
         <translation>搜索卷...</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="138"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="726"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="141"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="735"/>
         <source>comic %1 of %2 - %3</source>
         <translation>第 %1 本 共 %2 本 - %3</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="257"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="262"/>
         <source>%1 comics selected</source>
         <translation>已选择 %1 本漫画</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="290"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="295"/>
         <source>Error connecting to ComicVine</source>
         <translation>ComicVine 连接时出错</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="460"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="496"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="467"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="503"/>
         <source>Retrieving tags for : %1</source>
         <translation>正在检索标签: %1</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="774"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="788"/>
         <source>Retrieving volume info...</source>
         <translation>正在接收卷信息...</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="800"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="814"/>
         <source>Looking for comic...</source>
         <translation>搜索漫画中...</translation>
     </message>
@@ -481,9 +538,25 @@
     </message>
 </context>
 <context>
+    <name>FolderContentView</name>
+    <message>
+        <location filename="qml/FolderContentView.qml" line="238"/>
+        <source>Continue Reading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FolderContentView6</name>
+    <message>
+        <location filename="qml/FolderContentView6.qml" line="240"/>
+        <source>Continue Reading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GridComicsView</name>
     <message>
-        <location filename="grid_comics_view.cpp" line="163"/>
+        <location filename="grid_comics_view.cpp" line="147"/>
         <source>Show info</source>
         <translation>显示信息</translation>
     </message>
@@ -491,17 +564,17 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
-        <location filename="../custom_widgets/help_about_dialog.cpp" line="25"/>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation>关于</translation>
     </message>
     <message>
-        <location filename="../custom_widgets/help_about_dialog.cpp" line="28"/>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
         <translation>帮助</translation>
     </message>
     <message>
-        <location filename="../custom_widgets/help_about_dialog.cpp" line="31"/>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
         <source>System info</source>
         <translation>系统信息</translation>
     </message>
@@ -628,498 +701,506 @@
 <context>
     <name>LibraryWindow</name>
     <message>
-        <location filename="library_window.cpp" line="184"/>
+        <location filename="library_window.cpp" line="188"/>
         <source>YACReader Library</source>
         <translation>YACReader 库</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1026"/>
+        <location filename="library_window.cpp" line="1027"/>
         <source>Library</source>
         <translation>库</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="480"/>
+        <location filename="library_window.cpp" line="484"/>
         <source>Create a new library</source>
         <translation>创建一个新的库</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="486"/>
+        <location filename="library_window.cpp" line="490"/>
         <source>Open an existing library</source>
         <translation>打开现有的库</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="491"/>
-        <location filename="library_window.cpp" line="492"/>
+        <location filename="library_window.cpp" line="495"/>
+        <location filename="library_window.cpp" line="496"/>
         <source>Export comics info</source>
         <translation>导出漫画信息</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="497"/>
-        <location filename="library_window.cpp" line="498"/>
+        <location filename="library_window.cpp" line="501"/>
+        <location filename="library_window.cpp" line="502"/>
         <source>Import comics info</source>
         <translation>导入漫画信息</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="503"/>
+        <location filename="library_window.cpp" line="507"/>
         <source>Pack covers</source>
         <translation>打包封面</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="504"/>
+        <location filename="library_window.cpp" line="508"/>
         <source>Pack the covers of the selected library</source>
         <translation>打包所选库的封面</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="509"/>
+        <location filename="library_window.cpp" line="513"/>
         <source>Unpack covers</source>
         <translation>解压封面</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="510"/>
+        <location filename="library_window.cpp" line="514"/>
         <source>Unpack a catalog</source>
         <translation>解压目录</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="515"/>
+        <location filename="library_window.cpp" line="519"/>
         <source>Update library</source>
         <translation>更新库</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="516"/>
+        <location filename="library_window.cpp" line="520"/>
         <source>Update current library</source>
         <translation>更新当前库</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="521"/>
+        <location filename="library_window.cpp" line="525"/>
         <source>Rename library</source>
         <translation>重命名库</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="522"/>
+        <location filename="library_window.cpp" line="526"/>
         <source>Rename current library</source>
         <translation>重命名当前库</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="527"/>
+        <location filename="library_window.cpp" line="531"/>
         <source>Remove library</source>
         <translation>移除库</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="528"/>
+        <location filename="library_window.cpp" line="532"/>
         <source>Remove current library from your collection</source>
         <translation>从您的集合中移除当前库</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="538"/>
+        <location filename="library_window.cpp" line="542"/>
         <source>Open current comic</source>
         <translation>打开当前漫画</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="539"/>
+        <location filename="library_window.cpp" line="543"/>
         <source>Open current comic on YACReader</source>
         <translation>用YACReader打开漫画</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="544"/>
+        <location filename="library_window.cpp" line="548"/>
         <source>Save selected covers to...</source>
         <translation>选中的封面保存到...</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="545"/>
+        <location filename="library_window.cpp" line="549"/>
         <source>Save covers of the selected comics as JPG files</source>
         <translation>保存所选的封面为jpg</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="549"/>
-        <location filename="library_window.cpp" line="686"/>
+        <location filename="library_window.cpp" line="553"/>
+        <location filename="library_window.cpp" line="690"/>
+        <location filename="library_window.cpp" line="1800"/>
         <source>Set as read</source>
         <translation>设为已读</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="550"/>
+        <location filename="library_window.cpp" line="554"/>
         <source>Set comic as read</source>
         <translation>漫画设为已读</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="555"/>
-        <location filename="library_window.cpp" line="691"/>
+        <location filename="library_window.cpp" line="559"/>
+        <location filename="library_window.cpp" line="695"/>
+        <location filename="library_window.cpp" line="1803"/>
         <source>Set as unread</source>
         <translation>设为未读</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="556"/>
+        <location filename="library_window.cpp" line="560"/>
         <source>Set comic as unread</source>
         <translation>漫画设为未读</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="581"/>
+        <location filename="library_window.cpp" line="585"/>
         <source>Show/Hide marks</source>
         <translation>显示/隐藏标记</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="630"/>
+        <location filename="library_window.cpp" line="634"/>
         <source>Collapse all nodes</source>
         <translation>折叠所有节点</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="732"/>
+        <location filename="library_window.cpp" line="736"/>
         <source>Assign current order to comics</source>
         <translation>将当前序号分配给漫画</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1362"/>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library not available</source>
         <oldsource>Library &apos;</oldsource>
         <translation>库不可用</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="589"/>
-        <location filename="library_window.cpp" line="590"/>
+        <location filename="library_window.cpp" line="593"/>
+        <location filename="library_window.cpp" line="594"/>
         <source>Fullscreen mode on/off</source>
         <translation>全屏模式 开/关</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="533"/>
+        <location filename="library_window.cpp" line="537"/>
         <source>Rescan library for XML info</source>
         <translation>重新扫描库的 XML 信息</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="534"/>
+        <location filename="library_window.cpp" line="538"/>
         <source>Tries to find XML info embedded in comic files. You only need to do this if the library was created with 9.8.2 or earlier versions or if you are using third party software to embed XML info in the files.</source>
         <translation>尝试查找漫画文件内嵌的 XML 信息。只有当创建库的 YACReaderLibrary 版本低于 9.8.2 或者使用第三方软件嵌入 XML 信息时，才需要执行该操作。</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="561"/>
-        <location filename="library_window.cpp" line="696"/>
+        <location filename="library_window.cpp" line="565"/>
+        <location filename="library_window.cpp" line="700"/>
+        <location filename="library_window.cpp" line="1806"/>
         <source>Set as manga</source>
         <translation>设为日漫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="562"/>
+        <location filename="library_window.cpp" line="566"/>
         <source>Set issue as manga</source>
         <translation>Set issue as manga</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="567"/>
+        <location filename="library_window.cpp" line="571"/>
         <source>Set as normal</source>
         <translation>设置为正常向</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="568"/>
+        <location filename="library_window.cpp" line="572"/>
         <source>Set issue as normal</source>
         <translation>设置发行状态为正常发行</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="598"/>
+        <location filename="library_window.cpp" line="602"/>
         <source>Help, About YACReader</source>
         <translation>帮助, 关于 YACReader</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="611"/>
-        <location filename="library_window.cpp" line="1615"/>
+        <location filename="library_window.cpp" line="615"/>
+        <location filename="library_window.cpp" line="1610"/>
         <source>Delete folder</source>
         <translation>删除文件夹</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="620"/>
+        <location filename="library_window.cpp" line="624"/>
         <source>Select root node</source>
         <translation>选择根节点</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="624"/>
+        <location filename="library_window.cpp" line="628"/>
         <source>Expand all nodes</source>
         <translation>展开所有节点</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="636"/>
+        <location filename="library_window.cpp" line="640"/>
         <source>Show options dialog</source>
         <translation>显示选项对话框</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="644"/>
+        <location filename="library_window.cpp" line="648"/>
         <source>Show comics server options dialog</source>
         <translation>显示漫画服务器选项对话框</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="670"/>
+        <location filename="library_window.cpp" line="674"/>
+        <location filename="library_window.cpp" line="1787"/>
         <source>Open folder...</source>
         <translation>打开文件夹...</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="676"/>
+        <location filename="library_window.cpp" line="680"/>
+        <location filename="library_window.cpp" line="1794"/>
         <source>Set as uncompleted</source>
         <translation>设为未完成</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="681"/>
+        <location filename="library_window.cpp" line="685"/>
+        <location filename="library_window.cpp" line="1797"/>
         <source>Set as completed</source>
         <translation>设为已完成</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="701"/>
+        <location filename="library_window.cpp" line="705"/>
+        <location filename="library_window.cpp" line="1809"/>
         <source>Set as comic</source>
         <translation>设置为漫画</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="708"/>
+        <location filename="library_window.cpp" line="712"/>
         <source>Open containing folder...</source>
         <translation>打开包含文件夹...</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="714"/>
+        <location filename="library_window.cpp" line="718"/>
         <source>Reset comic rating</source>
         <translation>重置漫画评分</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="720"/>
+        <location filename="library_window.cpp" line="724"/>
         <source>Select all comics</source>
         <translation>全选漫画</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="726"/>
+        <location filename="library_window.cpp" line="730"/>
         <source>Edit</source>
         <translation>编辑</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="738"/>
+        <location filename="library_window.cpp" line="742"/>
         <source>Update cover</source>
         <translation>更新封面</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="744"/>
+        <location filename="library_window.cpp" line="748"/>
         <source>Delete selected comics</source>
         <translation>删除所选的漫画</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="752"/>
+        <location filename="library_window.cpp" line="756"/>
         <source>Download tags from Comic Vine</source>
         <translation>从 Comic Vine 下载标签</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="756"/>
+        <location filename="library_window.cpp" line="760"/>
         <source>Focus search line</source>
         <translation>聚焦于搜索行</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="762"/>
+        <location filename="library_window.cpp" line="766"/>
         <source>Focus comics view</source>
         <translation>聚焦于漫画视图</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="767"/>
+        <location filename="library_window.cpp" line="771"/>
         <source>Edit shortcuts</source>
         <translation>编辑快捷键</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="773"/>
+        <location filename="library_window.cpp" line="777"/>
         <source>&amp;Quit</source>
         <translation>退出(&amp;Q)</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="780"/>
+        <location filename="library_window.cpp" line="784"/>
+        <location filename="library_window.cpp" line="1790"/>
         <source>Update folder</source>
         <translation>更新文件夹</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="783"/>
+        <location filename="library_window.cpp" line="787"/>
         <source>Update current folder</source>
         <translation>更新当前文件夹</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="788"/>
+        <location filename="library_window.cpp" line="792"/>
         <source>Add new reading list</source>
         <translation>添加新的阅读列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="791"/>
+        <location filename="library_window.cpp" line="795"/>
         <source>Add a new reading list to the current library</source>
         <translation>在当前库添加新的阅读列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="794"/>
+        <location filename="library_window.cpp" line="798"/>
         <source>Remove reading list</source>
         <translation>移除阅读列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="797"/>
+        <location filename="library_window.cpp" line="801"/>
         <source>Remove current reading list from the library</source>
         <translation>从当前库移除阅读列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="800"/>
+        <location filename="library_window.cpp" line="804"/>
         <source>Add new label</source>
         <translation>添加新标签</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="803"/>
+        <location filename="library_window.cpp" line="807"/>
         <source>Add a new label to this library</source>
         <translation>在当前库添加标签</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="806"/>
+        <location filename="library_window.cpp" line="810"/>
         <source>Rename selected list</source>
         <translation>重命名列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="809"/>
+        <location filename="library_window.cpp" line="813"/>
         <source>Rename any selected labels or lists</source>
         <translation>重命名任何选定的标签或列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="813"/>
+        <location filename="library_window.cpp" line="817"/>
         <source>Add to...</source>
         <translation>添加到...</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="815"/>
+        <location filename="library_window.cpp" line="819"/>
         <source>Favorites</source>
         <translation>收藏夹</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="818"/>
+        <location filename="library_window.cpp" line="822"/>
         <source>Add selected comics to favorites list</source>
         <translation>将所选漫画添加到收藏夹列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1045"/>
+        <location filename="library_window.cpp" line="1046"/>
         <source>Folder</source>
         <translation>文件夹</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1059"/>
+        <location filename="library_window.cpp" line="1060"/>
         <source>Comic</source>
         <translation>漫画</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1256"/>
+        <location filename="library_window.cpp" line="1251"/>
         <source>Upgrade failed</source>
         <translation>更新失败</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1256"/>
+        <location filename="library_window.cpp" line="1251"/>
         <source>There were errors during library upgrade in: </source>
         <translation>漫画库更新时出现错误: </translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1274"/>
+        <location filename="library_window.cpp" line="1269"/>
         <source>Update needed</source>
         <translation>需要更新</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1274"/>
+        <location filename="library_window.cpp" line="1269"/>
         <source>This library was created with a previous version of YACReaderLibrary. It needs to be updated. Update now?</source>
         <translation>此库是使用旧版本的YACReaderLibrary创建的. 它需要更新. 现在更新?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1341"/>
+        <location filename="library_window.cpp" line="1336"/>
         <source>Download new version</source>
         <translation>下载新版本</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1341"/>
+        <location filename="library_window.cpp" line="1336"/>
         <source>This library was created with a newer version of YACReaderLibrary. Download the new version now?</source>
         <translation>此库是使用较新版本的YACReaderLibrary创建的。 立即下载新版本?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1362"/>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library &apos;%1&apos; is no longer available. Do you want to remove it?</source>
         <translation>库 &apos;%1&apos; 不再可用。 你想删除它吗?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1381"/>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Old library</source>
         <translation>旧的库</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1381"/>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Library &apos;%1&apos; has been created with an older version of YACReaderLibrary. It must be created again. Do you want to create the library now?</source>
         <translation>库 &apos;%1&apos; 是通过旧版本的YACReaderLibrary创建的。 必须再次创建。 你想现在创建吗?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1414"/>
-        <location filename="library_window.cpp" line="1450"/>
+        <location filename="library_window.cpp" line="1409"/>
+        <location filename="library_window.cpp" line="1445"/>
         <source>Copying comics...</source>
         <translation>复制漫画中...</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1431"/>
-        <location filename="library_window.cpp" line="1469"/>
+        <location filename="library_window.cpp" line="1426"/>
+        <location filename="library_window.cpp" line="1464"/>
         <source>Moving comics...</source>
         <translation>移动漫画中...</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1580"/>
+        <location filename="library_window.cpp" line="1575"/>
         <source>Folder name:</source>
         <translation>文件夹名称:</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1609"/>
+        <location filename="library_window.cpp" line="1604"/>
         <source>No folder selected</source>
         <translation>没有选中的文件夹</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1609"/>
+        <location filename="library_window.cpp" line="1604"/>
         <source>Please, select a folder first</source>
         <translation>请先选择一个文件夹</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1613"/>
+        <location filename="library_window.cpp" line="1608"/>
         <source>Error in path</source>
         <translation>路径错误</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1613"/>
+        <location filename="library_window.cpp" line="1608"/>
         <source>There was an error accessing the folder&apos;s path</source>
         <translation>访问文件夹的路径时出错</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1615"/>
+        <location filename="library_window.cpp" line="1610"/>
         <source>The selected folder and all its contents will be deleted from your disk. Are you sure?</source>
         <translation>所选文件夹及其所有内容将从磁盘中删除。 你确定吗?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1641"/>
+        <location filename="library_window.cpp" line="1636"/>
         <source>There was an issue trying to delete the selected folders. Please, check for write permissions and be sure that any applications are using these folders or any of the contained files.</source>
         <translation>尝试删除所选文件夹时出现问题。 请检查写入权限，并确保没有其他应用程序在使用这些文件夹或文件。</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1653"/>
+        <location filename="library_window.cpp" line="1648"/>
         <source>Add new reading lists</source>
         <translation>添加新的阅读列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1654"/>
-        <location filename="library_window.cpp" line="1703"/>
+        <location filename="library_window.cpp" line="1649"/>
+        <location filename="library_window.cpp" line="1698"/>
         <source>List name:</source>
         <translation>列表名称:</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1672"/>
+        <location filename="library_window.cpp" line="1667"/>
         <source>Delete list/label</source>
         <translation>删除 列表/标签</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1672"/>
+        <location filename="library_window.cpp" line="1667"/>
         <source>The selected item will be deleted, your comics or folders will NOT be deleted from your disk. Are you sure?</source>
         <translation>所选项目将被删除，您的漫画或文件夹将不会从您的磁盘中删除。 你确定吗?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1702"/>
+        <location filename="library_window.cpp" line="1697"/>
         <source>Rename list name</source>
         <translation>重命名列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1832"/>
+        <location filename="library_window.cpp" line="1916"/>
         <source>Save covers</source>
         <translation>保存封面</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1851"/>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.</source>
         <translation>您添加的库太多了。</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1851"/>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.
 
 You probably only need one library in your top level comics folder, you can browse any subfolders using the folders section in the left sidebar.
@@ -1132,141 +1213,141 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 YACReaderLibrary不会阻止您创建更多的库，但是您应该保持较低的库数量来提升性能。</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1909"/>
-        <location filename="library_window.cpp" line="1911"/>
+        <location filename="library_window.cpp" line="1993"/>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found</source>
         <translation>YACReader 未找到</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1999"/>
+        <location filename="library_window.cpp" line="2083"/>
         <source>Library not found</source>
         <translation>未找到库</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1999"/>
+        <location filename="library_window.cpp" line="2083"/>
         <source>The selected folder doesn&apos;t contain any library.</source>
         <translation>所选文件夹不包含任何库。</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2054"/>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Are you sure?</source>
         <translation>你确定吗?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2054"/>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Do you want remove </source>
         <translation>你想要删除 </translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2054"/>
+        <location filename="library_window.cpp" line="2138"/>
         <source> library?</source>
         <translation> 库?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2055"/>
+        <location filename="library_window.cpp" line="2139"/>
         <source>Remove and delete metadata</source>
         <translation>移除并删除元数据</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2357"/>
+        <location filename="library_window.cpp" line="2448"/>
         <source>Assign comics numbers</source>
         <translation>分配漫画编号</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2358"/>
+        <location filename="library_window.cpp" line="2449"/>
         <source>Assign numbers starting in:</source>
         <translation>从以下位置开始分配编号:</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1641"/>
-        <location filename="library_window.cpp" line="2326"/>
+        <location filename="library_window.cpp" line="1636"/>
+        <location filename="library_window.cpp" line="2417"/>
         <source>Unable to delete</source>
         <translation>无法删除</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="582"/>
+        <location filename="library_window.cpp" line="586"/>
         <source>Show or hide read marks</source>
         <translation>显示或隐藏阅读标记</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="605"/>
-        <location filename="library_window.cpp" line="1579"/>
+        <location filename="library_window.cpp" line="609"/>
+        <location filename="library_window.cpp" line="1574"/>
         <source>Add new folder</source>
         <translation>添加新的文件夹</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="608"/>
+        <location filename="library_window.cpp" line="612"/>
         <source>Add new folder to the current library</source>
         <translation>在当前库下添加新的文件夹</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="614"/>
+        <location filename="library_window.cpp" line="618"/>
         <source>Delete current folder from disk</source>
         <translation>从磁盘上删除当前文件夹</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="651"/>
-        <location filename="library_window.cpp" line="652"/>
+        <location filename="library_window.cpp" line="655"/>
+        <location filename="library_window.cpp" line="656"/>
         <source>Change between comics views</source>
         <translation>漫画视图之间的变化</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1909"/>
+        <location filename="library_window.cpp" line="1993"/>
         <source>YACReader not found. YACReader should be installed in the same folder as YACReaderLibrary.</source>
         <translation>未找到YACReader. YACReader应安装在与YACReaderLibrary相同的文件夹中.</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1911"/>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found. There might be a problem with your YACReader installation.</source>
         <translation>未找到YACReader. YACReader的安装可能有问题.</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2326"/>
+        <location filename="library_window.cpp" line="2417"/>
         <source>There was an issue trying to delete the selected comics. Please, check for write permissions in the selected files or containing folder.</source>
         <translation>尝试删除所选漫画时出现问题。 请检查所选文件或包含文件夹中的写入权限。</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2559"/>
+        <location filename="library_window.cpp" line="2649"/>
         <source>Error creating the library</source>
         <translation>创建库时出错</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2564"/>
+        <location filename="library_window.cpp" line="2654"/>
         <source>Error updating the library</source>
         <translation>更新库时出错</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2569"/>
+        <location filename="library_window.cpp" line="2659"/>
         <source>Error opening the library</source>
         <translation>打开库时出错</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2604"/>
+        <location filename="library_window.cpp" line="2694"/>
         <source>Delete comics</source>
         <translation>删除漫画</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2604"/>
+        <location filename="library_window.cpp" line="2694"/>
         <source>All the selected comics will be deleted from your disk. Are you sure?</source>
         <translation>所有选定的漫画都将从您的磁盘中删除。你确定吗?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2641"/>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Remove comics</source>
         <translation>移除漫画</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2641"/>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Comics will only be deleted from the current label/list. Are you sure?</source>
         <translation>漫画只会从当前标签/列表中删除。 你确定吗?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2715"/>
+        <location filename="library_window.cpp" line="2805"/>
         <source>Library name already exists</source>
         <translation>库名已存在</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2715"/>
+        <location filename="library_window.cpp" line="2805"/>
         <source>There is another library with the name &apos;%1&apos;.</source>
         <translation>已存在另一个名为&apos;%1&apos;的库。</translation>
     </message>
@@ -1431,179 +1512,179 @@ YACReaderLibrary不会阻止您创建更多的库，但是您应该保持较低�
 <context>
     <name>PropertiesDialog</name>
     <message>
-        <location filename="properties_dialog.cpp" line="80"/>
+        <location filename="properties_dialog.cpp" line="82"/>
         <source>General info</source>
         <translation>基本信息</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="81"/>
+        <location filename="properties_dialog.cpp" line="83"/>
         <source>Authors</source>
         <translation>作者</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="82"/>
+        <location filename="properties_dialog.cpp" line="84"/>
         <source>Publishing</source>
         <translation>出版</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="83"/>
+        <location filename="properties_dialog.cpp" line="85"/>
         <source>Plot</source>
         <translation>情节</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="92"/>
+        <location filename="properties_dialog.cpp" line="94"/>
         <source>Cover page</source>
         <translation>封面</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="152"/>
+        <location filename="properties_dialog.cpp" line="143"/>
         <source>Title:</source>
         <translation>标题:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="160"/>
-        <location filename="properties_dialog.cpp" line="177"/>
+        <location filename="properties_dialog.cpp" line="151"/>
+        <location filename="properties_dialog.cpp" line="168"/>
         <source>of:</source>
         <translation>of:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="167"/>
+        <location filename="properties_dialog.cpp" line="158"/>
         <source>Issue number:</source>
         <translation>发行数量:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="169"/>
+        <location filename="properties_dialog.cpp" line="160"/>
         <source>Volume:</source>
         <translation>卷:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="173"/>
+        <location filename="properties_dialog.cpp" line="164"/>
         <source>Arc number:</source>
         <translation>世界线数量:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="182"/>
+        <location filename="properties_dialog.cpp" line="173"/>
         <source>Story arc:</source>
         <translation>故事线:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="184"/>
+        <location filename="properties_dialog.cpp" line="175"/>
         <source>Genre:</source>
         <oldsource>Genere:</oldsource>
         <translation>类型:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="186"/>
+        <location filename="properties_dialog.cpp" line="177"/>
         <source>Size:</source>
         <translation>大小:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="210"/>
+        <location filename="properties_dialog.cpp" line="197"/>
         <source>Writer(s):</source>
         <translation>作者:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="213"/>
+        <location filename="properties_dialog.cpp" line="200"/>
         <source>Penciller(s):</source>
         <translation>线稿:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="221"/>
+        <location filename="properties_dialog.cpp" line="207"/>
         <source>Inker(s):</source>
         <translation>墨稿:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="224"/>
+        <location filename="properties_dialog.cpp" line="210"/>
         <source>Colorist(s):</source>
         <translation>上色:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="234"/>
+        <location filename="properties_dialog.cpp" line="217"/>
         <source>Letterer(s):</source>
         <translation>文本:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="237"/>
+        <location filename="properties_dialog.cpp" line="220"/>
         <source>Cover Artist(s):</source>
         <translation>封面设计:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="259"/>
+        <location filename="properties_dialog.cpp" line="240"/>
         <source>Day:</source>
         <translation>日:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="263"/>
+        <location filename="properties_dialog.cpp" line="244"/>
         <source>Month:</source>
         <translation>月:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="267"/>
+        <location filename="properties_dialog.cpp" line="248"/>
         <source>Year:</source>
         <translation>年:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="275"/>
+        <location filename="properties_dialog.cpp" line="256"/>
         <source>Publisher:</source>
         <translation>出版者:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="276"/>
+        <location filename="properties_dialog.cpp" line="257"/>
         <source>Format:</source>
         <translation>格式:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="277"/>
+        <location filename="properties_dialog.cpp" line="258"/>
         <source>Color/BW:</source>
         <translation>彩色/黑白:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="278"/>
+        <location filename="properties_dialog.cpp" line="259"/>
         <source>Age rating:</source>
         <translation>年龄等级:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="279"/>
+        <location filename="properties_dialog.cpp" line="260"/>
         <source>Manga:</source>
         <translation>日漫:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="292"/>
+        <location filename="properties_dialog.cpp" line="273"/>
         <source>Synopsis:</source>
         <translation>概要:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="293"/>
+        <location filename="properties_dialog.cpp" line="274"/>
         <source>Characters:</source>
         <translation>角色:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="294"/>
+        <location filename="properties_dialog.cpp" line="275"/>
         <source>Notes:</source>
         <translation>笔记:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="390"/>
+        <location filename="properties_dialog.cpp" line="369"/>
         <source>Comic Vine link: &lt;a style=&apos;color: #FFCB00; text-decoration:none; font-weight:bold;&apos; href=&quot;http://www.comicvine.com/comic/4000-%1/&quot;&gt; view &lt;/a&gt;</source>
         <translation>Comic Vine 连接: &lt;a style=&apos;color: #FFCB00; text-decoration:none; font-weight:bold;&apos; href=&quot;http://www.comicvine.com/comic/4000-%1/&quot;&gt; 查看 &lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="415"/>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Not found</source>
         <translation>未找到</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="415"/>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Comic not found. You should update your library.</source>
         <translation>未找到漫画,请先更新您的库.</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="492"/>
+        <location filename="properties_dialog.cpp" line="501"/>
         <source>Edit selected comics information</source>
         <translation>编辑选中的漫画信息</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="559"/>
+        <location filename="properties_dialog.cpp" line="467"/>
         <source>Edit comic information</source>
         <translation>编辑漫画信息</translation>
     </message>
@@ -1791,27 +1872,37 @@ YACReaderLibrary不会阻止您创建更多的库，但是您应该保持较低�
 <context>
     <name>SelectVolume</name>
     <message>
-        <location filename="comic_vine/select_volume.cpp" line="32"/>
+        <location filename="comic_vine/select_volume.cpp" line="35"/>
         <source>Please, select the right series for your comic.</source>
         <translation>请选择正确的漫画系列。</translation>
     </message>
     <message>
-        <location filename="comic_vine/select_volume.cpp" line="62"/>
+        <location filename="comic_vine/select_volume.cpp" line="56"/>
+        <source>Filter:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="68"/>
         <source>volumes</source>
         <translation>卷</translation>
     </message>
     <message>
-        <location filename="comic_vine/select_volume.cpp" line="123"/>
+        <location filename="comic_vine/select_volume.cpp" line="138"/>
+        <source>Nothing found, clear the filter if any.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="144"/>
         <source>loading cover</source>
         <translation>加载封面</translation>
     </message>
     <message>
-        <location filename="comic_vine/select_volume.cpp" line="124"/>
+        <location filename="comic_vine/select_volume.cpp" line="145"/>
         <source>loading description</source>
         <translation>加载描述</translation>
     </message>
     <message>
-        <location filename="comic_vine/select_volume.cpp" line="164"/>
+        <location filename="comic_vine/select_volume.cpp" line="185"/>
         <source>description unavailable</source>
         <translation>描述不可用</translation>
     </message>
@@ -1985,7 +2076,7 @@ to improve the performance</source>
 <context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
-        <location filename="../custom_widgets/whats_new_dialog.cpp" line="104"/>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation>关闭</translation>
     </message>
@@ -2218,7 +2309,7 @@ to improve the performance</source>
 <context>
     <name>YACReaderSearchLineEdit</name>
     <message>
-        <location filename="../custom_widgets/yacreader_search_line_edit.cpp" line="46"/>
+        <location filename="../custom_widgets/yacreader_search_line_edit.cpp" line="68"/>
         <source>type to search</source>
         <translation>搜索类型</translation>
     </message>

--- a/YACReaderLibrary/yacreaderlibrary_zh_HK.ts
+++ b/YACReaderLibrary/yacreaderlibrary_zh_HK.ts
@@ -153,54 +153,112 @@
     </message>
 </context>
 <context>
+    <name>ComicInfoView</name>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="279"/>
+        <source>Authors</source>
+        <translation type="unfinished">作者</translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="309"/>
+        <source>writer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="331"/>
+        <source>penciller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="353"/>
+        <source>inker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="375"/>
+        <source>colorist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="397"/>
+        <source>letterer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="419"/>
+        <source>cover artist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="434"/>
+        <source>Publisher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
+        <source>color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
+        <source>b/w</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="502"/>
+        <source>Characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ComicModel</name>
     <message>
-        <location filename="db/comic_model.cpp" line="303"/>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>yes</source>
         <translation>是</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="303"/>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>no</source>
         <translation>否</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="335"/>
+        <location filename="db/comic_model.cpp" line="343"/>
         <source>Title</source>
         <translation>標題</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="337"/>
+        <location filename="db/comic_model.cpp" line="345"/>
         <source>File Name</source>
         <translation>檔案名</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="339"/>
+        <location filename="db/comic_model.cpp" line="347"/>
         <source>Pages</source>
         <translation>頁數</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="341"/>
+        <location filename="db/comic_model.cpp" line="349"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="343"/>
+        <location filename="db/comic_model.cpp" line="351"/>
         <source>Read</source>
         <translation>閱讀</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="345"/>
+        <location filename="db/comic_model.cpp" line="353"/>
         <source>Current Page</source>
         <translation>當前頁</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="347"/>
+        <location filename="db/comic_model.cpp" line="355"/>
         <source>Publication Date</source>
         <translation>發行日期</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="349"/>
+        <location filename="db/comic_model.cpp" line="357"/>
         <source>Rating</source>
         <translation>評分</translation>
     </message>
@@ -208,68 +266,67 @@
 <context>
     <name>ComicVineDialog</name>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="50"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="57"/>
         <source>skip</source>
         <translation>忽略</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="51"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="58"/>
         <source>back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="52"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="59"/>
         <source>next</source>
         <translation>下一步</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="53"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="60"/>
         <source>search</source>
         <translation>搜索</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="54"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="61"/>
         <source>close</source>
         <translation>關閉</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="130"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="140"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="252"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="759"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="793"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="143"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="257"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="773"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="807"/>
         <source>Looking for volume...</source>
         <translation>搜索卷...</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="138"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="726"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="141"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="735"/>
         <source>comic %1 of %2 - %3</source>
         <translation>第 %1 本 共 %2 本 - %3</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="257"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="262"/>
         <source>%1 comics selected</source>
         <translation>已選擇 %1 本漫畫</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="290"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="295"/>
         <source>Error connecting to ComicVine</source>
         <translation>ComicVine 連接時出錯</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="460"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="496"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="467"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="503"/>
         <source>Retrieving tags for : %1</source>
         <translation>正在檢索標籤: %1</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="774"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="788"/>
         <source>Retrieving volume info...</source>
         <translation>正在接收卷資訊...</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="800"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="814"/>
         <source>Looking for comic...</source>
         <translation>搜索漫畫中...</translation>
     </message>
@@ -481,9 +538,25 @@
     </message>
 </context>
 <context>
+    <name>FolderContentView</name>
+    <message>
+        <location filename="qml/FolderContentView.qml" line="238"/>
+        <source>Continue Reading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FolderContentView6</name>
+    <message>
+        <location filename="qml/FolderContentView6.qml" line="240"/>
+        <source>Continue Reading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GridComicsView</name>
     <message>
-        <location filename="grid_comics_view.cpp" line="163"/>
+        <location filename="grid_comics_view.cpp" line="147"/>
         <source>Show info</source>
         <translation>顯示資訊</translation>
     </message>
@@ -491,17 +564,17 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
-        <location filename="../custom_widgets/help_about_dialog.cpp" line="25"/>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation>關於</translation>
     </message>
     <message>
-        <location filename="../custom_widgets/help_about_dialog.cpp" line="28"/>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
         <translation>幫助</translation>
     </message>
     <message>
-        <location filename="../custom_widgets/help_about_dialog.cpp" line="31"/>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
         <source>System info</source>
         <translation>系統資訊</translation>
     </message>
@@ -628,498 +701,506 @@
 <context>
     <name>LibraryWindow</name>
     <message>
-        <location filename="library_window.cpp" line="184"/>
+        <location filename="library_window.cpp" line="188"/>
         <source>YACReader Library</source>
         <translation>YACReader 庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1026"/>
+        <location filename="library_window.cpp" line="1027"/>
         <source>Library</source>
         <translation>庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="480"/>
+        <location filename="library_window.cpp" line="484"/>
         <source>Create a new library</source>
         <translation>創建一個新的庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="486"/>
+        <location filename="library_window.cpp" line="490"/>
         <source>Open an existing library</source>
         <translation>打開現有的庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="491"/>
-        <location filename="library_window.cpp" line="492"/>
+        <location filename="library_window.cpp" line="495"/>
+        <location filename="library_window.cpp" line="496"/>
         <source>Export comics info</source>
         <translation>導出漫畫資訊</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="497"/>
-        <location filename="library_window.cpp" line="498"/>
+        <location filename="library_window.cpp" line="501"/>
+        <location filename="library_window.cpp" line="502"/>
         <source>Import comics info</source>
         <translation>導入漫畫資訊</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="503"/>
+        <location filename="library_window.cpp" line="507"/>
         <source>Pack covers</source>
         <translation>打包封面</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="504"/>
+        <location filename="library_window.cpp" line="508"/>
         <source>Pack the covers of the selected library</source>
         <translation>打包所選庫的封面</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="509"/>
+        <location filename="library_window.cpp" line="513"/>
         <source>Unpack covers</source>
         <translation>解壓封面</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="510"/>
+        <location filename="library_window.cpp" line="514"/>
         <source>Unpack a catalog</source>
         <translation>解壓目錄</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="515"/>
+        <location filename="library_window.cpp" line="519"/>
         <source>Update library</source>
         <translation>更新庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="516"/>
+        <location filename="library_window.cpp" line="520"/>
         <source>Update current library</source>
         <translation>更新當前庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="521"/>
+        <location filename="library_window.cpp" line="525"/>
         <source>Rename library</source>
         <translation>重命名庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="522"/>
+        <location filename="library_window.cpp" line="526"/>
         <source>Rename current library</source>
         <translation>重命名當前庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="527"/>
+        <location filename="library_window.cpp" line="531"/>
         <source>Remove library</source>
         <translation>移除庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="528"/>
+        <location filename="library_window.cpp" line="532"/>
         <source>Remove current library from your collection</source>
         <translation>從您的集合中移除當前庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="538"/>
+        <location filename="library_window.cpp" line="542"/>
         <source>Open current comic</source>
         <translation>打開當前漫畫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="539"/>
+        <location filename="library_window.cpp" line="543"/>
         <source>Open current comic on YACReader</source>
         <translation>用YACReader打開漫畫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="544"/>
+        <location filename="library_window.cpp" line="548"/>
         <source>Save selected covers to...</source>
         <translation>選中的封面保存到...</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="545"/>
+        <location filename="library_window.cpp" line="549"/>
         <source>Save covers of the selected comics as JPG files</source>
         <translation>保存所選的封面為jpg</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="549"/>
-        <location filename="library_window.cpp" line="686"/>
+        <location filename="library_window.cpp" line="553"/>
+        <location filename="library_window.cpp" line="690"/>
+        <location filename="library_window.cpp" line="1800"/>
         <source>Set as read</source>
         <translation>設為已讀</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="550"/>
+        <location filename="library_window.cpp" line="554"/>
         <source>Set comic as read</source>
         <translation>漫畫設為已讀</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="555"/>
-        <location filename="library_window.cpp" line="691"/>
+        <location filename="library_window.cpp" line="559"/>
+        <location filename="library_window.cpp" line="695"/>
+        <location filename="library_window.cpp" line="1803"/>
         <source>Set as unread</source>
         <translation>設為未讀</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="556"/>
+        <location filename="library_window.cpp" line="560"/>
         <source>Set comic as unread</source>
         <translation>漫畫設為未讀</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="581"/>
+        <location filename="library_window.cpp" line="585"/>
         <source>Show/Hide marks</source>
         <translation>顯示/隱藏標記</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="630"/>
+        <location filename="library_window.cpp" line="634"/>
         <source>Collapse all nodes</source>
         <translation>折疊所有節點</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="732"/>
+        <location filename="library_window.cpp" line="736"/>
         <source>Assign current order to comics</source>
         <translation>將當前序號分配給漫畫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1362"/>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library not available</source>
         <oldsource>Library &apos;</oldsource>
         <translation>庫不可用</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="589"/>
-        <location filename="library_window.cpp" line="590"/>
+        <location filename="library_window.cpp" line="593"/>
+        <location filename="library_window.cpp" line="594"/>
         <source>Fullscreen mode on/off</source>
         <translation>全屏模式 開/關</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="533"/>
+        <location filename="library_window.cpp" line="537"/>
         <source>Rescan library for XML info</source>
         <translation>重新掃描庫的 XML 資訊</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="534"/>
+        <location filename="library_window.cpp" line="538"/>
         <source>Tries to find XML info embedded in comic files. You only need to do this if the library was created with 9.8.2 or earlier versions or if you are using third party software to embed XML info in the files.</source>
         <translation>嘗試查找漫畫檔內嵌的 XML 資訊。只有當創建庫的 YACReaderLibrary 版本低於 9.8.2 或者使用第三方軟體嵌入 XML 資訊時，才需要執行該操作。</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="561"/>
-        <location filename="library_window.cpp" line="696"/>
+        <location filename="library_window.cpp" line="565"/>
+        <location filename="library_window.cpp" line="700"/>
+        <location filename="library_window.cpp" line="1806"/>
         <source>Set as manga</source>
         <translation>設為日漫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="562"/>
+        <location filename="library_window.cpp" line="566"/>
         <source>Set issue as manga</source>
         <translation>Set issue as manga</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="567"/>
+        <location filename="library_window.cpp" line="571"/>
         <source>Set as normal</source>
         <translation>設置為正常向</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="568"/>
+        <location filename="library_window.cpp" line="572"/>
         <source>Set issue as normal</source>
         <translation>設置發行狀態為正常發行</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="598"/>
+        <location filename="library_window.cpp" line="602"/>
         <source>Help, About YACReader</source>
         <translation>幫助, 關於 YACReader</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="611"/>
-        <location filename="library_window.cpp" line="1615"/>
+        <location filename="library_window.cpp" line="615"/>
+        <location filename="library_window.cpp" line="1610"/>
         <source>Delete folder</source>
         <translation>刪除檔夾</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="620"/>
+        <location filename="library_window.cpp" line="624"/>
         <source>Select root node</source>
         <translation>選擇根節點</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="624"/>
+        <location filename="library_window.cpp" line="628"/>
         <source>Expand all nodes</source>
         <translation>展開所有節點</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="636"/>
+        <location filename="library_window.cpp" line="640"/>
         <source>Show options dialog</source>
         <translation>顯示選項對話框</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="644"/>
+        <location filename="library_window.cpp" line="648"/>
         <source>Show comics server options dialog</source>
         <translation>顯示漫畫伺服器選項對話框</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="670"/>
+        <location filename="library_window.cpp" line="674"/>
+        <location filename="library_window.cpp" line="1787"/>
         <source>Open folder...</source>
         <translation>打開檔夾...</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="676"/>
+        <location filename="library_window.cpp" line="680"/>
+        <location filename="library_window.cpp" line="1794"/>
         <source>Set as uncompleted</source>
         <translation>設為未完成</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="681"/>
+        <location filename="library_window.cpp" line="685"/>
+        <location filename="library_window.cpp" line="1797"/>
         <source>Set as completed</source>
         <translation>設為已完成</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="701"/>
+        <location filename="library_window.cpp" line="705"/>
+        <location filename="library_window.cpp" line="1809"/>
         <source>Set as comic</source>
         <translation>設置為漫畫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="708"/>
+        <location filename="library_window.cpp" line="712"/>
         <source>Open containing folder...</source>
         <translation>打開包含檔夾...</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="714"/>
+        <location filename="library_window.cpp" line="718"/>
         <source>Reset comic rating</source>
         <translation>重置漫畫評分</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="720"/>
+        <location filename="library_window.cpp" line="724"/>
         <source>Select all comics</source>
         <translation>全選漫畫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="726"/>
+        <location filename="library_window.cpp" line="730"/>
         <source>Edit</source>
         <translation>編輯</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="738"/>
+        <location filename="library_window.cpp" line="742"/>
         <source>Update cover</source>
         <translation>更新封面</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="744"/>
+        <location filename="library_window.cpp" line="748"/>
         <source>Delete selected comics</source>
         <translation>刪除所選的漫畫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="752"/>
+        <location filename="library_window.cpp" line="756"/>
         <source>Download tags from Comic Vine</source>
         <translation>從 Comic Vine 下載標籤</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="756"/>
+        <location filename="library_window.cpp" line="760"/>
         <source>Focus search line</source>
         <translation>聚焦於搜索行</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="762"/>
+        <location filename="library_window.cpp" line="766"/>
         <source>Focus comics view</source>
         <translation>聚焦於漫畫視圖</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="767"/>
+        <location filename="library_window.cpp" line="771"/>
         <source>Edit shortcuts</source>
         <translation>編輯快捷鍵</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="773"/>
+        <location filename="library_window.cpp" line="777"/>
         <source>&amp;Quit</source>
         <translation>退出(&amp;Q)</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="780"/>
+        <location filename="library_window.cpp" line="784"/>
+        <location filename="library_window.cpp" line="1790"/>
         <source>Update folder</source>
         <translation>更新檔夾</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="783"/>
+        <location filename="library_window.cpp" line="787"/>
         <source>Update current folder</source>
         <translation>更新當前檔夾</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="788"/>
+        <location filename="library_window.cpp" line="792"/>
         <source>Add new reading list</source>
         <translation>添加新的閱讀列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="791"/>
+        <location filename="library_window.cpp" line="795"/>
         <source>Add a new reading list to the current library</source>
         <translation>在當前庫添加新的閱讀列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="794"/>
+        <location filename="library_window.cpp" line="798"/>
         <source>Remove reading list</source>
         <translation>移除閱讀列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="797"/>
+        <location filename="library_window.cpp" line="801"/>
         <source>Remove current reading list from the library</source>
         <translation>從當前庫移除閱讀列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="800"/>
+        <location filename="library_window.cpp" line="804"/>
         <source>Add new label</source>
         <translation>添加新標籤</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="803"/>
+        <location filename="library_window.cpp" line="807"/>
         <source>Add a new label to this library</source>
         <translation>在當前庫添加標籤</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="806"/>
+        <location filename="library_window.cpp" line="810"/>
         <source>Rename selected list</source>
         <translation>重命名列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="809"/>
+        <location filename="library_window.cpp" line="813"/>
         <source>Rename any selected labels or lists</source>
         <translation>重命名任何選定的標籤或列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="813"/>
+        <location filename="library_window.cpp" line="817"/>
         <source>Add to...</source>
         <translation>添加到...</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="815"/>
+        <location filename="library_window.cpp" line="819"/>
         <source>Favorites</source>
         <translation>收藏夾</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="818"/>
+        <location filename="library_window.cpp" line="822"/>
         <source>Add selected comics to favorites list</source>
         <translation>將所選漫畫添加到收藏夾列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1045"/>
+        <location filename="library_window.cpp" line="1046"/>
         <source>Folder</source>
         <translation>檔夾</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1059"/>
+        <location filename="library_window.cpp" line="1060"/>
         <source>Comic</source>
         <translation>漫畫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1256"/>
+        <location filename="library_window.cpp" line="1251"/>
         <source>Upgrade failed</source>
         <translation>更新失敗</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1256"/>
+        <location filename="library_window.cpp" line="1251"/>
         <source>There were errors during library upgrade in: </source>
         <translation>漫畫庫更新時出現錯誤: </translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1274"/>
+        <location filename="library_window.cpp" line="1269"/>
         <source>Update needed</source>
         <translation>需要更新</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1274"/>
+        <location filename="library_window.cpp" line="1269"/>
         <source>This library was created with a previous version of YACReaderLibrary. It needs to be updated. Update now?</source>
         <translation>此庫是使用舊版本的YACReaderLibrary創建的. 它需要更新. 現在更新?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1341"/>
+        <location filename="library_window.cpp" line="1336"/>
         <source>Download new version</source>
         <translation>下載新版本</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1341"/>
+        <location filename="library_window.cpp" line="1336"/>
         <source>This library was created with a newer version of YACReaderLibrary. Download the new version now?</source>
         <translation>此庫是使用較新版本的YACReaderLibrary創建的。 立即下載新版本?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1362"/>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library &apos;%1&apos; is no longer available. Do you want to remove it?</source>
         <translation>庫 &apos;%1&apos; 不再可用。 你想刪除它嗎?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1381"/>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Old library</source>
         <translation>舊的庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1381"/>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Library &apos;%1&apos; has been created with an older version of YACReaderLibrary. It must be created again. Do you want to create the library now?</source>
         <translation>庫 &apos;%1&apos; 是通過舊版本的YACReaderLibrary創建的。 必須再次創建。 你想現在創建嗎?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1414"/>
-        <location filename="library_window.cpp" line="1450"/>
+        <location filename="library_window.cpp" line="1409"/>
+        <location filename="library_window.cpp" line="1445"/>
         <source>Copying comics...</source>
         <translation>複製漫畫中...</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1431"/>
-        <location filename="library_window.cpp" line="1469"/>
+        <location filename="library_window.cpp" line="1426"/>
+        <location filename="library_window.cpp" line="1464"/>
         <source>Moving comics...</source>
         <translation>移動漫畫中...</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1580"/>
+        <location filename="library_window.cpp" line="1575"/>
         <source>Folder name:</source>
         <translation>檔夾名稱:</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1609"/>
+        <location filename="library_window.cpp" line="1604"/>
         <source>No folder selected</source>
         <translation>沒有選中的檔夾</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1609"/>
+        <location filename="library_window.cpp" line="1604"/>
         <source>Please, select a folder first</source>
         <translation>請先選擇一個檔夾</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1613"/>
+        <location filename="library_window.cpp" line="1608"/>
         <source>Error in path</source>
         <translation>路徑錯誤</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1613"/>
+        <location filename="library_window.cpp" line="1608"/>
         <source>There was an error accessing the folder&apos;s path</source>
         <translation>訪問檔夾的路徑時出錯</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1615"/>
+        <location filename="library_window.cpp" line="1610"/>
         <source>The selected folder and all its contents will be deleted from your disk. Are you sure?</source>
         <translation>所選檔夾及其所有內容將從磁片中刪除。 你確定嗎?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1641"/>
+        <location filename="library_window.cpp" line="1636"/>
         <source>There was an issue trying to delete the selected folders. Please, check for write permissions and be sure that any applications are using these folders or any of the contained files.</source>
         <translation>嘗試刪除所選檔夾時出現問題。 請檢查寫入許可權，並確保沒有其他應用程式在使用這些檔夾或檔。</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1653"/>
+        <location filename="library_window.cpp" line="1648"/>
         <source>Add new reading lists</source>
         <translation>添加新的閱讀列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1654"/>
-        <location filename="library_window.cpp" line="1703"/>
+        <location filename="library_window.cpp" line="1649"/>
+        <location filename="library_window.cpp" line="1698"/>
         <source>List name:</source>
         <translation>列表名稱:</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1672"/>
+        <location filename="library_window.cpp" line="1667"/>
         <source>Delete list/label</source>
         <translation>刪除 列表/標籤</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1672"/>
+        <location filename="library_window.cpp" line="1667"/>
         <source>The selected item will be deleted, your comics or folders will NOT be deleted from your disk. Are you sure?</source>
         <translation>所選項目將被刪除，您的漫畫或檔夾將不會從您的磁片中刪除。 你確定嗎?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1702"/>
+        <location filename="library_window.cpp" line="1697"/>
         <source>Rename list name</source>
         <translation>重命名列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1832"/>
+        <location filename="library_window.cpp" line="1916"/>
         <source>Save covers</source>
         <translation>保存封面</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1851"/>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.</source>
         <translation>您添加的庫太多了。</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1851"/>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.
 
 You probably only need one library in your top level comics folder, you can browse any subfolders using the folders section in the left sidebar.
@@ -1132,141 +1213,141 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 YACReaderLibrary不會阻止您創建更多的庫，但是您應該保持較低的庫數量來提升性能。</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1909"/>
-        <location filename="library_window.cpp" line="1911"/>
+        <location filename="library_window.cpp" line="1993"/>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found</source>
         <translation>YACReader 未找到</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1999"/>
+        <location filename="library_window.cpp" line="2083"/>
         <source>Library not found</source>
         <translation>未找到庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1999"/>
+        <location filename="library_window.cpp" line="2083"/>
         <source>The selected folder doesn&apos;t contain any library.</source>
         <translation>所選檔夾不包含任何庫。</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2054"/>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Are you sure?</source>
         <translation>你確定嗎?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2054"/>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Do you want remove </source>
         <translation>你想要刪除 </translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2054"/>
+        <location filename="library_window.cpp" line="2138"/>
         <source> library?</source>
         <translation> 庫?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2055"/>
+        <location filename="library_window.cpp" line="2139"/>
         <source>Remove and delete metadata</source>
         <translation>移除並刪除元數據</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2357"/>
+        <location filename="library_window.cpp" line="2448"/>
         <source>Assign comics numbers</source>
         <translation>分配漫畫編號</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2358"/>
+        <location filename="library_window.cpp" line="2449"/>
         <source>Assign numbers starting in:</source>
         <translation>從以下位置開始分配編號:</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1641"/>
-        <location filename="library_window.cpp" line="2326"/>
+        <location filename="library_window.cpp" line="1636"/>
+        <location filename="library_window.cpp" line="2417"/>
         <source>Unable to delete</source>
         <translation>無法刪除</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="582"/>
+        <location filename="library_window.cpp" line="586"/>
         <source>Show or hide read marks</source>
         <translation>顯示或隱藏閱讀標記</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="605"/>
-        <location filename="library_window.cpp" line="1579"/>
+        <location filename="library_window.cpp" line="609"/>
+        <location filename="library_window.cpp" line="1574"/>
         <source>Add new folder</source>
         <translation>添加新的檔夾</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="608"/>
+        <location filename="library_window.cpp" line="612"/>
         <source>Add new folder to the current library</source>
         <translation>在當前庫下添加新的檔夾</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="614"/>
+        <location filename="library_window.cpp" line="618"/>
         <source>Delete current folder from disk</source>
         <translation>從磁片上刪除當前檔夾</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="651"/>
-        <location filename="library_window.cpp" line="652"/>
+        <location filename="library_window.cpp" line="655"/>
+        <location filename="library_window.cpp" line="656"/>
         <source>Change between comics views</source>
         <translation>漫畫視圖之間的變化</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1909"/>
+        <location filename="library_window.cpp" line="1993"/>
         <source>YACReader not found. YACReader should be installed in the same folder as YACReaderLibrary.</source>
         <translation>未找到YACReader. YACReader應安裝在與YACReaderLibrary相同的檔夾中.</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1911"/>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found. There might be a problem with your YACReader installation.</source>
         <translation>未找到YACReader. YACReader的安裝可能有問題.</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2326"/>
+        <location filename="library_window.cpp" line="2417"/>
         <source>There was an issue trying to delete the selected comics. Please, check for write permissions in the selected files or containing folder.</source>
         <translation>嘗試刪除所選漫畫時出現問題。 請檢查所選檔或包含檔夾中的寫入許可權。</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2559"/>
+        <location filename="library_window.cpp" line="2649"/>
         <source>Error creating the library</source>
         <translation>創建庫時出錯</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2564"/>
+        <location filename="library_window.cpp" line="2654"/>
         <source>Error updating the library</source>
         <translation>更新庫時出錯</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2569"/>
+        <location filename="library_window.cpp" line="2659"/>
         <source>Error opening the library</source>
         <translation>打開庫時出錯</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2604"/>
+        <location filename="library_window.cpp" line="2694"/>
         <source>Delete comics</source>
         <translation>刪除漫畫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2604"/>
+        <location filename="library_window.cpp" line="2694"/>
         <source>All the selected comics will be deleted from your disk. Are you sure?</source>
         <translation>所有選定的漫畫都將從您的磁片中刪除。你確定嗎?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2641"/>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Remove comics</source>
         <translation>移除漫畫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2641"/>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Comics will only be deleted from the current label/list. Are you sure?</source>
         <translation>漫畫只會從當前標籤/列表中刪除。 你確定嗎?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2715"/>
+        <location filename="library_window.cpp" line="2805"/>
         <source>Library name already exists</source>
         <translation>庫名已存在</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2715"/>
+        <location filename="library_window.cpp" line="2805"/>
         <source>There is another library with the name &apos;%1&apos;.</source>
         <translation>已存在另一個名為&apos;%1&apos;的庫。</translation>
     </message>
@@ -1431,179 +1512,179 @@ YACReaderLibrary不會阻止您創建更多的庫，但是您應該保持較低�
 <context>
     <name>PropertiesDialog</name>
     <message>
-        <location filename="properties_dialog.cpp" line="80"/>
+        <location filename="properties_dialog.cpp" line="82"/>
         <source>General info</source>
         <translation>基本資訊</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="81"/>
+        <location filename="properties_dialog.cpp" line="83"/>
         <source>Authors</source>
         <translation>作者</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="82"/>
+        <location filename="properties_dialog.cpp" line="84"/>
         <source>Publishing</source>
         <translation>出版</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="83"/>
+        <location filename="properties_dialog.cpp" line="85"/>
         <source>Plot</source>
         <translation>情節</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="92"/>
+        <location filename="properties_dialog.cpp" line="94"/>
         <source>Cover page</source>
         <translation>封面</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="152"/>
+        <location filename="properties_dialog.cpp" line="143"/>
         <source>Title:</source>
         <translation>標題:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="160"/>
-        <location filename="properties_dialog.cpp" line="177"/>
+        <location filename="properties_dialog.cpp" line="151"/>
+        <location filename="properties_dialog.cpp" line="168"/>
         <source>of:</source>
         <translation>of:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="167"/>
+        <location filename="properties_dialog.cpp" line="158"/>
         <source>Issue number:</source>
         <translation>發行數量:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="169"/>
+        <location filename="properties_dialog.cpp" line="160"/>
         <source>Volume:</source>
         <translation>卷:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="173"/>
+        <location filename="properties_dialog.cpp" line="164"/>
         <source>Arc number:</source>
         <translation>世界線數量:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="182"/>
+        <location filename="properties_dialog.cpp" line="173"/>
         <source>Story arc:</source>
         <translation>故事線:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="184"/>
+        <location filename="properties_dialog.cpp" line="175"/>
         <source>Genre:</source>
         <oldsource>Genere:</oldsource>
         <translation>類型:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="186"/>
+        <location filename="properties_dialog.cpp" line="177"/>
         <source>Size:</source>
         <translation>大小:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="210"/>
+        <location filename="properties_dialog.cpp" line="197"/>
         <source>Writer(s):</source>
         <translation>作者:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="213"/>
+        <location filename="properties_dialog.cpp" line="200"/>
         <source>Penciller(s):</source>
         <translation>線稿:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="221"/>
+        <location filename="properties_dialog.cpp" line="207"/>
         <source>Inker(s):</source>
         <translation>墨稿:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="224"/>
+        <location filename="properties_dialog.cpp" line="210"/>
         <source>Colorist(s):</source>
         <translation>上色:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="234"/>
+        <location filename="properties_dialog.cpp" line="217"/>
         <source>Letterer(s):</source>
         <translation>文本:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="237"/>
+        <location filename="properties_dialog.cpp" line="220"/>
         <source>Cover Artist(s):</source>
         <translation>封面設計:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="259"/>
+        <location filename="properties_dialog.cpp" line="240"/>
         <source>Day:</source>
         <translation>日:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="263"/>
+        <location filename="properties_dialog.cpp" line="244"/>
         <source>Month:</source>
         <translation>月:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="267"/>
+        <location filename="properties_dialog.cpp" line="248"/>
         <source>Year:</source>
         <translation>年:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="275"/>
+        <location filename="properties_dialog.cpp" line="256"/>
         <source>Publisher:</source>
         <translation>出版者:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="276"/>
+        <location filename="properties_dialog.cpp" line="257"/>
         <source>Format:</source>
         <translation>格式:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="277"/>
+        <location filename="properties_dialog.cpp" line="258"/>
         <source>Color/BW:</source>
         <translation>彩色/黑白:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="278"/>
+        <location filename="properties_dialog.cpp" line="259"/>
         <source>Age rating:</source>
         <translation>年齡等級:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="279"/>
+        <location filename="properties_dialog.cpp" line="260"/>
         <source>Manga:</source>
         <translation>日漫:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="292"/>
+        <location filename="properties_dialog.cpp" line="273"/>
         <source>Synopsis:</source>
         <translation>概要:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="293"/>
+        <location filename="properties_dialog.cpp" line="274"/>
         <source>Characters:</source>
         <translation>角色:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="294"/>
+        <location filename="properties_dialog.cpp" line="275"/>
         <source>Notes:</source>
         <translation>筆記:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="390"/>
+        <location filename="properties_dialog.cpp" line="369"/>
         <source>Comic Vine link: &lt;a style=&apos;color: #FFCB00; text-decoration:none; font-weight:bold;&apos; href=&quot;http://www.comicvine.com/comic/4000-%1/&quot;&gt; view &lt;/a&gt;</source>
         <translation>Comic Vine 連接: &lt;a style=&apos;color: #FFCB00; text-decoration:none; font-weight:bold;&apos; href=&quot;http://www.comicvine.com/comic/4000-%1/&quot;&gt; 查看 &lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="415"/>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Not found</source>
         <translation>未找到</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="415"/>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Comic not found. You should update your library.</source>
         <translation>未找到漫畫,請先更新您的庫.</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="492"/>
+        <location filename="properties_dialog.cpp" line="501"/>
         <source>Edit selected comics information</source>
         <translation>編輯選中的漫畫資訊</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="559"/>
+        <location filename="properties_dialog.cpp" line="467"/>
         <source>Edit comic information</source>
         <translation>編輯漫畫資訊</translation>
     </message>
@@ -1791,27 +1872,37 @@ YACReaderLibrary不會阻止您創建更多的庫，但是您應該保持較低�
 <context>
     <name>SelectVolume</name>
     <message>
-        <location filename="comic_vine/select_volume.cpp" line="32"/>
+        <location filename="comic_vine/select_volume.cpp" line="35"/>
         <source>Please, select the right series for your comic.</source>
         <translation>請選擇正確的漫畫系列。</translation>
     </message>
     <message>
-        <location filename="comic_vine/select_volume.cpp" line="62"/>
+        <location filename="comic_vine/select_volume.cpp" line="56"/>
+        <source>Filter:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="68"/>
         <source>volumes</source>
         <translation>卷</translation>
     </message>
     <message>
-        <location filename="comic_vine/select_volume.cpp" line="123"/>
+        <location filename="comic_vine/select_volume.cpp" line="138"/>
+        <source>Nothing found, clear the filter if any.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="144"/>
         <source>loading cover</source>
         <translation>加載封面</translation>
     </message>
     <message>
-        <location filename="comic_vine/select_volume.cpp" line="124"/>
+        <location filename="comic_vine/select_volume.cpp" line="145"/>
         <source>loading description</source>
         <translation>加載描述</translation>
     </message>
     <message>
-        <location filename="comic_vine/select_volume.cpp" line="164"/>
+        <location filename="comic_vine/select_volume.cpp" line="185"/>
         <source>description unavailable</source>
         <translation>描述不可用</translation>
     </message>
@@ -1985,7 +2076,7 @@ to improve the performance</source>
 <context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
-        <location filename="../custom_widgets/whats_new_dialog.cpp" line="104"/>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation>關閉</translation>
     </message>
@@ -2218,7 +2309,7 @@ to improve the performance</source>
 <context>
     <name>YACReaderSearchLineEdit</name>
     <message>
-        <location filename="../custom_widgets/yacreader_search_line_edit.cpp" line="46"/>
+        <location filename="../custom_widgets/yacreader_search_line_edit.cpp" line="68"/>
         <source>type to search</source>
         <translation>搜索類型</translation>
     </message>

--- a/YACReaderLibrary/yacreaderlibrary_zh_TW.ts
+++ b/YACReaderLibrary/yacreaderlibrary_zh_TW.ts
@@ -153,54 +153,112 @@
     </message>
 </context>
 <context>
+    <name>ComicInfoView</name>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="279"/>
+        <source>Authors</source>
+        <translation type="unfinished">作者</translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="309"/>
+        <source>writer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="331"/>
+        <source>penciller</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="353"/>
+        <source>inker</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="375"/>
+        <source>colorist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="397"/>
+        <source>letterer</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="419"/>
+        <source>cover artist</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="434"/>
+        <source>Publisher</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
+        <source>color</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="474"/>
+        <source>b/w</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="502"/>
+        <source>Characters</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>ComicModel</name>
     <message>
-        <location filename="db/comic_model.cpp" line="303"/>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>yes</source>
         <translation>是</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="303"/>
+        <location filename="db/comic_model.cpp" line="311"/>
         <source>no</source>
         <translation>否</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="335"/>
+        <location filename="db/comic_model.cpp" line="343"/>
         <source>Title</source>
         <translation>標題</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="337"/>
+        <location filename="db/comic_model.cpp" line="345"/>
         <source>File Name</source>
         <translation>檔案名</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="339"/>
+        <location filename="db/comic_model.cpp" line="347"/>
         <source>Pages</source>
         <translation>頁數</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="341"/>
+        <location filename="db/comic_model.cpp" line="349"/>
         <source>Size</source>
         <translation>大小</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="343"/>
+        <location filename="db/comic_model.cpp" line="351"/>
         <source>Read</source>
         <translation>閱讀</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="345"/>
+        <location filename="db/comic_model.cpp" line="353"/>
         <source>Current Page</source>
         <translation>當前頁</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="347"/>
+        <location filename="db/comic_model.cpp" line="355"/>
         <source>Publication Date</source>
         <translation>發行日期</translation>
     </message>
     <message>
-        <location filename="db/comic_model.cpp" line="349"/>
+        <location filename="db/comic_model.cpp" line="357"/>
         <source>Rating</source>
         <translation>評分</translation>
     </message>
@@ -208,68 +266,67 @@
 <context>
     <name>ComicVineDialog</name>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="50"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="57"/>
         <source>skip</source>
         <translation>忽略</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="51"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="58"/>
         <source>back</source>
         <translation>返回</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="52"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="59"/>
         <source>next</source>
         <translation>下一步</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="53"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="60"/>
         <source>search</source>
         <translation>搜索</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="54"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="61"/>
         <source>close</source>
         <translation>關閉</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="130"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="140"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="252"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="759"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="793"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="143"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="257"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="773"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="807"/>
         <source>Looking for volume...</source>
         <translation>搜索卷...</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="138"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="726"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="141"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="735"/>
         <source>comic %1 of %2 - %3</source>
         <translation>第 %1 本 共 %2 本 - %3</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="257"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="262"/>
         <source>%1 comics selected</source>
         <translation>已選擇 %1 本漫畫</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="290"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="295"/>
         <source>Error connecting to ComicVine</source>
         <translation>ComicVine 連接時出錯</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="460"/>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="496"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="467"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="503"/>
         <source>Retrieving tags for : %1</source>
         <translation>正在檢索標籤: %1</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="774"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="788"/>
         <source>Retrieving volume info...</source>
         <translation>正在接收卷資訊...</translation>
     </message>
     <message>
-        <location filename="comic_vine/comic_vine_dialog.cpp" line="800"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="814"/>
         <source>Looking for comic...</source>
         <translation>搜索漫畫中...</translation>
     </message>
@@ -481,9 +538,25 @@
     </message>
 </context>
 <context>
+    <name>FolderContentView</name>
+    <message>
+        <location filename="qml/FolderContentView.qml" line="238"/>
+        <source>Continue Reading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>FolderContentView6</name>
+    <message>
+        <location filename="qml/FolderContentView6.qml" line="240"/>
+        <source>Continue Reading...</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
     <name>GridComicsView</name>
     <message>
-        <location filename="grid_comics_view.cpp" line="163"/>
+        <location filename="grid_comics_view.cpp" line="147"/>
         <source>Show info</source>
         <translation>顯示資訊</translation>
     </message>
@@ -491,17 +564,17 @@
 <context>
     <name>HelpAboutDialog</name>
     <message>
-        <location filename="../custom_widgets/help_about_dialog.cpp" line="25"/>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="27"/>
         <source>About</source>
         <translation>關於</translation>
     </message>
     <message>
-        <location filename="../custom_widgets/help_about_dialog.cpp" line="28"/>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="30"/>
         <source>Help</source>
         <translation>幫助</translation>
     </message>
     <message>
-        <location filename="../custom_widgets/help_about_dialog.cpp" line="31"/>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="33"/>
         <source>System info</source>
         <translation>系統資訊</translation>
     </message>
@@ -628,498 +701,506 @@
 <context>
     <name>LibraryWindow</name>
     <message>
-        <location filename="library_window.cpp" line="184"/>
+        <location filename="library_window.cpp" line="188"/>
         <source>YACReader Library</source>
         <translation>YACReader 庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1026"/>
+        <location filename="library_window.cpp" line="1027"/>
         <source>Library</source>
         <translation>庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="480"/>
+        <location filename="library_window.cpp" line="484"/>
         <source>Create a new library</source>
         <translation>創建一個新的庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="486"/>
+        <location filename="library_window.cpp" line="490"/>
         <source>Open an existing library</source>
         <translation>打開現有的庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="491"/>
-        <location filename="library_window.cpp" line="492"/>
+        <location filename="library_window.cpp" line="495"/>
+        <location filename="library_window.cpp" line="496"/>
         <source>Export comics info</source>
         <translation>導出漫畫資訊</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="497"/>
-        <location filename="library_window.cpp" line="498"/>
+        <location filename="library_window.cpp" line="501"/>
+        <location filename="library_window.cpp" line="502"/>
         <source>Import comics info</source>
         <translation>導入漫畫資訊</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="503"/>
+        <location filename="library_window.cpp" line="507"/>
         <source>Pack covers</source>
         <translation>打包封面</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="504"/>
+        <location filename="library_window.cpp" line="508"/>
         <source>Pack the covers of the selected library</source>
         <translation>打包所選庫的封面</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="509"/>
+        <location filename="library_window.cpp" line="513"/>
         <source>Unpack covers</source>
         <translation>解壓封面</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="510"/>
+        <location filename="library_window.cpp" line="514"/>
         <source>Unpack a catalog</source>
         <translation>解壓目錄</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="515"/>
+        <location filename="library_window.cpp" line="519"/>
         <source>Update library</source>
         <translation>更新庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="516"/>
+        <location filename="library_window.cpp" line="520"/>
         <source>Update current library</source>
         <translation>更新當前庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="521"/>
+        <location filename="library_window.cpp" line="525"/>
         <source>Rename library</source>
         <translation>重命名庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="522"/>
+        <location filename="library_window.cpp" line="526"/>
         <source>Rename current library</source>
         <translation>重命名當前庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="527"/>
+        <location filename="library_window.cpp" line="531"/>
         <source>Remove library</source>
         <translation>移除庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="528"/>
+        <location filename="library_window.cpp" line="532"/>
         <source>Remove current library from your collection</source>
         <translation>從您的集合中移除當前庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="538"/>
+        <location filename="library_window.cpp" line="542"/>
         <source>Open current comic</source>
         <translation>打開當前漫畫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="539"/>
+        <location filename="library_window.cpp" line="543"/>
         <source>Open current comic on YACReader</source>
         <translation>用YACReader打開漫畫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="544"/>
+        <location filename="library_window.cpp" line="548"/>
         <source>Save selected covers to...</source>
         <translation>選中的封面保存到...</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="545"/>
+        <location filename="library_window.cpp" line="549"/>
         <source>Save covers of the selected comics as JPG files</source>
         <translation>保存所選的封面為jpg</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="549"/>
-        <location filename="library_window.cpp" line="686"/>
+        <location filename="library_window.cpp" line="553"/>
+        <location filename="library_window.cpp" line="690"/>
+        <location filename="library_window.cpp" line="1800"/>
         <source>Set as read</source>
         <translation>設為已讀</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="550"/>
+        <location filename="library_window.cpp" line="554"/>
         <source>Set comic as read</source>
         <translation>漫畫設為已讀</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="555"/>
-        <location filename="library_window.cpp" line="691"/>
+        <location filename="library_window.cpp" line="559"/>
+        <location filename="library_window.cpp" line="695"/>
+        <location filename="library_window.cpp" line="1803"/>
         <source>Set as unread</source>
         <translation>設為未讀</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="556"/>
+        <location filename="library_window.cpp" line="560"/>
         <source>Set comic as unread</source>
         <translation>漫畫設為未讀</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="581"/>
+        <location filename="library_window.cpp" line="585"/>
         <source>Show/Hide marks</source>
         <translation>顯示/隱藏標記</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="630"/>
+        <location filename="library_window.cpp" line="634"/>
         <source>Collapse all nodes</source>
         <translation>折疊所有節點</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="732"/>
+        <location filename="library_window.cpp" line="736"/>
         <source>Assign current order to comics</source>
         <translation>將當前序號分配給漫畫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1362"/>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library not available</source>
         <oldsource>Library &apos;</oldsource>
         <translation>庫不可用</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="589"/>
-        <location filename="library_window.cpp" line="590"/>
+        <location filename="library_window.cpp" line="593"/>
+        <location filename="library_window.cpp" line="594"/>
         <source>Fullscreen mode on/off</source>
         <translation>全屏模式 開/關</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="533"/>
+        <location filename="library_window.cpp" line="537"/>
         <source>Rescan library for XML info</source>
         <translation>重新掃描庫的 XML 資訊</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="534"/>
+        <location filename="library_window.cpp" line="538"/>
         <source>Tries to find XML info embedded in comic files. You only need to do this if the library was created with 9.8.2 or earlier versions or if you are using third party software to embed XML info in the files.</source>
         <translation>嘗試查找漫畫檔內嵌的 XML 資訊。只有當創建庫的 YACReaderLibrary 版本低於 9.8.2 或者使用第三方軟體嵌入 XML 資訊時，才需要執行該操作。</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="561"/>
-        <location filename="library_window.cpp" line="696"/>
+        <location filename="library_window.cpp" line="565"/>
+        <location filename="library_window.cpp" line="700"/>
+        <location filename="library_window.cpp" line="1806"/>
         <source>Set as manga</source>
         <translation>設為日漫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="562"/>
+        <location filename="library_window.cpp" line="566"/>
         <source>Set issue as manga</source>
         <translation>Set issue as manga</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="567"/>
+        <location filename="library_window.cpp" line="571"/>
         <source>Set as normal</source>
         <translation>設置為正常向</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="568"/>
+        <location filename="library_window.cpp" line="572"/>
         <source>Set issue as normal</source>
         <translation>設置發行狀態為正常發行</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="598"/>
+        <location filename="library_window.cpp" line="602"/>
         <source>Help, About YACReader</source>
         <translation>幫助, 關於 YACReader</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="611"/>
-        <location filename="library_window.cpp" line="1615"/>
+        <location filename="library_window.cpp" line="615"/>
+        <location filename="library_window.cpp" line="1610"/>
         <source>Delete folder</source>
         <translation>刪除檔夾</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="620"/>
+        <location filename="library_window.cpp" line="624"/>
         <source>Select root node</source>
         <translation>選擇根節點</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="624"/>
+        <location filename="library_window.cpp" line="628"/>
         <source>Expand all nodes</source>
         <translation>展開所有節點</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="636"/>
+        <location filename="library_window.cpp" line="640"/>
         <source>Show options dialog</source>
         <translation>顯示選項對話框</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="644"/>
+        <location filename="library_window.cpp" line="648"/>
         <source>Show comics server options dialog</source>
         <translation>顯示漫畫伺服器選項對話框</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="670"/>
+        <location filename="library_window.cpp" line="674"/>
+        <location filename="library_window.cpp" line="1787"/>
         <source>Open folder...</source>
         <translation>打開檔夾...</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="676"/>
+        <location filename="library_window.cpp" line="680"/>
+        <location filename="library_window.cpp" line="1794"/>
         <source>Set as uncompleted</source>
         <translation>設為未完成</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="681"/>
+        <location filename="library_window.cpp" line="685"/>
+        <location filename="library_window.cpp" line="1797"/>
         <source>Set as completed</source>
         <translation>設為已完成</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="701"/>
+        <location filename="library_window.cpp" line="705"/>
+        <location filename="library_window.cpp" line="1809"/>
         <source>Set as comic</source>
         <translation>設置為漫畫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="708"/>
+        <location filename="library_window.cpp" line="712"/>
         <source>Open containing folder...</source>
         <translation>打開包含檔夾...</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="714"/>
+        <location filename="library_window.cpp" line="718"/>
         <source>Reset comic rating</source>
         <translation>重置漫畫評分</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="720"/>
+        <location filename="library_window.cpp" line="724"/>
         <source>Select all comics</source>
         <translation>全選漫畫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="726"/>
+        <location filename="library_window.cpp" line="730"/>
         <source>Edit</source>
         <translation>編輯</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="738"/>
+        <location filename="library_window.cpp" line="742"/>
         <source>Update cover</source>
         <translation>更新封面</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="744"/>
+        <location filename="library_window.cpp" line="748"/>
         <source>Delete selected comics</source>
         <translation>刪除所選的漫畫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="752"/>
+        <location filename="library_window.cpp" line="756"/>
         <source>Download tags from Comic Vine</source>
         <translation>從 Comic Vine 下載標籤</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="756"/>
+        <location filename="library_window.cpp" line="760"/>
         <source>Focus search line</source>
         <translation>聚焦於搜索行</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="762"/>
+        <location filename="library_window.cpp" line="766"/>
         <source>Focus comics view</source>
         <translation>聚焦於漫畫視圖</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="767"/>
+        <location filename="library_window.cpp" line="771"/>
         <source>Edit shortcuts</source>
         <translation>編輯快捷鍵</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="773"/>
+        <location filename="library_window.cpp" line="777"/>
         <source>&amp;Quit</source>
         <translation>退出(&amp;Q)</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="780"/>
+        <location filename="library_window.cpp" line="784"/>
+        <location filename="library_window.cpp" line="1790"/>
         <source>Update folder</source>
         <translation>更新檔夾</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="783"/>
+        <location filename="library_window.cpp" line="787"/>
         <source>Update current folder</source>
         <translation>更新當前檔夾</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="788"/>
+        <location filename="library_window.cpp" line="792"/>
         <source>Add new reading list</source>
         <translation>添加新的閱讀列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="791"/>
+        <location filename="library_window.cpp" line="795"/>
         <source>Add a new reading list to the current library</source>
         <translation>在當前庫添加新的閱讀列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="794"/>
+        <location filename="library_window.cpp" line="798"/>
         <source>Remove reading list</source>
         <translation>移除閱讀列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="797"/>
+        <location filename="library_window.cpp" line="801"/>
         <source>Remove current reading list from the library</source>
         <translation>從當前庫移除閱讀列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="800"/>
+        <location filename="library_window.cpp" line="804"/>
         <source>Add new label</source>
         <translation>添加新標籤</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="803"/>
+        <location filename="library_window.cpp" line="807"/>
         <source>Add a new label to this library</source>
         <translation>在當前庫添加標籤</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="806"/>
+        <location filename="library_window.cpp" line="810"/>
         <source>Rename selected list</source>
         <translation>重命名列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="809"/>
+        <location filename="library_window.cpp" line="813"/>
         <source>Rename any selected labels or lists</source>
         <translation>重命名任何選定的標籤或列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="813"/>
+        <location filename="library_window.cpp" line="817"/>
         <source>Add to...</source>
         <translation>添加到...</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="815"/>
+        <location filename="library_window.cpp" line="819"/>
         <source>Favorites</source>
         <translation>收藏夾</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="818"/>
+        <location filename="library_window.cpp" line="822"/>
         <source>Add selected comics to favorites list</source>
         <translation>將所選漫畫添加到收藏夾列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1045"/>
+        <location filename="library_window.cpp" line="1046"/>
         <source>Folder</source>
         <translation>檔夾</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1059"/>
+        <location filename="library_window.cpp" line="1060"/>
         <source>Comic</source>
         <translation>漫畫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1256"/>
+        <location filename="library_window.cpp" line="1251"/>
         <source>Upgrade failed</source>
         <translation>更新失敗</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1256"/>
+        <location filename="library_window.cpp" line="1251"/>
         <source>There were errors during library upgrade in: </source>
         <translation>漫畫庫更新時出現錯誤: </translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1274"/>
+        <location filename="library_window.cpp" line="1269"/>
         <source>Update needed</source>
         <translation>需要更新</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1274"/>
+        <location filename="library_window.cpp" line="1269"/>
         <source>This library was created with a previous version of YACReaderLibrary. It needs to be updated. Update now?</source>
         <translation>此庫是使用舊版本的YACReaderLibrary創建的. 它需要更新. 現在更新?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1341"/>
+        <location filename="library_window.cpp" line="1336"/>
         <source>Download new version</source>
         <translation>下載新版本</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1341"/>
+        <location filename="library_window.cpp" line="1336"/>
         <source>This library was created with a newer version of YACReaderLibrary. Download the new version now?</source>
         <translation>此庫是使用較新版本的YACReaderLibrary創建的。 立即下載新版本?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1362"/>
+        <location filename="library_window.cpp" line="1357"/>
         <source>Library &apos;%1&apos; is no longer available. Do you want to remove it?</source>
         <translation>庫 &apos;%1&apos; 不再可用。 你想刪除它嗎?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1381"/>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Old library</source>
         <translation>舊的庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1381"/>
+        <location filename="library_window.cpp" line="1376"/>
         <source>Library &apos;%1&apos; has been created with an older version of YACReaderLibrary. It must be created again. Do you want to create the library now?</source>
         <translation>庫 &apos;%1&apos; 是通過舊版本的YACReaderLibrary創建的。 必須再次創建。 你想現在創建嗎?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1414"/>
-        <location filename="library_window.cpp" line="1450"/>
+        <location filename="library_window.cpp" line="1409"/>
+        <location filename="library_window.cpp" line="1445"/>
         <source>Copying comics...</source>
         <translation>複製漫畫中...</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1431"/>
-        <location filename="library_window.cpp" line="1469"/>
+        <location filename="library_window.cpp" line="1426"/>
+        <location filename="library_window.cpp" line="1464"/>
         <source>Moving comics...</source>
         <translation>移動漫畫中...</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1580"/>
+        <location filename="library_window.cpp" line="1575"/>
         <source>Folder name:</source>
         <translation>檔夾名稱:</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1609"/>
+        <location filename="library_window.cpp" line="1604"/>
         <source>No folder selected</source>
         <translation>沒有選中的檔夾</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1609"/>
+        <location filename="library_window.cpp" line="1604"/>
         <source>Please, select a folder first</source>
         <translation>請先選擇一個檔夾</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1613"/>
+        <location filename="library_window.cpp" line="1608"/>
         <source>Error in path</source>
         <translation>路徑錯誤</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1613"/>
+        <location filename="library_window.cpp" line="1608"/>
         <source>There was an error accessing the folder&apos;s path</source>
         <translation>訪問檔夾的路徑時出錯</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1615"/>
+        <location filename="library_window.cpp" line="1610"/>
         <source>The selected folder and all its contents will be deleted from your disk. Are you sure?</source>
         <translation>所選檔夾及其所有內容將從磁片中刪除。 你確定嗎?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1641"/>
+        <location filename="library_window.cpp" line="1636"/>
         <source>There was an issue trying to delete the selected folders. Please, check for write permissions and be sure that any applications are using these folders or any of the contained files.</source>
         <translation>嘗試刪除所選檔夾時出現問題。 請檢查寫入許可權，並確保沒有其他應用程式在使用這些檔夾或檔。</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1653"/>
+        <location filename="library_window.cpp" line="1648"/>
         <source>Add new reading lists</source>
         <translation>添加新的閱讀列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1654"/>
-        <location filename="library_window.cpp" line="1703"/>
+        <location filename="library_window.cpp" line="1649"/>
+        <location filename="library_window.cpp" line="1698"/>
         <source>List name:</source>
         <translation>列表名稱:</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1672"/>
+        <location filename="library_window.cpp" line="1667"/>
         <source>Delete list/label</source>
         <translation>刪除 列表/標籤</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1672"/>
+        <location filename="library_window.cpp" line="1667"/>
         <source>The selected item will be deleted, your comics or folders will NOT be deleted from your disk. Are you sure?</source>
         <translation>所選項目將被刪除，您的漫畫或檔夾將不會從您的磁片中刪除。 你確定嗎?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1702"/>
+        <location filename="library_window.cpp" line="1697"/>
         <source>Rename list name</source>
         <translation>重命名列表</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1832"/>
+        <location filename="library_window.cpp" line="1916"/>
         <source>Save covers</source>
         <translation>保存封面</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1851"/>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.</source>
         <translation>您添加的庫太多了。</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1851"/>
+        <location filename="library_window.cpp" line="1935"/>
         <source>You are adding too many libraries.
 
 You probably only need one library in your top level comics folder, you can browse any subfolders using the folders section in the left sidebar.
@@ -1132,141 +1213,141 @@ YACReaderLibrary will not stop you from creating more libraries but you should k
 YACReaderLibrary不會阻止您創建更多的庫，但是您應該保持較低的庫數量來提升性能。</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1909"/>
-        <location filename="library_window.cpp" line="1911"/>
+        <location filename="library_window.cpp" line="1993"/>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found</source>
         <translation>YACReader 未找到</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1999"/>
+        <location filename="library_window.cpp" line="2083"/>
         <source>Library not found</source>
         <translation>未找到庫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1999"/>
+        <location filename="library_window.cpp" line="2083"/>
         <source>The selected folder doesn&apos;t contain any library.</source>
         <translation>所選檔夾不包含任何庫。</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2054"/>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Are you sure?</source>
         <translation>你確定嗎?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2054"/>
+        <location filename="library_window.cpp" line="2138"/>
         <source>Do you want remove </source>
         <translation>你想要刪除 </translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2054"/>
+        <location filename="library_window.cpp" line="2138"/>
         <source> library?</source>
         <translation> 庫?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2055"/>
+        <location filename="library_window.cpp" line="2139"/>
         <source>Remove and delete metadata</source>
         <translation>移除並刪除元數據</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2357"/>
+        <location filename="library_window.cpp" line="2448"/>
         <source>Assign comics numbers</source>
         <translation>分配漫畫編號</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2358"/>
+        <location filename="library_window.cpp" line="2449"/>
         <source>Assign numbers starting in:</source>
         <translation>從以下位置開始分配編號:</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1641"/>
-        <location filename="library_window.cpp" line="2326"/>
+        <location filename="library_window.cpp" line="1636"/>
+        <location filename="library_window.cpp" line="2417"/>
         <source>Unable to delete</source>
         <translation>無法刪除</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="582"/>
+        <location filename="library_window.cpp" line="586"/>
         <source>Show or hide read marks</source>
         <translation>顯示或隱藏閱讀標記</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="605"/>
-        <location filename="library_window.cpp" line="1579"/>
+        <location filename="library_window.cpp" line="609"/>
+        <location filename="library_window.cpp" line="1574"/>
         <source>Add new folder</source>
         <translation>添加新的檔夾</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="608"/>
+        <location filename="library_window.cpp" line="612"/>
         <source>Add new folder to the current library</source>
         <translation>在當前庫下添加新的檔夾</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="614"/>
+        <location filename="library_window.cpp" line="618"/>
         <source>Delete current folder from disk</source>
         <translation>從磁片上刪除當前檔夾</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="651"/>
-        <location filename="library_window.cpp" line="652"/>
+        <location filename="library_window.cpp" line="655"/>
+        <location filename="library_window.cpp" line="656"/>
         <source>Change between comics views</source>
         <translation>漫畫視圖之間的變化</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1909"/>
+        <location filename="library_window.cpp" line="1993"/>
         <source>YACReader not found. YACReader should be installed in the same folder as YACReaderLibrary.</source>
         <translation>未找到YACReader. YACReader應安裝在與YACReaderLibrary相同的檔夾中.</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="1911"/>
+        <location filename="library_window.cpp" line="1995"/>
         <source>YACReader not found. There might be a problem with your YACReader installation.</source>
         <translation>未找到YACReader. YACReader的安裝可能有問題.</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2326"/>
+        <location filename="library_window.cpp" line="2417"/>
         <source>There was an issue trying to delete the selected comics. Please, check for write permissions in the selected files or containing folder.</source>
         <translation>嘗試刪除所選漫畫時出現問題。 請檢查所選檔或包含檔夾中的寫入許可權。</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2559"/>
+        <location filename="library_window.cpp" line="2649"/>
         <source>Error creating the library</source>
         <translation>創建庫時出錯</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2564"/>
+        <location filename="library_window.cpp" line="2654"/>
         <source>Error updating the library</source>
         <translation>更新庫時出錯</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2569"/>
+        <location filename="library_window.cpp" line="2659"/>
         <source>Error opening the library</source>
         <translation>打開庫時出錯</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2604"/>
+        <location filename="library_window.cpp" line="2694"/>
         <source>Delete comics</source>
         <translation>刪除漫畫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2604"/>
+        <location filename="library_window.cpp" line="2694"/>
         <source>All the selected comics will be deleted from your disk. Are you sure?</source>
         <translation>所有選定的漫畫都將從您的磁片中刪除。你確定嗎?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2641"/>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Remove comics</source>
         <translation>移除漫畫</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2641"/>
+        <location filename="library_window.cpp" line="2731"/>
         <source>Comics will only be deleted from the current label/list. Are you sure?</source>
         <translation>漫畫只會從當前標籤/列表中刪除。 你確定嗎?</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2715"/>
+        <location filename="library_window.cpp" line="2805"/>
         <source>Library name already exists</source>
         <translation>庫名已存在</translation>
     </message>
     <message>
-        <location filename="library_window.cpp" line="2715"/>
+        <location filename="library_window.cpp" line="2805"/>
         <source>There is another library with the name &apos;%1&apos;.</source>
         <translation>已存在另一個名為&apos;%1&apos;的庫。</translation>
     </message>
@@ -1431,179 +1512,179 @@ YACReaderLibrary不會阻止您創建更多的庫，但是您應該保持較低�
 <context>
     <name>PropertiesDialog</name>
     <message>
-        <location filename="properties_dialog.cpp" line="80"/>
+        <location filename="properties_dialog.cpp" line="82"/>
         <source>General info</source>
         <translation>基本資訊</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="81"/>
+        <location filename="properties_dialog.cpp" line="83"/>
         <source>Authors</source>
         <translation>作者</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="82"/>
+        <location filename="properties_dialog.cpp" line="84"/>
         <source>Publishing</source>
         <translation>出版</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="83"/>
+        <location filename="properties_dialog.cpp" line="85"/>
         <source>Plot</source>
         <translation>情節</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="92"/>
+        <location filename="properties_dialog.cpp" line="94"/>
         <source>Cover page</source>
         <translation>封面</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="152"/>
+        <location filename="properties_dialog.cpp" line="143"/>
         <source>Title:</source>
         <translation>標題:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="160"/>
-        <location filename="properties_dialog.cpp" line="177"/>
+        <location filename="properties_dialog.cpp" line="151"/>
+        <location filename="properties_dialog.cpp" line="168"/>
         <source>of:</source>
         <translation>of:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="167"/>
+        <location filename="properties_dialog.cpp" line="158"/>
         <source>Issue number:</source>
         <translation>發行數量:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="169"/>
+        <location filename="properties_dialog.cpp" line="160"/>
         <source>Volume:</source>
         <translation>卷:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="173"/>
+        <location filename="properties_dialog.cpp" line="164"/>
         <source>Arc number:</source>
         <translation>世界線數量:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="182"/>
+        <location filename="properties_dialog.cpp" line="173"/>
         <source>Story arc:</source>
         <translation>故事線:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="184"/>
+        <location filename="properties_dialog.cpp" line="175"/>
         <source>Genre:</source>
         <oldsource>Genere:</oldsource>
         <translation>類型:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="186"/>
+        <location filename="properties_dialog.cpp" line="177"/>
         <source>Size:</source>
         <translation>大小:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="210"/>
+        <location filename="properties_dialog.cpp" line="197"/>
         <source>Writer(s):</source>
         <translation>作者:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="213"/>
+        <location filename="properties_dialog.cpp" line="200"/>
         <source>Penciller(s):</source>
         <translation>線稿:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="221"/>
+        <location filename="properties_dialog.cpp" line="207"/>
         <source>Inker(s):</source>
         <translation>墨稿:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="224"/>
+        <location filename="properties_dialog.cpp" line="210"/>
         <source>Colorist(s):</source>
         <translation>上色:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="234"/>
+        <location filename="properties_dialog.cpp" line="217"/>
         <source>Letterer(s):</source>
         <translation>文本:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="237"/>
+        <location filename="properties_dialog.cpp" line="220"/>
         <source>Cover Artist(s):</source>
         <translation>封面設計:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="259"/>
+        <location filename="properties_dialog.cpp" line="240"/>
         <source>Day:</source>
         <translation>日:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="263"/>
+        <location filename="properties_dialog.cpp" line="244"/>
         <source>Month:</source>
         <translation>月:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="267"/>
+        <location filename="properties_dialog.cpp" line="248"/>
         <source>Year:</source>
         <translation>年:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="275"/>
+        <location filename="properties_dialog.cpp" line="256"/>
         <source>Publisher:</source>
         <translation>出版者:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="276"/>
+        <location filename="properties_dialog.cpp" line="257"/>
         <source>Format:</source>
         <translation>格式:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="277"/>
+        <location filename="properties_dialog.cpp" line="258"/>
         <source>Color/BW:</source>
         <translation>彩色/黑白:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="278"/>
+        <location filename="properties_dialog.cpp" line="259"/>
         <source>Age rating:</source>
         <translation>年齡等級:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="279"/>
+        <location filename="properties_dialog.cpp" line="260"/>
         <source>Manga:</source>
         <translation>日漫:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="292"/>
+        <location filename="properties_dialog.cpp" line="273"/>
         <source>Synopsis:</source>
         <translation>概要:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="293"/>
+        <location filename="properties_dialog.cpp" line="274"/>
         <source>Characters:</source>
         <translation>角色:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="294"/>
+        <location filename="properties_dialog.cpp" line="275"/>
         <source>Notes:</source>
         <translation>筆記:</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="390"/>
+        <location filename="properties_dialog.cpp" line="369"/>
         <source>Comic Vine link: &lt;a style=&apos;color: #FFCB00; text-decoration:none; font-weight:bold;&apos; href=&quot;http://www.comicvine.com/comic/4000-%1/&quot;&gt; view &lt;/a&gt;</source>
         <translation>Comic Vine 連接: &lt;a style=&apos;color: #FFCB00; text-decoration:none; font-weight:bold;&apos; href=&quot;http://www.comicvine.com/comic/4000-%1/&quot;&gt; 查看 &lt;/a&gt;</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="415"/>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Not found</source>
         <translation>未找到</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="415"/>
+        <location filename="properties_dialog.cpp" line="394"/>
         <source>Comic not found. You should update your library.</source>
         <translation>未找到漫畫,請先更新您的庫.</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="492"/>
+        <location filename="properties_dialog.cpp" line="501"/>
         <source>Edit selected comics information</source>
         <translation>編輯選中的漫畫資訊</translation>
     </message>
     <message>
-        <location filename="properties_dialog.cpp" line="559"/>
+        <location filename="properties_dialog.cpp" line="467"/>
         <source>Edit comic information</source>
         <translation>編輯漫畫資訊</translation>
     </message>
@@ -1791,27 +1872,37 @@ YACReaderLibrary不會阻止您創建更多的庫，但是您應該保持較低�
 <context>
     <name>SelectVolume</name>
     <message>
-        <location filename="comic_vine/select_volume.cpp" line="32"/>
+        <location filename="comic_vine/select_volume.cpp" line="35"/>
         <source>Please, select the right series for your comic.</source>
         <translation>請選擇正確的漫畫系列。</translation>
     </message>
     <message>
-        <location filename="comic_vine/select_volume.cpp" line="62"/>
+        <location filename="comic_vine/select_volume.cpp" line="56"/>
+        <source>Filter:</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="68"/>
         <source>volumes</source>
         <translation>卷</translation>
     </message>
     <message>
-        <location filename="comic_vine/select_volume.cpp" line="123"/>
+        <location filename="comic_vine/select_volume.cpp" line="138"/>
+        <source>Nothing found, clear the filter if any.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="144"/>
         <source>loading cover</source>
         <translation>加載封面</translation>
     </message>
     <message>
-        <location filename="comic_vine/select_volume.cpp" line="124"/>
+        <location filename="comic_vine/select_volume.cpp" line="145"/>
         <source>loading description</source>
         <translation>加載描述</translation>
     </message>
     <message>
-        <location filename="comic_vine/select_volume.cpp" line="164"/>
+        <location filename="comic_vine/select_volume.cpp" line="185"/>
         <source>description unavailable</source>
         <translation>描述不可用</translation>
     </message>
@@ -1985,7 +2076,7 @@ to improve the performance</source>
 <context>
     <name>YACReader::WhatsNewDialog</name>
     <message>
-        <location filename="../custom_widgets/whats_new_dialog.cpp" line="104"/>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="95"/>
         <source>Close</source>
         <translation>關閉</translation>
     </message>
@@ -2218,7 +2309,7 @@ to improve the performance</source>
 <context>
     <name>YACReaderSearchLineEdit</name>
     <message>
-        <location filename="../custom_widgets/yacreader_search_line_edit.cpp" line="46"/>
+        <location filename="../custom_widgets/yacreader_search_line_edit.cpp" line="68"/>
         <source>type to search</source>
         <translation>搜索類型</translation>
     </message>

--- a/config.pri
+++ b/config.pri
@@ -3,7 +3,13 @@
 # for a more detailed description, see INSTALL.TXT
 
 CONFIG += c++17
-win32:QMAKE_CXXFLAGS += /std:c++17 /Zc:__cplusplus /permissive- #enable c++17 explicitly in msvc
+
+win32 {
+    #enable c++17 explicitly in msvc
+    QMAKE_CXXFLAGS += /std:c++17 /Zc:__cplusplus /permissive-
+    CONFIG -= debug_and_release
+    !CONFIG(Release):!CONFIG(Debug):CONFIG += Release
+}
 
 DEFINES += NOMINMAX
 

--- a/config.pri
+++ b/config.pri
@@ -7,8 +7,6 @@ CONFIG += c++17
 win32 {
     #enable c++17 explicitly in msvc
     QMAKE_CXXFLAGS += /std:c++17 /Zc:__cplusplus /permissive-
-    CONFIG -= debug_and_release
-    !CONFIG(Release):!CONFIG(Debug):CONFIG += Release
 }
 
 DEFINES += NOMINMAX


### PR DESCRIPTION
Older versions of the Qt documentation advocate using QLocale::system::name for system language resolving. This is deprecated and causes misbehavior, such as selecting the system unit language instead of system display language on Windows.

Solution: Use QTranslator::load(QLocale(), ... ...), which is display language aware.

@luisangelsm the following things need to be tested:

[ ] Correct directory resolution on Win and MacOS
[ ] Working languages on Win and MacOS