### PR TITLE
Update builds

### DIFF
--- a/YACReaderLibrary/initial_comic_info_extractor.cpp
+++ b/YACReaderLibrary/initial_comic_info_extractor.cpp
@@ -156,15 +156,15 @@ void InitialComicInfoExtractor::saveCover(const QString &path, const QImage &cov
 {
     QImage scaled;
     if (cover.width() > cover.height()) {
-        scaled = cover.scaledToWidth(640, Qt::SmoothTransformation);
+        scaled = cover.scaledToWidth(820, Qt::SmoothTransformation);
     } else {
         auto aspectRatio = static_cast<double>(cover.width()) / static_cast<double>(cover.height());
         auto maxAllowedAspectRatio = 0.5;
         if (aspectRatio < maxAllowedAspectRatio) { // cover is too tall, e.g. webtoon
-            scaled = cover.scaledToHeight(960, Qt::SmoothTransformation);
+            scaled = cover.scaledToHeight(1220, Qt::SmoothTransformation);
         } else {
-            scaled = cover.scaledToWidth(480, Qt::SmoothTransformation);
+            scaled = cover.scaledToWidth(640, Qt::SmoothTransformation);
         }
     }
-    scaled.save(_target, 0, 75);
+    scaled.save(_target, "WEBP", 75);
 }

--- a/YACReaderLibrary/library_creator.cpp
+++ b/YACReaderLibrary/library_creator.cpp
@@ -143,7 +143,7 @@ void LibraryCreator::run()
 #if !defined use_unarr && !defined use_libarchive
 // check for 7z lib
 #if defined Q_OS_UNIX && !defined Q_OS_MACOS
-    QLibrary *sevenzLib = new QLibrary(QString(LIBDIR) + "/p7zip/7z.so");
+    QLibrary *sevenzLib = new QLibrary(QString(LIBDIR) + "/7zip/7z.so");
 #else
     QLibrary *sevenzLib = new QLibrary(QCoreApplication::applicationDirPath() + "/utils/7z");
 #endif

--- a/YACReaderLibrary/main.cpp
+++ b/YACReaderLibrary/main.cpp
@@ -47,7 +47,7 @@ void logSystemAndConfig()
 #ifdef Q_OS_WIN
     if (QLibrary::isLibrary(QApplication::applicationDirPath() + "/utils/7z.dll"))
 #elif defined Q_OS_UNIX && !defined Q_OS_MACOS
-    if (QLibrary::isLibrary(QString(LIBDIR) + "/yacreader/7z.so") | QLibrary::isLibrary(QString(LIBDIR) + "/p7zip/7z.so"))
+    if (QLibrary::isLibrary(QString(LIBDIR) + "/yacreader/7z.so") | QLibrary::isLibrary(QString(LIBDIR) + "/7zip/7z.so"))
 #else
     if (QLibrary::isLibrary(QApplication::applicationDirPath() + "/utils/7z.so"))
 #endif

--- a/YACReaderLibrary/xml_info_library_scanner.cpp
+++ b/YACReaderLibrary/xml_info_library_scanner.cpp
@@ -47,7 +47,7 @@ void XMLInfoLibraryScanner::run()
 #if !defined use_unarr && !defined use_libarchive
 // check for 7z lib
 #if defined Q_OS_UNIX && !defined Q_OS_MACOS
-    QLibrary *sevenzLib = new QLibrary(QString(LIBDIR) + "/p7zip/7z.so");
+    QLibrary *sevenzLib = new QLibrary(QString(LIBDIR) + "/7zip/7z.so");
 #else
     QLibrary *sevenzLib = new QLibrary(QCoreApplication::applicationDirPath() + "/utils/7z");
 #endif

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,7 +102,7 @@ jobs:
   - script: |
       qtchooser -list-versions
       export DEFINES_VAR=DEFINES+\=\"BUILD_NUMBER=\\\\\\\"$(Build.BuildNumber)\\\\\\\"\"
-      qmake6 CONFIG+="unarr" $DEFINES_VAR
+      qmake6 CONFIG+="unarr pdfium" $DEFINES_VAR
       qmake6 -v
       make
     displayName: 'Build'
@@ -132,7 +132,7 @@ jobs:
   - script: |
       qtchooser -list-versions
       export DEFINES_VAR=DEFINES+\=\"BUILD_NUMBER=\\\\\\\"$(Build.BuildNumber)\\\\\\\"\"
-      qmake6 CONFIG+="7zip" $DEFINES_VAR
+      qmake6 CONFIG+="7zip pdfium" $DEFINES_VAR
       qmake6 -v
       make
     displayName: 'Build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -102,7 +102,7 @@ jobs:
   - script: |
       qtchooser -list-versions
       export DEFINES_VAR=DEFINES+\=\"BUILD_NUMBER=\\\\\\\"$(Build.BuildNumber)\\\\\\\"\"
-      qmake6 CONFIG+="unarr no_pdf" $DEFINES_VAR
+      qmake6 CONFIG+="unarr" $DEFINES_VAR
       qmake6 -v
       make
     displayName: 'Build'
@@ -132,7 +132,7 @@ jobs:
   - script: |
       qtchooser -list-versions
       export DEFINES_VAR=DEFINES+\=\"BUILD_NUMBER=\\\\\\\"$(Build.BuildNumber)\\\\\\\"\"
-      qmake6 CONFIG+="7zip no_pdf" $DEFINES_VAR
+      qmake6 CONFIG+="7zip" $DEFINES_VAR
       qmake6 -v
       make
     displayName: 'Build'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -124,7 +124,8 @@ jobs:
       sudo apt-get update
       sudo apt-get install -y qtchooser qt6-tools-dev qt6-base-dev-tools qmake6 qmake6-bin \
       qt6-base-dev qt6-multimedia-dev qt6-tools-dev-tools libgl-dev qt6-l10n-tools \
-      libqt6opengl6-dev libunarr-dev qt6-declarative-dev libqt6svg6-dev libqt6core5compat6-dev libpoppler-qt6-dev   mkdir $(Build.SourcesDirectory)\compressed_archive
+      libqt6opengl6-dev libunarr-dev qt6-declarative-dev libqt6svg6-dev libqt6core5compat6-dev libpoppler-qt6-dev 
+      mkdir $(Build.SourcesDirectory)\compressed_archive
       wget "https://github.com/YACReader/yacreader-7z-deps/blob/main/7z2301-src.7z?raw=true" -O $(Build.SourcesDirectory)/compressed_archive/7z2301-src.7z
       7z x $(Build.SourcesDirectory)/compressed_archive/7z2301-src.7z -o$(Build.SourcesDirectory)/compressed_archive/lib7zip
     displayName: 'Install dependencies'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -97,7 +97,7 @@ jobs:
       sudo apt-get update
       sudo apt-get install -y qtchooser qt6-tools-dev qt6-base-dev-tools qmake6 qmake6-bin \
       qt6-base-dev qt6-multimedia-dev qt6-tools-dev-tools libgl-dev qt6-l10n-tools \
-      libqt6opengl6-dev libunarr-dev qt6-declarative-dev libqt6svg6-dev libqt6core5compat6-dev
+      libqt6opengl6-dev libunarr-dev qt6-declarative-dev libqt6svg6-dev libqt6core5compat6-dev libpoppler-qt6-dev 
     displayName: 'Install dependencies'
   - script: |
       qtchooser -list-versions

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -91,7 +91,7 @@ jobs:
   timeoutInMinutes: 90
   dependsOn: CodeFormatValidation
   pool:
-    vmImage: 'ubuntu-22.04'
+    vmImage: 'ubuntu-24.04'
   steps:
   - script: |
       sudo apt-get update
@@ -102,7 +102,7 @@ jobs:
   - script: |
       qtchooser -list-versions
       export DEFINES_VAR=DEFINES+\=\"BUILD_NUMBER=\\\\\\\"$(Build.BuildNumber)\\\\\\\"\"
-      qmake6 CONFIG+="unarr pdfium" $DEFINES_VAR
+      qmake6 CONFIG+="unarr" $DEFINES_VAR
       qmake6 -v
       make
     displayName: 'Build'
@@ -118,21 +118,20 @@ jobs:
   timeoutInMinutes: 90
   dependsOn: CodeFormatValidation
   pool:
-    vmImage: 'ubuntu-22.04'
+    vmImage: 'ubuntu-24.04'
   steps:
   - script: |
       sudo apt-get update
       sudo apt-get install -y qtchooser qt6-tools-dev qt6-base-dev-tools qmake6 qmake6-bin \
       qt6-base-dev qt6-multimedia-dev qt6-tools-dev-tools libgl-dev qt6-l10n-tools \
-      libqt6opengl6-dev libunarr-dev qt6-declarative-dev libqt6svg6-dev libqt6core5compat6-dev
-      mkdir $(Build.SourcesDirectory)\compressed_archive
+      libqt6opengl6-dev libunarr-dev qt6-declarative-dev libqt6svg6-dev libqt6core5compat6-dev libpoppler-qt6-dev   mkdir $(Build.SourcesDirectory)\compressed_archive
       wget "https://github.com/YACReader/yacreader-7z-deps/blob/main/7z2301-src.7z?raw=true" -O $(Build.SourcesDirectory)/compressed_archive/7z2301-src.7z
       7z x $(Build.SourcesDirectory)/compressed_archive/7z2301-src.7z -o$(Build.SourcesDirectory)/compressed_archive/lib7zip
     displayName: 'Install dependencies'
   - script: |
       qtchooser -list-versions
       export DEFINES_VAR=DEFINES+\=\"BUILD_NUMBER=\\\\\\\"$(Build.BuildNumber)\\\\\\\"\"
-      qmake6 CONFIG+="7zip pdfium" $DEFINES_VAR
+      qmake6 CONFIG+="7zip" $DEFINES_VAR
       qmake6 -v
       make
     displayName: 'Build'

--- a/build_scripts/ubuntu_22.04/README.md
+++ b/build_scripts/ubuntu_22.04/README.md
@@ -1,0 +1,6 @@
+## Ubuntu 22.04 build script
+You can use `build.sh` to build YACReader from scratch in `Ubuntu 22.04` with `7zip` (including `RAR5` support) and `poppler` (pdf). This build uses Qt5.
+
+The script will create a folder next to it where all the downloads and building will happen, it will also install all the required dependencies. 7zip 23.01 is not available in `Ubuntu 22.04` so the script builds it and installs 7z.so in /usr/lib/7zip/. Once the scrip finishes succesfully `YACReader`, `YACReaderLibrary` and `YACReaderLibraryServer` should be installed in your system.
+
+WARNIG: This doesn't work with the latest release (9.14), there is a bug and some of the code is still looking for the old p7zip library, you need to build from develop, to do so run: `build.sh develop`.

--- a/build_scripts/ubuntu_22.04/build.sh
+++ b/build_scripts/ubuntu_22.04/build.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Define variables
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="$SCRIPT_DIR/yacreader_build"
+YACREADER_DIR="$BUILD_DIR/yacreader"
+COMPRESSED_ARCHIVE_DIR="$YACREADER_DIR/compressed_archive"
+YACREADER_REPO="https://github.com/YACReader/yacreader.git"
+SEVENZIP_URL="https://github.com/YACReader/yacreader-7z-deps/blob/main/7z2301-src.7z?raw=true"
+SEVENZIP_ARCHIVE="$COMPRESSED_ARCHIVE_DIR/7z2301-src.7z"
+SEVENZIP_DIR="$COMPRESSED_ARCHIVE_DIR/lib7zip"
+
+# Function to download the latest release source tarball
+download_latest_release() {
+    echo "Fetching the latest release information..."
+    LATEST_RELEASE_URL=$(curl -s https://api.github.com/repos/YACReader/yacreader/releases/latest | grep "browser_download_url.*src.tar.xz" | cut -d '"' -f 4 | head -n 1)
+    if [ -z "$LATEST_RELEASE_URL" ]; then
+        echo "Failed to fetch the latest release information."
+        exit 1
+    fi
+    echo "Downloading the latest release source tarball..."
+    wget "$LATEST_RELEASE_URL" -O "$BUILD_DIR/latest_release_src.tar.xz"
+    echo "Extracting the latest release source tarball..."
+    mkdir -p "$YACREADER_DIR"
+    tar -xf "$BUILD_DIR/latest_release_src.tar.xz" -C "$YACREADER_DIR" --strip-components=1
+}
+
+# Step 1: Create a folder for the build process
+if [ -d "$BUILD_DIR" ]; then
+    echo "Removing existing build directory..."
+    rm -rf "$BUILD_DIR"
+fi
+echo "Creating build directory..."
+mkdir -p "$BUILD_DIR"
+mkdir -p "$COMPRESSED_ARCHIVE_DIR"
+
+# Step 2: Install required packages
+echo "Updating package list and installing required packages..."
+sudo apt-get update
+sudo apt-get install -y qtchooser qtbase5-dev-tools qt5-qmake \
+    qtbase5-dev qtmultimedia5-dev libpoppler-qt5-dev qttools5-dev-tools \
+    libqt5opengl5-dev qtdeclarative5-dev libqt5svg5-dev qtquickcontrols2-5-dev \
+    qt5-image-formats-plugins qml-module-qtquick-controls2 qml-module-qtquick-layouts \
+    qml-module-qtgraphicaleffects qml-module-qtquick2 qml-module-qtquick-controls \
+    libqt5multimedia5-plugins qt5-image-formats-plugins qml-module-qtquick-controls2 qml-module-qtquick-layouts \
+    qml-module-qtgraphicaleffects qml-module-qtquick2 qml-module-qtquick-controls \
+    git build-essential
+
+# Step 3: Download YACReader source code
+if [ "$1" == "develop" ]; then
+    if [ -d "$YACREADER_DIR" ]; then
+        echo "Removing existing YACReader directory..."
+        rm -rf "$YACREADER_DIR"
+    fi
+    echo "Cloning YACReader repository..."
+    git clone "$YACREADER_REPO" "$YACREADER_DIR"
+else
+    download_latest_release
+fi
+
+# Step 4: Download and extract 7zip source code
+echo "Downloading 7zip source code..."
+wget "$SEVENZIP_URL" -O "$SEVENZIP_ARCHIVE"
+echo "Extracting 7zip source code..."
+7z x "$SEVENZIP_ARCHIVE" -o"$SEVENZIP_DIR"
+
+# Step 5: Build and install 7z.so with RAR support
+echo "Building and installing 7z.so with RAR support..."
+cd "$SEVENZIP_DIR/CPP/7zip/Bundles/Format7zF"
+make -f makefile.gcc
+sudo mkdir -p /usr/lib/7zip
+sudo cp ./_o/7z.so /usr/lib/7zip
+
+# Step 6: Build YACReader
+echo "Building YACReader..."
+cd "$YACREADER_DIR"
+export DEFINES_VAR=DEFINES+\=\"BUILD_NUMBER=\\\\\\\"CUSTOM_BUILD\\\\\\\"\"
+qmake CONFIG+="7zip" $DEFINES_VAR
+make
+
+# Step 7: Install YACReader
+echo "Installing YACReader..."
+sudo make install
+
+echo "YACReader build and installation complete."

--- a/build_scripts/ubuntu_24.04/README.md
+++ b/build_scripts/ubuntu_24.04/README.md
@@ -1,0 +1,6 @@
+## Ubuntu 24.04 build script
+You can use `build.sh` to build YACReader from scratch in `Ubuntu 24.04` with `7zip` (including `RAR5` support) and `poppler` (pdf). This build uses `Qt6`.
+
+The script will create a folder next to it where all the downloads and building will happen, it will also install all the required dependencies. Once the scrip finishes succesfully `YACReader`, `YACReaderLibrary` and `YACReaderLibraryServer` should be installed in your system.
+
+WARNIG: This doesn't work with the latest release (9.14), there is a bug and some of the code is still looking for the old p7zip library, you need to build from develop, to do so run: `build.sh develop`.

--- a/build_scripts/ubuntu_24.04/build.sh
+++ b/build_scripts/ubuntu_24.04/build.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status
+set -e
+
+# Define variables
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BUILD_DIR="$SCRIPT_DIR/yacreader_build"
+YACREADER_DIR="$BUILD_DIR/yacreader"
+COMPRESSED_ARCHIVE_DIR="$YACREADER_DIR/compressed_archive"
+YACREADER_REPO="https://github.com/YACReader/yacreader.git"
+SEVENZIP_URL="https://github.com/YACReader/yacreader-7z-deps/blob/main/7z2301-src.7z?raw=true"
+SEVENZIP_ARCHIVE="$COMPRESSED_ARCHIVE_DIR/7z2301-src.7z"
+SEVENZIP_DIR="$COMPRESSED_ARCHIVE_DIR/lib7zip"
+
+# Function to download the latest release source tarball
+download_latest_release() {
+    echo "Fetching the latest release information..."
+    LATEST_RELEASE_URL=$(curl -s https://api.github.com/repos/YACReader/yacreader/releases/latest | grep "browser_download_url.*src.tar.xz" | cut -d '"' -f 4 | head -n 1)
+    if [ -z "$LATEST_RELEASE_URL" ]; then
+        echo "Failed to fetch the latest release information."
+        exit 1
+    fi
+    echo "Downloading the latest release source tarball..."
+    wget "$LATEST_RELEASE_URL" -O "$BUILD_DIR/latest_release_src.tar.xz"
+    echo "Extracting the latest release source tarball..."
+    mkdir -p "$YACREADER_DIR"
+    tar -xf "$BUILD_DIR/latest_release_src.tar.xz" -C "$YACREADER_DIR" --strip-components=1
+}
+
+# Step 1: Create a folder for the build process
+if [ -d "$BUILD_DIR" ]; then
+    echo "Removing existing build directory..."
+    rm -rf "$BUILD_DIR"
+fi
+echo "Creating build directory..."
+mkdir -p "$BUILD_DIR"
+mkdir -p "$COMPRESSED_ARCHIVE_DIR"
+
+# Step 2: Install required packages
+echo "Updating package list and installing required packages..."
+sudo apt-get update
+sudo apt-get install -y qtchooser qt6-tools-dev qt6-base-dev-tools qmake6 qmake6-bin qt6-base-dev qt6-multimedia-dev qt6-tools-dev-tools libgl-dev qt6-l10n-tools libqt6opengl6-dev qt6-declarative-dev libqt6svg6-dev libqt6core5compat6-dev qml6-module-qt5compat-graphicaleffects qt6-5compat-dev  libpoppler-qt6-dev qt6-image-formats-plugins qml6-module-qtquick-controls qml6-module-qtquick-layouts qml6-module-qtqml-workerscript qml6-module-qtquick-templates p7zip-full p7zip-rar git build-essential
+
+# Step 3: Download YACReader source code
+if [ "$1" == "develop" ]; then
+    if [ -d "$YACREADER_DIR" ]; then
+        echo "Removing existing YACReader directory..."
+        rm -rf "$YACREADER_DIR"
+    fi
+    echo "Cloning YACReader repository..."
+    git clone "$YACREADER_REPO" "$YACREADER_DIR"
+else
+    download_latest_release
+fi
+
+# Step 4: Download and extract 7zip source code
+echo "Downloading 7zip source code..."
+wget "$SEVENZIP_URL" -O "$SEVENZIP_ARCHIVE"
+echo "Extracting 7zip source code..."
+7z x "$SEVENZIP_ARCHIVE" -o"$SEVENZIP_DIR"
+
+# Step 5: Build YACReader
+echo "Building YACReader..."
+cd "$YACREADER_DIR"
+export DEFINES_VAR=DEFINES+\=\"BUILD_NUMBER=\\\\\\\"CUSTOM_BUILD\\\\\\\"\"
+qmake6 CONFIG+="7zip" $DEFINES_VAR
+make
+
+# Step 6: Install YACReader
+echo "Installing YACReader..."
+sudo make install
+
+echo "YACReader build and installation complete."


### PR DESCRIPTION
Qt6 builds need to be done using Ubuntu 24.04 for better availability of needed packages. Building agains 7zip 23.01 and poppler using Ubuntu 24.04 should be pretty straightforward.

I added a couple of scripts for building and installing the apps in Ubuntu 22.04 (Qt5) and Ubuntu 24.04 (Qt6), both using 7zip (for rar5 support and consistency with the Windows and macOS versions) and poppler. Hopefully it will help some users to build YACReader. 

This PR also fixes 7zip loading in Linux, the apps were still looking for p7zip in some paths.