### PR TITLE
Unarr: Enable 7z for unarr 1.1.x +

### DIFF
--- a/YACReader/main_window_viewer.cpp
+++ b/YACReader/main_window_viewer.cpp
@@ -35,6 +35,10 @@
 #include <QDate>
 #include <QMenuBar>
 
+#ifdef use_unarr
+#include "unarr.h"
+#endif
+
 MainWindowViewer::MainWindowViewer()
     : QMainWindow(), fullscreen(false), toolbars(true), currentDirectory("."), currentDirectoryImgDest("."), isClient(false)
 {
@@ -781,8 +785,10 @@ void MainWindowViewer::open()
     QFileDialog openDialog;
 #ifndef use_unarr
     QString pathFile = openDialog.getOpenFileName(this, tr("Open Comic"), currentDirectory, tr("Comic files") + "(*.cbr *.cbz *.rar *.zip *.tar *.pdf *.7z *.cb7 *.arj *.cbt)");
-#else
+#elif (UNARR_API_VERSION < 110)
     QString pathFile = openDialog.getOpenFileName(this, tr("Open Comic"), currentDirectory, tr("Comic files") + "(*.cbr *.cbz *.rar *.zip *.tar *.pdf *.cbt)");
+#else
+    QString pathFile = openDialog.getOpenFileName(this, tr("Open Comic"), currentDirectory, tr("Comic files") + "(*.cbr *.cbz *.rar *.zip *.tar *.pdf *.cbt *.7z *.cb7)");
 #endif
     if (!pathFile.isEmpty()) {
         openComicFromPath(pathFile);
@@ -1435,6 +1441,10 @@ void MainWindowViewer::getSiblingComics(QString path, QString currentComic)
                                    << "*.zip"
                                    << "*.tar"
                                    << "*.pdf"
+#if (UNARR_API_VERSION >= 110)
+                                   << "*.7z"
+                                   << "*.cb7"
+#endif
                                    << "*.cbt");
 #endif
     d.setSorting(QDir::Name | QDir::IgnoreCase | QDir::LocaleAware);

--- a/YACReaderLibrary/db/comic_model.cpp
+++ b/YACReaderLibrary/db/comic_model.cpp
@@ -11,6 +11,9 @@
 #include "comic_db.h"
 #include "db_helper.h"
 #include "reading_list_model.h"
+#ifdef use_unarr
+#include <unarr.h>
+#endif
 
 // ci.number,ci.title,c.fileName,ci.numPages,c.id,c.parentId,c.path,ci.hash,ci.read
 #include "QsLog.h"
@@ -433,7 +436,7 @@ QVariant ComicModel::headerData(int section, Qt::Orientation orientation,
             return QVariant(QIcon(":/images/zip.png"));
         else if (ext.compare("rar", Qt::CaseInsensitive) == 0)
             return QVariant(QIcon(":/images/rar.png"));
-#ifndef use_unarr
+#if !defined(use_unarr) || (UNARR_API_VERSION >= 110)
         else if (ext.compare("7z", Qt::CaseInsensitive) == 0)
             return QVariant(QIcon(":/images/7z.png"));
         else if (ext.compare("cb7", Qt::CaseInsensitive) == 0)


### PR DESCRIPTION
This adds the 7z format in file selection dialog and database for builds with a recent enough Unarr version.