### PR TITLE
New qr engine: Fix output on Windows

### DIFF
--- a/YACReaderLibraryServer/main.cpp
+++ b/YACReaderLibraryServer/main.cpp
@@ -80,9 +80,9 @@ void printServerInfo(YACReaderHttpServer *httpServer)
         for (int x = -border - 1; x < code.getSize() + border + 1; x++) {
             QRCodeString.append((code.getModule(x, y) && code.getModule(x, y + 1))
                                         ? " "
-                                        : code.getModule(x, y + 1) ? "\u2580"
-                                        : code.getModule(x, y)     ? "\u2584"
-                                                                   : "\u2588");
+                                        : code.getModule(x, y + 1) ? u8"\u2580"
+                                        : code.getModule(x, y)     ? u8"\u2584"
+                                                                   : u8"\u2588");
         }
         QLOG_INFO() << QRCodeString;
     }

--- a/third_party/QsLog/QsLogDestConsole.cpp
+++ b/third_party/QsLog/QsLogDestConsole.cpp
@@ -31,17 +31,18 @@
 #include <cstdio>
 void QsDebugOutput::output( const QString& message )
 {
-   fprintf(stderr, "%s\n", qPrintable(message));
-   fflush(stderr);
+    fprintf(stderr, "%s\n", qPrintable(message));
+    fflush(stderr);
 }
 #elif defined(Q_OS_WIN)
 #define WIN32_LEAN_AND_MEAN
-#include <windows.h>
+#include <Windows.h>
 void QsDebugOutput::output( const QString& message )
 {
-   OutputDebugStringW(reinterpret_cast<const WCHAR*>(message.utf16()));
-   OutputDebugStringW(L"\n");
+    WriteConsoleW(GetStdHandle(STD_ERROR_HANDLE), message.utf16(), message.size(), NULL, NULL);
+    WriteConsoleW(GetStdHandle(STD_ERROR_HANDLE), L"\n", 1, NULL, NULL);
 }
+
 #endif
 
 const char* const QsLogging::DebugOutputDestination::Type = "console";


### PR DESCRIPTION
Fix for two problems:

1. QsLog output was not shown on the Windows Console
2. QRCode unicode characters for YACReaderLibraryServer's new console QR code were not correctly encoded on Windows machines

@luisangelsm We should probably add 1 to our changelog for the upcoming release