### PR TITLE
Custom comic covers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,11 @@ Version counting is based on semantic versioning (Major.Feature.Patch)
 * New setting in Comic Vine scraper to force exact volume matches.
 * Better default search query in the Comic Vine scraper.
 * Improved navigation in Comic Vine scraper, including keeping the current query around to make edits and refined searches easier.
-* Add support for adding custom covers for folders using the context menu.
+* Add support for custom covers for any folder using the context menu.
+* The edit cover buttons now support looping through pages, going forward from the last returns to the first, and going backward from the first jumps to the last.
+* Add support for custom covers for comics using the edit metadata dialog, you can use a pick file button or drag&drop an image into the cover view in the dialog.
+* Covers can be set in bulk for various comics at once.
+* New button to reset to the default cover of a comic.
 
 ### YACReaderLibraryServer
 * Log libraries validation when the app starts.

--- a/YACReaderLibrary/images.qrc
+++ b/YACReaderLibrary/images.qrc
@@ -70,6 +70,7 @@
         <file>../images/previousCoverPage.png</file>
         <file>../images/readingRibbon.png</file>
         <file>../images/readRibbon.png</file>
+        <file>../images/resetCover.svg</file>
         <file>../images/searching_icon.png</file>
         <file>../images/serverConfigBackground.png</file>
         <file>../images/shortcuts_group_comics.svg</file>

--- a/YACReaderLibrary/images.qrc
+++ b/YACReaderLibrary/images.qrc
@@ -43,6 +43,7 @@
         <file>../images/flow4.png</file>
         <file>../images/flow5.png</file>
         <file>../images/glowLine.png</file>
+        <file>../images/loadCustomCover.svg</file>
         <file>../images/hiddenCovers.png</file>
         <file>../images/icon-new.svg</file>
         <file>../images/iconLibrary.png</file>

--- a/YACReaderLibrary/library_window.cpp
+++ b/YACReaderLibrary/library_window.cpp
@@ -1,6 +1,7 @@
 #include "library_window.h"
 
 #include "yacreader_global.h"
+#include "yacreader_global_gui.h"
 
 #include <QHBoxLayout>
 #include <QSplitter>
