### PR TITLE
Unix: Fix regression in translation install target

### DIFF
--- a/YACReader/YACReader.pro
+++ b/YACReader/YACReader.pro
@@ -214,28 +214,16 @@ win32 {
                        $(COPY) $$shell_path($${SOURCE_QM_DIR}) $$shell_path($${DEPLOYMENT_OUT_QM_DIR})
 } else {
     LRELEASE_DIR = ../release/languages/
+    QM_FILES_INSTALL_PATH = $$DATADIR/yacreader/languages
 }
 
 unix:!macx {
-# set install prefix if it's empty
-isEmpty(PREFIX) {
-  PREFIX = /usr
-}
-isEmpty(BINDIR) {
-  BINDIR = $$PREFIX/bin
-}
-isEmpty(LIBDIR) {
-  LIBDIR = $$PREFIX/lib
-}
-isEmpty(DATADIR) {
-  DATADIR = $$PREFIX/share
-}
 
 DEFINES += "LIBDIR=\\\"$$LIBDIR\\\""  "DATADIR=\\\"$$DATADIR\\\""
 
 #MAKE INSTALL
 
-INSTALLS += bin docs icon desktop translation manpage
+INSTALLS += bin docs icon desktop manpage
 
 bin.path = $$BINDIR
 isEmpty(DESTDIR) {
@@ -255,9 +243,6 @@ icon.files = ../YACReader.svg
 
 desktop.path = $$DATADIR/applications
 desktop.files = ../YACReader.desktop
-
-translation.path = $$DATADIR/yacreader/languages
-translation.files = ../release/languages/yacreader_*
 
 manpage.path = $$DATADIR/man/man1
 manpage.files = ../YACReader.1

--- a/YACReaderLibrary/YACReaderLibrary.pro
+++ b/YACReaderLibrary/YACReaderLibrary.pro
@@ -307,6 +307,7 @@ win32 {
                        $(COPY) $$shell_path($${SOURCE_QM_DIR}) $$shell_path($${DEPLOYMENT_OUT_QM_DIR})
 } else {
     LRELEASE_DIR = ../release/languages/
+    QM_FILES_INSTALL_PATH = $$DATADIR/yacreader/languages
 }
 
 #QML/GridView
@@ -328,24 +329,11 @@ unix:!macx:RESOURCES += qml_win.qrc
 macx:RESOURCES += qml_osx.qrc
 
 unix:!macx {
-#set install prefix if it's empty
-isEmpty(PREFIX) {
-  PREFIX = /usr
-}
-isEmpty(BINDIR) {
-  BINDIR = $$PREFIX/bin
-}
-isEmpty(LIBDIR) {
-  LIBDIR = $$PREFIX/lib
-}
-isEmpty(DATADIR) {
-  DATADIR = $$PREFIX/share
-}
 
 DEFINES += "LIBDIR=\\\"$$LIBDIR\\\""  "DATADIR=\\\"$$DATADIR\\\"" "BINDIR=\\\"$$BINDIR\\\""
 
 #MAKE INSTALL
-INSTALLS += bin icon desktop server translation manpage
+INSTALLS += bin icon desktop server manpage
 
 bin.path = $$BINDIR
 isEmpty(DESTDIR) {
@@ -362,9 +350,6 @@ icon.files = ../YACReaderLibrary.svg
 
 desktop.path = $$DATADIR/applications
 desktop.files = ../YACReaderLibrary.desktop
-
-translation.path = $$DATADIR/yacreader/languages
-translation.files = ../release/languages/yacreaderlibrary_*
 
 manpage.path = $$DATADIR/man/man1
 manpage.files = ../YACReaderLibrary.1

--- a/YACReaderLibraryServer/YACReaderLibraryServer.pro
+++ b/YACReaderLibraryServer/YACReaderLibraryServer.pro
@@ -130,13 +130,6 @@ contains(QMAKE_TARGET.arch, x86_64) {
 
 unix:!macx {
 #set install prefix if it's empty
-isEmpty(PREFIX) {
-  PREFIX = /usr
-}
-
-BINDIR = $$PREFIX/bin
-LIBDIR = $$PREFIX/lib
-DATADIR = $$PREFIX/share
 
 DEFINES += "LIBDIR=\\\"$$LIBDIR\\\""  "DATADIR=\\\"$$DATADIR\\\"" "BINDIR=\\\"$$BINDIR\\\""
 
@@ -150,7 +143,7 @@ DEFINES += "LIBDIR=\\\"$$LIBDIR\\\""  "DATADIR=\\\"$$DATADIR\\\"" "BINDIR=\\\"$$
 }
 
 CONFIG(server_standalone) {
-  INSTALLS += bin server translation systemd
+  INSTALLS += bin server systemd
 }
 else:CONFIG(server_bundled) {
   INSTALLS += bin systemd
@@ -168,9 +161,6 @@ server.files = ../release/server
 
 systemd.path = $$LIBDIR/systemd/user
 systemd.files = yacreaderlibraryserver.service
-
-translation.path = $$DATADIR/yacreader/languages
-translation.files = ../release/languages/yacreaderlibrary_*
 
 # TODO: We need a manpage for yaclibserver
 #manpage.path = $$DATADIR/man/man1

--- a/config.pri
+++ b/config.pri
@@ -93,4 +93,20 @@ macx:!CONFIG(pdfkit):!CONFIG(pdfium):!CONFIG(no_pdf) {
     DEFINES += QT_DISABLE_DEPRECATED_BEFORE=0x050900
 }
 
+unix:!macx {
+# set install prefix if it's empty
+isEmpty(PREFIX) {
+  PREFIX = /usr
+}
+isEmpty(BINDIR) {
+  BINDIR = $$PREFIX/bin
+}
+isEmpty(LIBDIR) {
+  LIBDIR = $$PREFIX/lib
+}
+isEmpty(DATADIR) {
+  DATADIR = $$PREFIX/share
+}
+}
+
 DEFINES += QT_DEPRECATED_WARNINGS


### PR DESCRIPTION
The introduction of CONFIG+= lrelease introduced a regression in the installation of translation files on systems using make install targets.

This is fixed by replacing the old translation targets with the target supplied by lrelease.

Fixes #349