### PR TITLE
Remove YACReaderComicInfoPair metatype

### DIFF
--- a/common/comic_db.h
+++ b/common/comic_db.h
@@ -8,9 +8,6 @@
 #include <QImage>
 #include <QMetaType>
 
-typedef QPair<QString, QString> YACReaderComicInfoPair;
-Q_DECLARE_METATYPE(YACReaderComicInfoPair)
-
 class ComicInfo : public QObject
 {
     Q_OBJECT


### PR DESCRIPTION
When doing modularized builds, the definition of YACReaderComicInfoPair as a metatype can lead to redefinition of Qt internal metatypes at the moc stage. This is currently not happening in qmake, but is a problem for our CMake migartion.

As we don't really use this type, it is safe to remove.