@@ -2313,12 +2314,7 @@ void LibraryWindow::setFolderCover()
 
 void LibraryWindow::setCustomFolderCover(Folder folder)
 {
-    QString supportedImageFormatsString;
-    for (const QByteArray &format : QImageReader::supportedImageFormats()) {
-        supportedImageFormatsString += QString("*.%1 ").arg(QString(format));
-    }
-
-    QString customCoverPath = QFileDialog::getOpenFileName(this, tr("Select custom cover"), QDir::homePath(), tr("Images (%1)").arg(supportedImageFormatsString));
+    auto customCoverPath = YACReader::imageFileLoader(this);
     if (!customCoverPath.isEmpty()) {
         QImage cover(customCoverPath);
         if (cover.isNull()) {

--- a/YACReaderLibrary/properties_dialog.cpp
+++ b/YACReaderLibrary/properties_dialog.cpp
@@ -107,6 +107,10 @@ void PropertiesDialog::createCoverBox()
     showNextCoverPageButton->setIcon(QIcon(":/images/nextCoverPage.png"));
     showNextCoverPageButton->setStyleSheet("QToolButton {border:none;}");
 
+    resetCoverButton = new QToolButton();
+    resetCoverButton->setIcon(QIcon(":/images/resetCover.svg"));
+    resetCoverButton->setStyleSheet("QToolButton {border:none;}");
+
     coverPageNumberLabel = new QLabel("-");
 
     coverPageNumberLabel->setStyleSheet("QLabel {color: white; font-weight:bold; font-size:14px;}");
@@ -116,6 +120,8 @@ void PropertiesDialog::createCoverBox()
     layout->addWidget(coverPageNumberLabel, 0, Qt::AlignVCenter);
     layout->addSpacing(5);
     layout->addWidget(showNextCoverPageButton, 0, Qt::AlignVCenter);
+    layout->addSpacing(5);
+    layout->addWidget(resetCoverButton, 0, Qt::AlignVCenter);
 
     coverPageEdit->setStyleSheet("QLineEdit {border:none;}");
     layout->setSpacing(0);
@@ -132,6 +138,7 @@ void PropertiesDialog::createCoverBox()
 
     connect(showPreviousCoverPageButton, &QAbstractButton::clicked, this, &PropertiesDialog::loadPreviousCover);
     connect(showNextCoverPageButton, &QAbstractButton::clicked, this, &PropertiesDialog::loadNextCover);
+    connect(resetCoverButton, &QAbstractButton::clicked, this, &PropertiesDialog::resetCover);
 }
 
 void PropertiesDialog::createGeneralInfoBox()
@@ -1095,17 +1102,9 @@ void PropertiesDialog::loadNextCover()
     else
         next = current + 1;
 
-    updateCoverPageNumberLabel(next);
+    setCoverPage(next);
 
-    InitialComicInfoExtractor ie(basePath + comics[currentComicIndex].path, "", next);
-    ie.extract();
-    setCover(ie.getCover());
-    repaint();
-
-    if (next != comics[currentComicIndex].info.coverPage)
-        coverChanged = true;
-    else
-        coverChanged = false;
+    coverChanged = next != comics[currentComicIndex].info.coverPage;
 }
 
 void PropertiesDialog::loadPreviousCover()
@@ -1118,16 +1117,24 @@ void PropertiesDialog::loadPreviousCover()
     else
         previous = current - 1;
 
-    updateCoverPageNumberLabel(previous);
-    InitialComicInfoExtractor ie(basePath + comics[currentComicIndex].path, "", previous);
+    setCoverPage(previous);
+
+    coverChanged = previous != comics[currentComicIndex].info.coverPage.toInt();
+}
+
+void PropertiesDialog::resetCover()
+{
+    setCoverPage(1);
+    coverChanged = 1 != comics[currentComicIndex].info.coverPage.toInt();
+}
+
+void PropertiesDialog::setCoverPage(int pageNumber)
+{
+    updateCoverPageNumberLabel(pageNumber);
+    InitialComicInfoExtractor ie(basePath + comics[currentComicIndex].path, "", pageNumber);
     ie.extract();
     setCover(ie.getCover());
     repaint();
-
-    if (previous != comics[currentComicIndex].info.coverPage.toInt())
-        coverChanged = true;
-    else
-        coverChanged = false;
 }
 
 bool PropertiesDialog::close()

--- a/YACReaderLibrary/properties_dialog.cpp
+++ b/YACReaderLibrary/properties_dialog.cpp
@@ -734,14 +734,14 @@ void PropertiesDialog::setMultipleCover()
     QPixmap last = lastComic.info.getCover(basePath);
     last = last.scaledToHeight(575, Qt::SmoothTransformation);
 
-    coverImage = QPixmap::fromImage(blurred(last.toImage(), QRect(0, 0, last.width(), last.height()), 15));
+    auto coverImage = QPixmap::fromImage(blurred(last.toImage(), QRect(0, 0, last.width(), last.height()), 15));
 
     cover->setPixmap(coverImage);
 }
 
 void PropertiesDialog::setCover(const QPixmap &coverI)
 {
-    coverImage = coverI.scaledToHeight(575, Qt::SmoothTransformation);
+    auto coverImage = coverI.scaledToHeight(575, Qt::SmoothTransformation);
 
     cover->setPixmap(coverImage);
 }

--- a/YACReaderLibrary/properties_dialog.cpp
+++ b/YACReaderLibrary/properties_dialog.cpp
@@ -456,11 +456,6 @@ void PropertiesDialog::loadComic(ComicDB &comic)
         showPreviousCoverPageButton->setEnabled(true);
         showNextCoverPageButton->setEnabled(true);
 
