### PR TITLE
Server: Don't overwrite template and docroot path

### DIFF
--- a/YACReaderLibrary/server/yacreader_http_server.cpp
+++ b/YACReaderLibrary/server/yacreader_http_server.cpp
@@ -53,8 +53,8 @@ void YACReaderHttpServer::start(quint16 port)
 #else
     templatePath = QFileInfo(QCoreApplication::applicationDirPath(), baseTemplatePath).absoluteFilePath();
 #endif
-
-    templateSettings->setValue("path", templatePath);
+    if (!templateSettings->contains("path"))
+        templateSettings->setValue("path", templatePath);
 
     Static::templateLoader = new TemplateCache(templateSettings, app);
 
@@ -84,7 +84,8 @@ void YACReaderHttpServer::start(quint16 port)
     docroot = QFileInfo(QCoreApplication::applicationDirPath(), basedocroot).absoluteFilePath();
 #endif
 
-    fileSettings->setValue("path", docroot);
+    if (!fileSettings->contains("path"))
+        fileSettings->setValue("path", docroot);
 
     Static::staticFileController = new StaticFileController(fileSettings, app);
 


### PR DESCRIPTION
When starting the server, the paths for docroot and templates are always overwritten. This is a serious problem when developing or debugging outside of an installation.

Solution: Only write the settings if they are not present!