### PR TITLE
ComicInfo::getTypeString: Return an empty string for unhandled enums

### DIFF
--- a/YACReaderLibrary/db/comic_model.cpp
+++ b/YACReaderLibrary/db/comic_model.cpp
@@ -1307,6 +1307,9 @@ void ComicModel::deleteComicsFromSpecialList(const QList<QModelIndex> &comicsLis
     case ReadingListModel::TypeSpecialList::Favorites:
         deleteComicsFromFavorites(comicsList);
         break;
+    case ReadingListModel::TypeSpecialList::Recent:
+        // do nothing, recent is read only
+        break;
     }
 }
 

--- a/YACReaderLibrary/db/comic_model.cpp
+++ b/YACReaderLibrary/db/comic_model.cpp
@@ -172,7 +172,10 @@ bool ComicModel::dropMimeData(const QMimeData *data, Qt::DropAction action, int 
         case ReadingList:
             DBHelper::reasignOrderToComicsInReadingList(sourceId, allComicIds, db);
             break;
-        default:
+        case Folder:
+        case Reading:
+        case Recent:
+        case SearchResult:
             break;
         }
         connectionName = db.connectionName();

--- a/common/comic_db.cpp
+++ b/common/comic_db.cpp
@@ -524,24 +524,24 @@ QString ComicInfo::getTypeString()
 {
     if (!type.canConvert<YACReader::FileType>()) {
         assert(false);
-        return "Unknown";
+        return QStringLiteral("Unknown");
     }
 
     switch (type.value<YACReader::FileType>()) {
     case YACReader::FileType::Comic:
-        return "Comic";
+        return QStringLiteral("Comic");
     case YACReader::FileType::Manga:
-        return "Manga";
+        return QStringLiteral("Manga");
     case YACReader::FileType::WesternManga:
-        return "Western Manga";
+        return QStringLiteral("Western Manga");
     case YACReader::FileType::WebComic:
-        return "Web Comic";
+        return QStringLiteral("Web Comic");
     case YACReader::FileType::Yonkoma:
-        return "4-Koma";
+        return QStringLiteral("4-Koma");
     }
 
     assert(false);
-    return "Unknown";
+    return QStringLiteral("Unknown");
 }
 
 QString ComicInfo::getStoryArcInfoString()

--- a/common/comic_db.cpp
+++ b/common/comic_db.cpp
@@ -522,6 +522,11 @@ QStringList ComicInfo::getTags()
 
 QString ComicInfo::getTypeString()
 {
+    if (!type.canConvert<YACReader::FileType>()) {
+        assert(false);
+        return "Unknown";
+    }
+
     switch (type.value<YACReader::FileType>()) {
     case YACReader::FileType::Comic:
         return "Comic";
@@ -533,9 +538,10 @@ QString ComicInfo::getTypeString()
         return "Web Comic";
     case YACReader::FileType::Yonkoma:
         return "4-Koma";
-    default:
-        return "Unknown";
     }
+
+    assert(false);
+    return "Unknown";
 }
 
 QString ComicInfo::getStoryArcInfoString()

--- a/common/comic_db.cpp
+++ b/common/comic_db.cpp
@@ -533,6 +533,8 @@ QString ComicInfo::getTypeString()
         return "Web Comic";
     case YACReader::FileType::Yonkoma:
         return "4-Koma";
+    default:
+        return "Unknown";
     }
 }
 

--- a/config.pri
+++ b/config.pri
@@ -7,11 +7,17 @@ CONFIG += c++17
 win32 {
     #enable c++17 explicitly in msvc
     QMAKE_CXXFLAGS += /std:c++17 /Zc:__cplusplus /permissive-
+    #treat missing branches for enums as error
+    QMAKE_CXXFLAGS += /we4061
 }
 
 DEFINES += NOMINMAX
 
-if(unix|mingw):QMAKE_CXXFLAGS_RELEASE += -DNDEBUG
+if(unix|mingw) {
+    QMAKE_CXXFLAGS_RELEASE += -DNDEBUG
+    #treat missing branches for enums as error
+    QMAKE_CXXFLAGS += -Werror=switch
+}
 win32:msvc:QMAKE_CXXFLAGS_RELEASE += /DNDEBUG
 
 # check Qt version

--- a/config.pri
+++ b/config.pri
@@ -7,17 +7,11 @@ CONFIG += c++17
 win32 {
     #enable c++17 explicitly in msvc
     QMAKE_CXXFLAGS += /std:c++17 /Zc:__cplusplus /permissive-
-    #treat missing branches for enums as error
-    QMAKE_CXXFLAGS += /we4061
 }
 
 DEFINES += NOMINMAX
 
-if(unix|mingw) {
-    QMAKE_CXXFLAGS_RELEASE += -DNDEBUG
-    #treat missing branches for enums as error
-    QMAKE_CXXFLAGS += -Werror=switch
-}
+if(unix|mingw):QMAKE_CXXFLAGS_RELEASE += -DNDEBUG
 win32:msvc:QMAKE_CXXFLAGS_RELEASE += /DNDEBUG
 
 # check Qt version


### PR DESCRIPTION
When creating switch case structures, please don't forget the default case or you can have invalid control flows in your code :)