-        if (coverPage == 1)
-            showPreviousCoverPageButton->setDisabled(true);
-        if (coverPage == comic.info.numPages.toInt())
-            showNextCoverPageButton->setDisabled(true);
-
         coverChanged = false;
         coverBox->show();
 
@@ -469,9 +464,9 @@ void PropertiesDialog::loadComic(ComicDB &comic)
             showPreviousCoverPageButton->setDisabled(true);
             showNextCoverPageButton->setDisabled(true);
         }
+    } else {
+        coverPageNumberLabel->setText("1");
     }
-    /*if(comic.info.numPages != NULL)
-        numPagesEdit->setText(QString::number(*comic.info.numPages));*/
 
     if (!comic.info.number.isNull())
         numberEdit->setText(comic.info.number.toString());
@@ -1093,46 +1088,46 @@ void PropertiesDialog::updateCoverPageNumberLabel(int n)
 void PropertiesDialog::loadNextCover()
 {
     int current = coverPageNumberLabel->text().toInt();
-    if (current < comics[currentComicIndex].info.numPages.toInt()) {
-        updateCoverPageNumberLabel(current + 1);
+    int next;
 
-        InitialComicInfoExtractor ie(basePath + comics[currentComicIndex].path, "", current + 1);
-        ie.extract();
-        setCover(ie.getCover());
-        repaint();
+    if (current == comics[currentComicIndex].info.numPages.toInt())
+        next = 1;
+    else
+        next = current + 1;
 
-        if ((current + 1) == comics[currentComicIndex].info.numPages.toInt()) {
-            showNextCoverPageButton->setDisabled(true);
-        }
+    updateCoverPageNumberLabel(next);
 
-        showPreviousCoverPageButton->setEnabled(true);
-        if (current + 1 != comics[currentComicIndex].info.coverPage)
-            coverChanged = true;
-        else
-            coverChanged = false;
-    }
+    InitialComicInfoExtractor ie(basePath + comics[currentComicIndex].path, "", next);
+    ie.extract();
+    setCover(ie.getCover());
+    repaint();
+
+    if (next != comics[currentComicIndex].info.coverPage)
+        coverChanged = true;
+    else
+        coverChanged = false;
 }
 
 void PropertiesDialog::loadPreviousCover()
 {
     int current = coverPageNumberLabel->text().toInt();
-    if (current != 1) {
-        updateCoverPageNumberLabel(current - 1);
-        InitialComicInfoExtractor ie(basePath + comics[currentComicIndex].path, "", current - 1);
-        ie.extract();
-        setCover(ie.getCover());
-        repaint();
+    int previous;
 
-        if ((current - 1) == 1) {
-            showPreviousCoverPageButton->setDisabled(true);
-        }
+    if (current == 1)
+        previous = comics[currentComicIndex].info.numPages.toInt();
+    else
+        previous = current - 1;
 
-        showNextCoverPageButton->setEnabled(true);
-        if (current - 1 != comics[currentComicIndex].info.coverPage.toInt())
-            coverChanged = true;
-        else
-            coverChanged = false;
-    }
+    updateCoverPageNumberLabel(previous);
+    InitialComicInfoExtractor ie(basePath + comics[currentComicIndex].path, "", previous);
+    ie.extract();
+    setCover(ie.getCover());
+    repaint();
+
+    if (previous != comics[currentComicIndex].info.coverPage.toInt())
+        coverChanged = true;
+    else
+        coverChanged = false;
 }
 
 bool PropertiesDialog::close()

--- a/YACReaderLibrary/properties_dialog.cpp
+++ b/YACReaderLibrary/properties_dialog.cpp
@@ -8,6 +8,7 @@
 #include "yacreader_field_edit.h"
 #include "yacreader_field_plain_text_edit.h"
 #include "db_helper.h"
