### PR TITLE
QRencode: Add fallback for Linux distros that don't provide unversion…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ Version counting is based on semantic versioning (Major.Feature.Patch)
 * Fixed going forward history navigation.
 * Continue Reading view that it is shown for the root folder.
 * UI gets updated when YACReaderLibrary gets updates from YACReader or YACReader for iOS.
+* Linux: Add fallback for dynamically loading libqrencode on distros that don't provide unversioned library symlinks
 
 ## 9.9.2
 

--- a/YACReaderLibrary/server_config_dialog.cpp
+++ b/YACReaderLibrary/server_config_dialog.cpp
@@ -303,6 +303,13 @@ QrEncoder::QrEncoder()
     QLibrary encoder(QCoreApplication::applicationDirPath() + "/utils/libqrencode.dylib");
 #else
     QLibrary encoder("qrencode");
+#ifdef Q_OS_UNIX
+    encoder.load();
+    // Fallback - this loads libqrencode.4.x.x.so when libqrencode.so is not available
+    if (!encoder.isLoaded()) {
+        encoder.setFileNameAndVersion("qrencode", 4);
+    }
+#endif
 #endif
     QRcode_encodeString8bit = (_QRcode_encodeString8bit)encoder.resolve("QRcode_encodeString8bit");
     QRcode_free = (_QRcode_free)encoder.resolve("QRcode_free");


### PR DESCRIPTION
…ed library symlinks

With the current configuration, YACReaderLibrary on Linux searches for "libqrencode.so" and will fail to load it if only "libqrencode.so.x" is installed. To fix this, this PR adds a check to see if the library was loaded successfully and requests an exact version of the library if the load failed. By providing the version, QLibrary is made aware that it should look for "libqrencode.so.4" and the load works.