### PR TITLE
QsLog: Use dedicated logging thread to avoid segfaults during app shutdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ Version counting is based on semantic versioning (Major.Feature.Patch)
 * Fixed drag&drop in the comics grid view.
 * Detect back/forward mouse buttons to move back and forward through the browsing history.
 
+### All apps
+* Run logger in a dedicated thread to avoid segfaults at application shutdown
+
 ## 9.10
 
 ### YACReader

--- a/third_party/QsLog/QsLog.pri
+++ b/third_party/QsLog/QsLog.pri
@@ -1,7 +1,7 @@
 INCLUDEPATH += $$PWD
 #DEFINES += QS_LOG_LINE_NUMBERS       # automatically writes the file and line for each log message
 #DEFINES += QS_LOG_DISABLE            # logging code is replaced with a no-op
-#DEFINES += QS_LOG_SEPARATE_THREAD    # messages are queued and written from a separate thread
+DEFINES += QS_LOG_SEPARATE_THREAD    # messages are queued and written from a separate thread
 #DEFINES += QS_LOG_WIN_PRINTF_CONSOLE # Use fprintf instead of OutputDebugString on Windows
 #DEFINES += QS_LOG_WINDOW             # allows easily showing log messages in a UI
 


### PR DESCRIPTION
When shutting down our apps, we clean up some ressources after app.exec() has finished. As our logger runs on the apps main thread, it can no longer respond to any debug messages generated during the cleanup phase.

This can lead to segfaults and error masking.

Solution: Run QsLog in a dedicated thread.