+#include "yacreader_cover_label.h"
 
 #include <QHBoxLayout>
 #include <QApplication>
@@ -39,7 +40,8 @@ PropertiesDialog::PropertiesDialog(QWidget *parent)
     createTabBar();
     auto rootLayout = new QGridLayout;
 
-    cover = new QLabel();
+    cover = new YACReader::CoverLabel();
+    connect(cover, &YACReader::CoverLabel::imageDropped, this, &PropertiesDialog::loadCustomCoverImageFromPath);
 
     mainLayout = new QGridLayout;
     mainLayout->addWidget(tabBar, 0, 0);
@@ -1165,7 +1167,11 @@ void PropertiesDialog::resetCover()
 void PropertiesDialog::loadCustomCoverImage()
 {
     auto path = YACReader::imageFileLoader(this);
+    loadCustomCoverImageFromPath(path);
+}
 
+void PropertiesDialog::loadCustomCoverImageFromPath(const QString &path)
+{
     if (path.isEmpty()) {
         return;
     }

--- a/YACReaderLibrary/properties_dialog.h
+++ b/YACReaderLibrary/properties_dialog.h
@@ -113,8 +113,6 @@ private:
     QPushButton *previousButton;
     QPushButton *restoreButton; //??
 
-    QPixmap coverImage;
-
     QToolButton *showPreviousCoverPageButton;
     QToolButton *showNextCoverPageButton;
     QLabel *coverPageNumberLabel;

--- a/YACReaderLibrary/properties_dialog.h
+++ b/YACReaderLibrary/properties_dialog.h
@@ -182,6 +182,8 @@ public slots:
     void loadCustomCoverImageFromPath(const QString &path);
     void setCoverPage(int pageNumber);
     bool close();
+    void updateCoverBoxForMultipleComics();
+    void updateCoverBoxForSingleComic();
 
 signals:
     void coverChangedSignal(const ComicDB &comic);

--- a/YACReaderLibrary/properties_dialog.h
+++ b/YACReaderLibrary/properties_dialog.h
@@ -19,6 +19,10 @@ class QComboBox;
 // class YACReaderBusyWidget;
 class QToolButton;
 
+namespace YACReader {
+class CoverLabel;
+}
+
 #include "comic_db.h"
 
 class PropertiesDialog : public QDialog
@@ -33,7 +37,7 @@ private:
     QTabWidget *tabBar;
 
     QWidget *coverBox;
-    QLabel *cover;
+    YACReader::CoverLabel *cover;
     QScrollArea *sa;
 
     QWidget *generalInfoBox;
@@ -175,6 +179,7 @@ public slots:
     void loadPreviousCover();
     void resetCover();
     void loadCustomCoverImage();
+    void loadCustomCoverImageFromPath(const QString &path);
     void setCoverPage(int pageNumber);
     bool close();
 

--- a/YACReaderLibrary/properties_dialog.h
+++ b/YACReaderLibrary/properties_dialog.h
@@ -117,6 +117,8 @@ private:
     QToolButton *showNextCoverPageButton;
     QLabel *coverPageNumberLabel;
 
+    QToolButton *resetCoverButton;
+
     void createTabBar();
     void createCoverBox();
     void createGeneralInfoBox();
@@ -168,6 +170,8 @@ public slots:
     void setSize(float size);
     void loadNextCover();
     void loadPreviousCover();
+    void resetCover();
+    void setCoverPage(int pageNumber);
     bool close();
 
 signals:

--- a/YACReaderLibrary/properties_dialog.h
+++ b/YACReaderLibrary/properties_dialog.h
@@ -118,6 +118,7 @@ private:
     QLabel *coverPageNumberLabel;
 
     QToolButton *resetCoverButton;
+    QToolButton *loadCustomCoverImageButton;
 
     void createTabBar();
     void createCoverBox();
@@ -143,6 +144,8 @@ private:
     float coverSizeRatio;
     bool updated;
     QString originalCoverSize;
+
+    QImage customCover;
 
 public:
     PropertiesDialog(QWidget *parent = nullptr);
@@ -171,6 +174,7 @@ public slots:
     void loadNextCover();
     void loadPreviousCover();
     void resetCover();
+    void loadCustomCoverImage();
     void setCoverPage(int pageNumber);
     bool close();
 

--- a/common/comic_db.cpp
+++ b/common/comic_db.cpp
@@ -404,12 +404,7 @@ ComicInfo &ComicInfo::operator=(const ComicInfo &comicInfo)
 
 QPixmap ComicInfo::getCover(const QString &basePath)
 {
-    if (cover.isNull()) {
-        cover.load(YACReader::LibraryPaths::coverPath(basePath, hash));
-    }
-    QPixmap c;
-    c.convertFromImage(cover);
-    return c;
+    return QPixmap(YACReader::LibraryPaths::coverPath(basePath, hash));
 }
 
 QStringList ComicInfo::getWriters()

--- a/common/comic_db.h
+++ b/common/comic_db.h
@@ -84,8 +84,6 @@ public:
 
     QVariant comicVineID; // string
 
-    // QImage cover;
-
     QVariant lastTimeOpened; // integer/date
     QVariant coverSizeRatio; // h/w
     QVariant originalCoverSize; // string "WxH"

--- a/common/comic_db.h
+++ b/common/comic_db.h
@@ -84,7 +84,7 @@ public:
 
     QVariant comicVineID; // string
 
-    QImage cover;
+    // QImage cover;
 
     QVariant lastTimeOpened; // integer/date
     QVariant coverSizeRatio; // h/w
@@ -188,8 +188,6 @@ public:
     Q_PROPERTY(QVariant notes MEMBER notes CONSTANT)
 
     Q_PROPERTY(QVariant comicVineID MEMBER comicVineID CONSTANT)
-
-    Q_PROPERTY(QImage cover MEMBER cover CONSTANT)
 
     Q_PROPERTY(QVariant lastTimeOpened MEMBER lastTimeOpened CONSTANT)
 

--- a/common/yacreader_global_gui.cpp
+++ b/common/yacreader_global_gui.cpp
@@ -111,3 +111,40 @@ QString YACReader::imageFileLoader(QWidget *parent)
 
     return QFileDialog::getOpenFileName(parent, QObject::tr("Select custom cover"), QDir::homePath(), QObject::tr("Images (%1)").arg(supportedImageFormatsString));
 }
+
+QString YACReader::imagePathFromMimeData(const QMimeData *mimeData)
+{
+    QString filePath;
+    
+    // Check for URLs (drag from browser or file explorer)
+    if (mimeData->hasUrls()) {
+        QList<QUrl> urlList = mimeData->urls();
+        
+        // We only handle the first URL for simplicity
+        if (!urlList.isEmpty()) {
+            QUrl url = urlList.first();
+            if (url.isLocalFile()) {
+                filePath = url.toLocalFile();
+                
+                // Verify it's an image file using the extension
+                QFileInfo fileInfo(filePath);
+                QString extension = fileInfo.suffix().toLower();
+                QList<QByteArray> supportedFormats = QImageReader::supportedImageFormats();
+                bool isSupported = false;
+                
+                for (const QByteArray &format : supportedFormats) {
+                    if (extension == QString(format).toLower()) {
+                        isSupported = true;
+                        break;
+                    }
+                }
+                
+                if (!isSupported) {
+                    filePath.clear(); // Not a supported image format
+                }
+            }
+        }
+    }
+    
+    return filePath;
+}

--- a/common/yacreader_global_gui.cpp
+++ b/common/yacreader_global_gui.cpp
@@ -115,36 +115,33 @@ QString YACReader::imageFileLoader(QWidget *parent)
 QString YACReader::imagePathFromMimeData(const QMimeData *mimeData)
 {
     QString filePath;
-    
-    // Check for URLs (drag from browser or file explorer)
+
     if (mimeData->hasUrls()) {
         QList<QUrl> urlList = mimeData->urls();
-        
-        // We only handle the first URL for simplicity
+
         if (!urlList.isEmpty()) {
             QUrl url = urlList.first();
             if (url.isLocalFile()) {
                 filePath = url.toLocalFile();
-                
-                // Verify it's an image file using the extension
+
                 QFileInfo fileInfo(filePath);
                 QString extension = fileInfo.suffix().toLower();
                 QList<QByteArray> supportedFormats = QImageReader::supportedImageFormats();
                 bool isSupported = false;
-                
+
                 for (const QByteArray &format : supportedFormats) {
                     if (extension == QString(format).toLower()) {
                         isSupported = true;
                         break;
                     }
                 }
-                
+
                 if (!isSupported) {
-                    filePath.clear(); // Not a supported image format
+                    filePath.clear();
                 }
             }
         }
     }
-    
+
     return filePath;
 }

--- a/common/yacreader_global_gui.cpp
+++ b/common/yacreader_global_gui.cpp
@@ -2,6 +2,8 @@
 
 #include <QtCore>
 #include <QAction>
+#include <QImageReader>
+#include <QFileDialog>
 
 using namespace YACReader;
 
@@ -98,4 +100,14 @@ QAction *YACReader::actionWithCustomIcon(const QIcon &icon, QAction *action)
 QPixmap YACReader::hdpiPixmap(const QString &file, QSize size)
 {
     return QIcon(file).pixmap(size);
+}
+
+QString YACReader::imageFileLoader(QWidget *parent)
+{
+    QString supportedImageFormatsString;
+    for (const QByteArray &format : QImageReader::supportedImageFormats()) {
+        supportedImageFormatsString += QString("*.%1 ").arg(QString(format));
+    }
+
+    return QFileDialog::getOpenFileName(parent, QObject::tr("Select custom cover"), QDir::homePath(), QObject::tr("Images (%1)").arg(supportedImageFormatsString));
 }

--- a/common/yacreader_global_gui.h
+++ b/common/yacreader_global_gui.h
@@ -112,6 +112,6 @@ QString addExtensionToIconPath(const QString &path);
 QString addExtensionToIconPathInToolbar(const QString &path);
 QAction *actionWithCustomIcon(const QIcon &icon, QAction *action);
 QPixmap hdpiPixmap(const QString &file, QSize size);
-
+QString imageFileLoader(QWidget *parent);
 }
 #endif

--- a/common/yacreader_global_gui.h
+++ b/common/yacreader_global_gui.h
@@ -113,5 +113,6 @@ QString addExtensionToIconPathInToolbar(const QString &path);
 QAction *actionWithCustomIcon(const QIcon &icon, QAction *action);
 QPixmap hdpiPixmap(const QString &file, QSize size);
 QString imageFileLoader(QWidget *parent);
+QString imagePathFromMimeData(const QMimeData *mimeData);
 }
 #endif

--- a/custom_widgets/custom_widgets_yacreaderlibrary.pri
+++ b/custom_widgets/custom_widgets_yacreaderlibrary.pri
@@ -21,7 +21,8 @@ HEADERS += \
         $$PWD/yacreader_library_list_widget.h \
         $$PWD/yacreader_library_item_widget.h \
         $$PWD/yacreader_treeview.h \
-        $$PWD/yacreader_busy_widget.h
+        $$PWD/yacreader_busy_widget.h \
+        $$PWD/yacreader_cover_label.h
 !CONFIG(no_opengl){
 	HEADERS += $$PWD/yacreader_gl_flow_config_widget.h
 }
@@ -50,8 +51,8 @@ SOURCES += \
         $$PWD/yacreader_library_list_widget.cpp \
         $$PWD/yacreader_library_item_widget.cpp \
         $$PWD/yacreader_treeview.cpp \
-        $$PWD/yacreader_busy_widget.cpp
-
+        $$PWD/yacreader_busy_widget.cpp \
+        $$PWD/yacreader_cover_label.cpp
 !CONFIG(no_opengl){
         SOURCES += $$PWD/yacreader_gl_flow_config_widget.cpp
 }

--- a/custom_widgets/yacreader_cover_label.cpp
+++ b/custom_widgets/yacreader_cover_label.cpp
@@ -1,0 +1,31 @@
+#include "yacreader_cover_label.h"
+#include "yacreader_global_gui.h"
+
+YACReader::CoverLabel::CoverLabel(QWidget *parent)
+    : QLabel(parent)
+{
+    setAcceptDrops(true);
+}
+
+void YACReader::CoverLabel::dragEnterEvent(QDragEnterEvent *event)
+{
+    if (event->mimeData()->hasUrls() && !YACReader::imagePathFromMimeData(event->mimeData()).isEmpty()) {
+        event->acceptProposedAction();
+    }
+}
+
+void YACReader::CoverLabel::dragMoveEvent(QDragMoveEvent *event)
+{
+    if (event->mimeData()->hasUrls()) {
+        event->acceptProposedAction();
+    }
+}
+
+void YACReader::CoverLabel::dropEvent(QDropEvent *event)
+{
+    QString path = YACReader::imagePathFromMimeData(event->mimeData());
+    if (!path.isEmpty()) {
+        emit imageDropped(path);
+        event->acceptProposedAction();
+    }
+}

--- a/custom_widgets/yacreader_cover_label.h
+++ b/custom_widgets/yacreader_cover_label.h
@@ -1,0 +1,29 @@
+#ifndef DROP_LABEL_H
+#define DROP_LABEL_H
+
+#include <QLabel>
+#include <QDragEnterEvent>
+#include <QDropEvent>
+#include <QMimeData>
+
+namespace YACReader {
+
+class CoverLabel : public QLabel
+{
+    Q_OBJECT
+
+public:
+    explicit CoverLabel(QWidget *parent = nullptr);
+
+protected:
+    void dragEnterEvent(QDragEnterEvent *event) override;
+    void dragMoveEvent(QDragMoveEvent *event) override;
+    void dropEvent(QDropEvent *event) override;
+
+signals:
+    void imageDropped(const QString &path);
+};
+
+}
+
+#endif // DROP_LABEL_H

--- a/images/loadCustomCover.svg
+++ b/images/loadCustomCover.svg
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: #fff;
+      }
+    </style>
+  </defs>
+  <polygon class="cls-1" points="4 3 4 2 2 2 2 3 2 6 6 6 6 3 4 3"/>
+</svg>

--- a/images/resetCover.svg
+++ b/images/resetCover.svg
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<svg id="Layer_2" data-name="Layer 2" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 8 8">
+  <defs>
+    <style>
+      .cls-1 {
+        fill: none;
+        stroke: #fff;
+        stroke-miterlimit: 10;
+        stroke-width: 1.5px;
+      }
+    </style>
+  </defs>
+  <line class="cls-1" x1="2.35" y1="2.29" x2="5.65" y2="5.71"/>
+  <line class="cls-1" x1="5.65" y1="2.29" x2="2.35" y2="5.71"/>
+</svg>


### PR DESCRIPTION
![imagen](https://github.com/user-attachments/assets/68c4382e-b112-4cf5-b880-eff1e00e58cb)

* you can drag&drop an image into the cover view of the edit dialog to set it or use the button in the cover box tools
* there is a reset button too to restore the default cover
* and you can edit covers in bulk, so if you select various comics -> edit -> you can set the same cover for all of them, specially helpful when you have a list of web comics without covers