### PR TITLE
Add Korean translation

### DIFF
--- a/YACReader/CMakeLists.txt
+++ b/YACReader/CMakeLists.txt
@@ -242,6 +242,7 @@ qt_add_translations(YACReader
         yacreader_zh_TW.ts
         yacreader_zh_HK.ts
         yacreader_it.ts
+        yacreader_ko.ts
         yacreader_source.ts
         yacreader_en.ts
 )

--- a/YACReader/yacreader_ko.ts
+++ b/YACReader/yacreader_ko.ts
@@ -1,3892 +1,1515 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
-    <context>
-        <name>ActionsShortcutsModel</name>
-        <message>
-            <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="73" />
-            <source>None</source>
-            <translation>없음</translation>
-        </message>
-    </context>
-    <context>
-        <name>AddLabelDialog</name>
-        <message>
-            <location filename="add_label_dialog.cpp" line="25" />
-            <source>Label name:</source>
-            <translation>라벨 이름:</translation>
-        </message>
-        <message>
-            <location filename="add_label_dialog.cpp" line="28" />
-            <source>Choose a color:</source>
-            <translation>색상 선택:</translation>
-        </message>
-        <message>
-            <location filename="add_label_dialog.cpp" line="42" />
-            <source>accept</source>
-            <translation>확인</translation>
-        </message>
-        <message>
-            <location filename="add_label_dialog.cpp" line="43" />
-            <source>cancel</source>
-            <translation>취소</translation>
-        </message>
-    </context>
-    <context>
-        <name>AddLibraryDialog</name>
-        <message>
-            <location filename="add_library_dialog.cpp" line="26" />
-            <source>Add</source>
-            <translation>추가</translation>
-        </message>
-        <message>
-            <location filename="add_library_dialog.cpp" line="64" />
-            <source>Add an existing library</source>
-            <translation>기존 라이브러리 추가</translation>
-        </message>
-        <message>
-            <location filename="add_library_dialog.cpp" line="30" />
-            <source>Cancel</source>
-            <translation>취소</translation>
-        </message>
-        <message>
-            <location filename="add_library_dialog.cpp" line="16" />
-            <source>Comics folder : </source>
-            <translation>만화 폴더: </translation>
-        </message>
-        <message>
-            <location filename="add_library_dialog.cpp" line="21" />
-            <source>Library name : </source>
-            <translation>라이브러리 이름: </translation>
-        </message>
-    </context>
-    <context>
-        <name>ApiKeyDialog</name>
-        <message>
-            <location filename="comic_vine/api_key_dialog.cpp" line="32" />
-            <source>Cancel</source>
-            <translation>취소</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/api_key_dialog.cpp" line="21" />
-            <source>Before you can connect to Comic Vine, you need your own API key. Please, get one free &lt;a href="http://www.comicvine.com/api/"&gt;here&lt;/a&gt;</source>
-            <translation>Comic Vine에 연결하려면 본인의 API 키가 필요합니다. &lt;a href="http://www.comicvine.com/api/"&gt;여기&lt;/a&gt;에서 무료로 발급받으세요.</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/api_key_dialog.cpp" line="25" />
-            <source>Paste here your Comic Vine API key</source>
-            <translation>Comic Vine API 키를 여기 붙여넣으세요</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/api_key_dialog.cpp" line="28" />
-            <source>Accept</source>
-            <translation>확인</translation>
-        </message>
-    </context>
-    <context>
-        <name>AppearanceTabWidget</name>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="38" />
-            <source>Color scheme</source>
-            <translation>색 구성표</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="46" />
-            <source>System</source>
-            <translation>시스템</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="47" />
-            <source>Light</source>
-            <translation>밝은</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="48" />
-            <source>Dark</source>
-            <translation>어두운</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="49" />
-            <source>Custom</source>
-            <translation>사용자 지정</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="105" />
-            <source>Remove</source>
-            <translation>제거</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="107" />
-            <source>Remove this user-imported theme</source>
-            <translation>사용자 가져온 이 테마 제거</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="115" />
-            <source>Light:</source>
-            <translation>밝은:</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="116" />
-            <source>Dark:</source>
-            <translation>어두운:</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="117" />
-            <source>Custom:</source>
-            <translation>사용자 지정:</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="119" />
-            <source>Import theme...</source>
-            <translation>테마 가져오기...</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="121" />
-            <source>Theme</source>
-            <translation>테마</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="173" />
-            <source>Theme editor</source>
-            <translation>테마 편집기</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="175" />
-            <source>Open Theme Editor...</source>
-            <translation>테마 편집기 열기...</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="184" />
-            <source>Theme editor error</source>
-            <translation>테마 편집기 오류</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="185" />
-            <source>The current theme JSON could not be loaded.</source>
-            <translation>현재 테마 JSON을 불러올 수 없습니다.</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="279" />
-            <source>Import theme</source>
-            <translation>테마 가져오기</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="279" />
-            <source>JSON files (*.json);;All files (*)</source>
-            <translation>JSON 파일 (*.json);;모든 파일 (*)</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="287" />
-            <source>Could not import theme from:
+<TS version="2.1" language="ko">
+<context>
+    <name>ActionsShortcutsModel</name>
+    <message>
+        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="74"/>
+        <source>None</source>
+        <translation>없음</translation>
+    </message>
+</context>
+<context>
+    <name>AppearanceTabWidget</name>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="38"/>
+        <source>Color scheme</source>
+        <translation>색 구성표</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="46"/>
+        <source>System</source>
+        <translation>시스템</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="47"/>
+        <source>Light</source>
+        <translation>밝은</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="48"/>
+        <source>Dark</source>
+        <translation>어두운</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="49"/>
+        <source>Custom</source>
+        <translation>사용자 지정</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="105"/>
+        <source>Remove</source>
+        <translation>제거</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="107"/>
+        <source>Remove this user-imported theme</source>
+        <translation>사용자 가져온 이 테마 제거</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="115"/>
+        <source>Light:</source>
+        <translation>밝은:</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="116"/>
+        <source>Dark:</source>
+        <translation>어두운:</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="117"/>
+        <source>Custom:</source>
+        <translation>사용자 지정:</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="119"/>
+        <source>Import theme...</source>
+        <translation>테마 가져오기...</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="121"/>
+        <source>Theme</source>
+        <translation>테마</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="173"/>
+        <source>Theme editor</source>
+        <translation>테마 편집기</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="175"/>
+        <source>Open Theme Editor...</source>
+        <translation>테마 편집기 열기...</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="184"/>
+        <source>Theme editor error</source>
+        <translation>테마 편집기 오류</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="185"/>
+        <source>The current theme JSON could not be loaded.</source>
+        <translation>현재 테마 JSON을 불러올 수 없습니다.</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="279"/>
+        <source>Import theme</source>
+        <translation>테마 가져오기</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="279"/>
+        <source>JSON files (*.json);;All files (*)</source>
+        <translation>JSON 파일 (*.json);;모든 파일 (*)</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="287"/>
+        <source>Could not import theme from:
 %1</source>
-            <translation>다음에서 테마를 가져올 수 없습니다:
+        <translation>다음에서 테마를 가져올 수 없습니다:
 %1</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="288" />
-            <source>Could not import theme from:
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="288"/>
+        <source>Could not import theme from:
 %1
 
 %2</source>
-            <translation>다음에서 테마를 가져올 수 없습니다:
+        <translation>다음에서 테마를 가져올 수 없습니다:
 %1
 
 %2</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="289" />
-            <source>Import failed</source>
-            <translation>가져오기 실패</translation>
-        </message>
-    </context>
-    <context>
-        <name>BookmarksDialog</name>
-        <message>
-            <location filename="../YACReader/bookmarks_dialog.cpp" line="25" />
-            <source>Lastest Page</source>
-            <translation>마지막 페이지</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/bookmarks_dialog.cpp" line="75" />
-            <source>Close</source>
-            <translation>닫기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/bookmarks_dialog.cpp" line="85" />
-            <source>Click on any image to go to the bookmark</source>
-            <translation>이미지를 클릭하면 책갈피로 이동합니다</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/bookmarks_dialog.cpp" line="107" />
-            <location filename="../YACReader/bookmarks_dialog.cpp" line="124" />
-            <source>Loading...</source>
-            <translation>불러오는 중...</translation>
-        </message>
-    </context>
-    <context>
-        <name>ClassicComicsView</name>
-        <message>
-            <location filename="classic_comics_view.cpp" line="85" />
-            <source>Hide comic flow</source>
-            <translation>만화 흐름 숨기기</translation>
-        </message>
-    </context>
-    <context>
-        <name>ComicInfoView</name>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="302" />
-            <source>Characters</source>
-            <translation>등장인물</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="334" />
-            <source>Main character or team</source>
-            <translation>주요 등장인물 또는 팀</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="359" />
-            <source>Teams</source>
-            <translation>팀</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="393" />
-            <source>Locations</source>
-            <translation>장소</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="425" />
-            <source>Authors</source>
-            <translation>작가진</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="457" />
-            <source>writer</source>
-            <translation>글</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="479" />
-            <source>penciller</source>
-            <translation>밑그림</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="501" />
-            <source>inker</source>
-            <translation>펜선</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="523" />
-            <source>colorist</source>
-            <translation>채색</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="545" />
-            <source>letterer</source>
-            <translation>식자</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="567" />
-            <source>cover artist</source>
-            <translation>표지 그림</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="589" />
-            <source>editor</source>
-            <translation>편집</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="611" />
-            <source>imprint</source>
-            <translation>출판 브랜드</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="626" />
-            <source>Publisher</source>
-            <translation>출판사</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="678" />
-            <source>color</source>
-            <translation>컬러</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="678" />
-            <source>b/w</source>
-            <translation>흑백</translation>
-        </message>
-    </context>
-    <context>
-        <name>ComicModel</name>
-        <message>
-            <location filename="db/comic_model.cpp" line="364" />
-            <source>yes</source>
-            <translation>예</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="364" />
-            <source>no</source>
-            <translation>아니오</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="395" />
-            <source>Title</source>
-            <translation>제목</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="397" />
-            <source>File Name</source>
-            <translation>파일 이름</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="399" />
-            <source>Pages</source>
-            <translation>페이지</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="401" />
-            <source>Size</source>
-            <translation>크기</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="403" />
-            <source>Read</source>
-            <translation>읽음</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="405" />
-            <source>Current Page</source>
-            <translation>현재 페이지</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="407" />
-            <source>Publication Date</source>
-            <translation>출판일</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="409" />
-            <source>Rating</source>
-            <translation>평점</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="411" />
-            <source>Series</source>
-            <translation>시리즈</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="413" />
-            <source>Volume</source>
-            <translation>볼륨</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="415" />
-            <source>Story Arc</source>
-            <translation>스토리 아크</translation>
-        </message>
-    </context>
-    <context>
-        <name>ComicVineDialog</name>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="54" />
-            <source>skip</source>
-            <translation>건너뛰기</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="55" />
-            <source>back</source>
-            <translation>뒤로</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="56" />
-            <source>next</source>
-            <translation>다음</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="57" />
-            <source>search</source>
-            <translation>검색</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="58" />
-            <source>close</source>
-            <translation>닫기</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="134" />
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="588" />
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="627" />
-            <source>Looking for volume...</source>
-            <translation>볼륨 검색 중...</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="132" />
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="546" />
-            <source>comic %1 of %2 - %3</source>
-            <translation>%1 / %2 만화 - %3</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="249" />
-            <source>%1 comics selected</source>
-            <translation>만화 %1개 선택됨</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="280" />
-            <source>Error connecting to ComicVine</source>
-            <translation>Comic Vine 연결 오류</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="460" />
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="486" />
-            <source>Retrieving tags for : %1</source>
-            <translation>태그 가져오는 중 : %1</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="607" />
-            <source>Retrieving volume info...</source>
-            <translation>볼륨 정보 가져오는 중...</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="639" />
-            <source>Looking for comic...</source>
-            <translation>만화 검색 중...</translation>
-        </message>
-    </context>
-    <context>
-        <name>ContinuousPageWidget</name>
-        <message>
-            <location filename="../YACReader/continuous_page_widget.cpp" line="156" />
-            <source>Loading page %1</source>
-            <translation>페이지 %1 불러오는 중</translation>
-        </message>
-    </context>
-    <context>
-        <name>CreateLibraryDialog</name>
-        <message>
-            <location filename="create_library_dialog.cpp" line="76" />
-            <source>Create new library</source>
-            <translation>새 라이브러리 만들기</translation>
-        </message>
-        <message>
-            <location filename="create_library_dialog.cpp" line="34" />
-            <source>Cancel</source>
-            <translation>취소</translation>
-        </message>
-        <message>
-            <location filename="create_library_dialog.cpp" line="30" />
-            <source>Create</source>
-            <translation>만들기</translation>
-        </message>
-        <message>
-            <location filename="create_library_dialog.cpp" line="20" />
-            <source>Comics folder : </source>
-            <translation>만화 폴더: </translation>
-        </message>
-        <message>
-            <location filename="create_library_dialog.cpp" line="25" />
-            <source>Library Name : </source>
-            <translation>라이브러리 이름: </translation>
-        </message>
-        <message>
-            <location filename="create_library_dialog.cpp" line="56" />
-            <source>Create a library could take several minutes. You can stop the process and update the library later for completing the task.</source>
-            <translation>라이브러리 생성은 몇 분 걸릴 수 있습니다. 작업을 중지하고 나중에 라이브러리를 업데이트하여 완료할 수 있습니다.</translation>
-        </message>
-        <message>
-            <location filename="create_library_dialog.cpp" line="104" />
-            <source>Path not found</source>
-            <translation>경로를 찾을 수 없음</translation>
-        </message>
-        <message>
-            <location filename="create_library_dialog.cpp" line="104" />
-            <source>The selected path does not exist or is not a valid path. Be sure that you have write access to this folder</source>
-            <translation>선택한 경로가 존재하지 않거나 올바르지 않습니다. 이 폴더에 쓰기 권한이 있는지 확인하세요</translation>
-        </message>
-    </context>
-    <context>
-        <name>EditShortcutsDialog</name>
-        <message>
-            <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="23" />
-            <source>Restore defaults</source>
-            <translation>기본값으로 복원</translation>
-        </message>
-        <message>
-            <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="24" />
-            <source>To change a shortcut, double click in the key combination and type the new keys.</source>
-            <translation>단축키를 바꾸려면 키 조합을 더블 클릭하고 새 키를 입력하세요.</translation>
-        </message>
-        <message>
-            <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="71" />
-            <source>Shortcuts settings</source>
-            <translation>단축키 설정</translation>
-        </message>
-        <message>
-            <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="122" />
-            <source>Shortcut in use</source>
-            <translation>사용 중인 단축키</translation>
-        </message>
-        <message>
-            <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="122" />
-            <source>The shortcut "%1" is already assigned to other function</source>
-            <translation>"%1" 단축키는 이미 다른 기능이 사용 중입니다</translation>
-        </message>
-    </context>
-    <context>
-        <name>EmptyFolderWidget</name>
-        <message>
-            <location filename="empty_folder_widget.cpp" line="8" />
-            <source>This folder doesn't contain comics yet</source>
-            <translation>이 폴더에는 아직 만화가 없습니다</translation>
-        </message>
-    </context>
-    <context>
-        <name>EmptyLabelWidget</name>
-        <message>
-            <location filename="empty_label_widget.cpp" line="7" />
-            <source>This label doesn't contain comics yet</source>
-            <translation>이 라벨에 아직 만화가 없습니다</translation>
-        </message>
-    </context>
-    <context>
-        <name>EmptyReadingListWidget</name>
-        <message>
-            <location filename="empty_reading_list_widget.cpp" line="8" />
-            <source>This reading list does not contain any comics yet</source>
-            <translation>이 읽기 목록에 아직 만화가 없습니다</translation>
-        </message>
-    </context>
-    <context>
-        <name>EmptySpecialListWidget</name>
-        <message>
-            <location filename="empty_special_list.cpp" line="13" />
-            <source>No favorites</source>
-            <translation>즐겨찾기 없음</translation>
-        </message>
-        <message>
-            <location filename="empty_special_list.cpp" line="20" />
-            <source>You are not reading anything yet, come on!!</source>
-            <translation>아직 읽고 있는 만화가 없습니다. 지금 시작해보세요!!</translation>
-        </message>
-        <message>
-            <location filename="empty_special_list.cpp" line="27" />
-            <source>There are no recent comics!</source>
-            <translation>최근 본 만화가 없습니다!</translation>
-        </message>
-    </context>
-    <context>
-        <name>ExportComicsInfoDialog</name>
-        <message>
-            <location filename="export_comics_info_dialog.cpp" line="22" />
-            <source>Cancel</source>
-            <translation>취소</translation>
-        </message>
-        <message>
-            <location filename="export_comics_info_dialog.cpp" line="18" />
-            <source>Create</source>
-            <translation>생성</translation>
-        </message>
-        <message>
-            <location filename="export_comics_info_dialog.cpp" line="14" />
-            <source>Output file : </source>
-            <translation>출력 파일: </translation>
-        </message>
-        <message>
-            <location filename="export_comics_info_dialog.cpp" line="55" />
-            <source>Export comics info</source>
-            <translation>만화 정보 내보내기</translation>
-        </message>
-        <message>
-            <location filename="export_comics_info_dialog.cpp" line="72" />
-            <source>Destination database name</source>
-            <translation>대상 데이터베이스 이름</translation>
-        </message>
-        <message>
-            <location filename="export_comics_info_dialog.cpp" line="87" />
-            <source>Problem found while writing</source>
-            <translation>쓰기 중 문제 발생</translation>
-        </message>
-        <message>
-            <location filename="export_comics_info_dialog.cpp" line="87" />
-            <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
-            <translation>출력 파일에 선택한 경로가 존재하지 않거나 올바르지 않습니다. 이 폴더에 쓰기 권한이 있는지 확인하세요</translation>
-        </message>
-    </context>
-    <context>
-        <name>ExportLibraryDialog</name>
-        <message>
-            <location filename="export_library_dialog.cpp" line="19" />
-            <source>Cancel</source>
-            <translation>취소</translation>
-        </message>
-        <message>
-            <location filename="export_library_dialog.cpp" line="15" />
-            <source>Create</source>
-            <translation>생성</translation>
-        </message>
-        <message>
-            <location filename="export_library_dialog.cpp" line="11" />
-            <source>Output folder : </source>
-            <translation>출력 폴더: </translation>
-        </message>
-        <message>
-            <location filename="export_library_dialog.cpp" line="58" />
-            <source>Create covers package</source>
-            <translation>표지 패키지 생성</translation>
-        </message>
-        <message>
-            <location filename="export_library_dialog.cpp" line="82" />
-            <source>Destination directory</source>
-            <translation>대상 폴더</translation>
-        </message>
-        <message>
-            <location filename="export_library_dialog.cpp" line="77" />
-            <source>Problem found while writing</source>
-            <translation>쓰기 중 문제 발생</translation>
-        </message>
-        <message>
-            <location filename="export_library_dialog.cpp" line="77" />
-            <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
-            <translation>출력 파일에 선택한 경로가 존재하지 않거나 올바르지 않습니다. 이 폴더에 쓰기 권한이 있는지 확인하세요</translation>
-        </message>
-    </context>
-    <context>
-        <name>FileComic</name>
-        <message>
-            <location filename="../common/comic.cpp" line="562" />
-            <source>7z not found</source>
-            <translation>7z를 찾을 수 없습니다</translation>
-        </message>
-        <message>
-            <location filename="../common/comic.cpp" line="454" />
-            <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
-            <translation>%1번 페이지에서 CRC 오류 발생: 일부 페이지가 올바르게 표시되지 않을 수 있습니다</translation>
-        </message>
-        <message>
-            <location filename="../common/comic.cpp" line="461" />
-            <source>Unknown error opening the file</source>
-            <translation>파일을 여는 중 알 수 없는 오류가 발생했습니다</translation>
-        </message>
-        <message>
-            <location filename="../common/comic.cpp" line="568" />
-            <source>Format not supported</source>
-            <translation>지원하지 않는 형식입니다</translation>
-        </message>
-    </context>
-    <context>
-        <name>FolderContentView</name>
-        <message>
-            <location filename="qml/FolderContentView.qml" line="223" />
-            <source>Continue Reading...</source>
-            <translation>이어 읽기...</translation>
-        </message>
-    </context>
-    <context>
-        <name>GoToDialog</name>
-        <message>
-            <location filename="../YACReader/goto_dialog.cpp" line="15" />
-            <source>Page : </source>
-            <translation>페이지: </translation>
-        </message>
-        <message>
-            <location filename="../YACReader/goto_dialog.cpp" line="23" />
-            <source>Go To</source>
-            <translation>이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/goto_dialog.cpp" line="25" />
-            <source>Cancel</source>
-            <translation>취소</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/goto_dialog.cpp" line="39" />
-            <location filename="../YACReader/goto_dialog.cpp" line="71" />
-            <source>Total pages : </source>
-            <translation>전체 페이지: </translation>
-        </message>
-        <message>
-            <location filename="../YACReader/goto_dialog.cpp" line="53" />
-            <source>Go to...</source>
-            <translation>이동...</translation>
-        </message>
-    </context>
-    <context>
-        <name>GoToFlowToolBar</name>
-        <message>
-            <location filename="../YACReader/goto_flow_toolbar.cpp" line="25" />
-            <source>Page : </source>
-            <translation>페이지: </translation>
-        </message>
-    </context>
-    <context>
-        <name>GridComicsView</name>
-        <message>
-            <location filename="grid_comics_view.cpp" line="77" />
-            <source>Show info</source>
-            <translation>정보 보기</translation>
-        </message>
-    </context>
-    <context>
-        <name>HelpAboutDialog</name>
-        <message>
-            <location filename="../custom_widgets/help_about_dialog.cpp" line="23" />
-            <source>About</source>
-            <translation>정보</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/help_about_dialog.cpp" line="26" />
-            <source>Help</source>
-            <translation>도움말</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/help_about_dialog.cpp" line="29" />
-            <source>System info</source>
-            <translation>시스템 정보</translation>
-        </message>
-    </context>
-    <context>
-        <name>ImportComicsInfoDialog</name>
-        <message>
-            <location filename="import_comics_info_dialog.cpp" line="24" />
-            <source>Cancel</source>
-            <translation>취소</translation>
-        </message>
-        <message>
-            <location filename="import_comics_info_dialog.cpp" line="14" />
-            <source>Import comics info</source>
-            <translation>만화 정보 가져오기</translation>
-        </message>
-        <message>
-            <location filename="import_comics_info_dialog.cpp" line="16" />
-            <source>Info database location : </source>
-            <translation>정보 데이터베이스 경로: </translation>
-        </message>
-        <message>
-            <location filename="import_comics_info_dialog.cpp" line="20" />
-            <source>Import</source>
-            <translation>가져오기</translation>
-        </message>
-        <message>
-            <location filename="import_comics_info_dialog.cpp" line="80" />
-            <source>Comics info file (*.ydb)</source>
-            <translation>만화 정보 파일 (*.ydb)</translation>
-        </message>
-    </context>
-    <context>
-        <name>ImportLibraryDialog</name>
-        <message>
-            <location filename="import_library_dialog.cpp" line="26" />
-            <source>Destination folder : </source>
-            <translation>대상 폴더: </translation>
-        </message>
-        <message>
-            <location filename="import_library_dialog.cpp" line="34" />
-            <source>Cancel</source>
-            <translation>취소</translation>
-        </message>
-        <message>
-            <location filename="import_library_dialog.cpp" line="30" />
-            <source>Unpack</source>
-            <translation>풀기</translation>
-        </message>
-        <message>
-            <location filename="import_library_dialog.cpp" line="115" />
-            <source>Compresed library covers (*.clc)</source>
-            <translation>압축된 라이브러리 표지 (*.clc)</translation>
-        </message>
-        <message>
-            <location filename="import_library_dialog.cpp" line="22" />
-            <source>Package location : </source>
-            <translation>패키지 경로: </translation>
-        </message>
-        <message>
-            <location filename="import_library_dialog.cpp" line="17" />
-            <source>Library Name : </source>
-            <translation>라이브러리 이름: </translation>
-        </message>
-        <message>
-            <location filename="import_library_dialog.cpp" line="85" />
-            <source>Extract a catalog</source>
-            <translation>카탈로그 추출</translation>
-        </message>
-    </context>
-    <context>
-        <name>ImportWidget</name>
-        <message>
-            <location filename="import_widget.cpp" line="131" />
-            <source>stop</source>
-            <translation>중지</translation>
-        </message>
-        <message>
-            <location filename="import_widget.cpp" line="171" />
-            <source>Some of the comics being added...</source>
-            <translation>일부 만화를 추가하는 중...</translation>
-        </message>
-        <message>
-            <location filename="import_widget.cpp" line="318" />
-            <source>Importing comics</source>
-            <translation>만화 가져오는 중</translation>
-        </message>
-        <message>
-            <location filename="import_widget.cpp" line="319" />
-            <source>&lt;p&gt;YACReaderLibrary is now creating a new library.&lt;/p&gt;&lt;p&gt;Create a library could take several minutes. You can stop the process and update the library later for completing the task.&lt;/p&gt;</source>
-            <translation>&lt;p&gt;YACReaderLibrary가 새 라이브러리를 만들고 있습니다.&lt;/p&gt;&lt;p&gt;라이브러리 생성은 몇 분 걸릴 수 있습니다. 작업을 중지하고 나중에 라이브러리를 업데이트하여 작업을 완료할 수 있습니다.&lt;/p&gt;</translation>
-        </message>
-        <message>
-            <location filename="import_widget.cpp" line="330" />
-            <source>Updating the library</source>
-            <translation>라이브러리 업데이트 중</translation>
-        </message>
-        <message>
-            <location filename="import_widget.cpp" line="331" />
-            <source>&lt;p&gt;The current library is being updated. For faster updates, please, update your libraries frequently.&lt;/p&gt;&lt;p&gt;You can stop the process and continue updating this library later.&lt;/p&gt;</source>
-            <translation>&lt;p&gt;현재 라이브러리를 업데이트하고 있습니다. 더 빠른 업데이트를 위해 라이브러리를 자주 업데이트하세요.&lt;/p&gt;&lt;p&gt;작업을 중지하고 나중에 이 라이브러리 업데이트를 계속할 수 있습니다.&lt;/p&gt;</translation>
-        </message>
-        <message>
-            <location filename="import_widget.cpp" line="342" />
-            <source>Upgrading the library</source>
-            <translation>라이브러리 업그레이드 중</translation>
-        </message>
-        <message>
-            <location filename="import_widget.cpp" line="343" />
-            <source>&lt;p&gt;The current library is being upgraded, please wait.&lt;/p&gt;</source>
-            <translation>&lt;p&gt;현재 라이브러리를 업그레이드하고 있습니다. 잠시만 기다려주세요.&lt;/p&gt;</translation>
-        </message>
-        <message>
-            <location filename="import_widget.cpp" line="354" />
-            <source>Scanning the library</source>
-            <translation>라이브러리 스캔 중</translation>
-        </message>
-        <message>
-            <location filename="import_widget.cpp" line="355" />
-            <source>&lt;p&gt;Current library is being scanned for legacy XML metadata information.&lt;/p&gt;&lt;p&gt;This is only needed once, and only if the library was crated with YACReaderLibrary 9.8.2 or earlier.&lt;/p&gt;</source>
-            <translation>&lt;p&gt;현재 라이브러리에서 레거시 XML 메타데이터 정보를 스캔하고 있습니다.&lt;/p&gt;&lt;p&gt;이 작업은 한 번만 필요하며, 라이브러리가 YACReaderLibrary 9.8.2 또는 이전 버전으로 만들어진 경우에만 해당됩니다.&lt;/p&gt;</translation>
-        </message>
-    </context>
-    <context>
-        <name>LibraryWindow</name>
-        <message>
-            <source>Remove current library from your collection</source>
-            <translation type="vanished">내 컬렉션에서 현재 라이브러리 제거</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="626" />
-            <source>Library</source>
-            <translation>라이브러리</translation>
-        </message>
-        <message>
-            <source>Rename current library</source>
-            <translation type="vanished">현재 라이브러리 이름 변경</translation>
-        </message>
-        <message>
-            <source>Open current comic on YACReader</source>
-            <translation type="vanished">YACReader에서 현재 만화 열기</translation>
-        </message>
-        <message>
-            <source>Update current library</source>
-            <translation type="vanished">현재 라이브러리 업데이트</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1408" />
-            <source>Open folder...</source>
-            <translation>폴더 열기...</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="545" />
-            <location filename="library_window.cpp" line="1310" />
-            <location filename="library_window.cpp" line="1435" />
-            <source>western manga (left to right)</source>
-            <translation>서양 만화 (왼쪽 → 오른쪽)</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="551" />
-            <location filename="library_window.cpp" line="1316" />
-            <location filename="library_window.cpp" line="1441" />
-            <source>4koma (top to botom)</source>
-            <oldsource>4koma (top to botom</oldsource>
-            <translation>4컷 (위 → 아래)</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1861" />
-            <source>Do you want remove </source>
-            <translation>다음을 제거하시겠습니까: </translation>
-        </message>
-        <message>
-            <source>Expand all nodes</source>
-            <translation type="vanished">모든 노드 펼치기</translation>
-        </message>
-        <message>
-            <source>Show options dialog</source>
-            <translation type="vanished">환경설정 다이얼로그 표시</translation>
-        </message>
-        <message>
-            <source>Create a new library</source>
-            <translation type="vanished">새 라이브러리 만들기</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="223" />
-            <source>YACReader Library</source>
-            <translation>YACReader Library</translation>
-        </message>
-        <message>
-            <source>Open an existing library</source>
-            <translation type="vanished">기존 라이브러리 열기</translation>
-        </message>
-        <message>
-            <source>Pack the covers of the selected library</source>
-            <translation type="vanished">선택한 라이브러리의 표지 묶기</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="542" />
-            <location filename="library_window.cpp" line="1307" />
-            <location filename="library_window.cpp" line="1429" />
-            <source>manga</source>
-            <translation>망가</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="539" />
-            <location filename="library_window.cpp" line="1304" />
-            <location filename="library_window.cpp" line="1432" />
-            <source>comic</source>
-            <translation>만화</translation>
-        </message>
-        <message>
-            <source>Help, About YACReader</source>
-            <translation type="vanished">도움말, YACReader 정보</translation>
-        </message>
-        <message>
-            <source>Select root node</source>
-            <translation type="vanished">루트 노드 선택</translation>
-        </message>
-        <message>
-            <source>Unpack a catalog</source>
-            <translation type="vanished">카탈로그 풀기</translation>
-        </message>
-        <message>
-            <source>Open containing folder...</source>
-            <translation type="vanished">포함된 폴더 열기...</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1861" />
-            <source>Are you sure?</source>
-            <translation>확실합니까?</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1414" />
-            <source>Rescan library for XML info</source>
-            <translation>XML 정보로 라이브러리 재검색</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1423" />
-            <source>Set as read</source>
-            <translation>읽음으로 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1426" />
-            <location filename="library_window.cpp" line="1567" />
-            <source>Set as unread</source>
-            <translation>읽지 않음으로 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="548" />
-            <location filename="library_window.cpp" line="1313" />
-            <location filename="library_window.cpp" line="1438" />
-            <source>web comic</source>
-            <translation>웹 만화</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1150" />
-            <source>Add new folder</source>
-            <translation>새 폴더 추가</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1186" />
-            <source>Delete folder</source>
-            <translation>폴더 삭제</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1417" />
-            <source>Set as uncompleted</source>
-            <translation>미완료로 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1420" />
-            <source>Set as completed</source>
-            <translation>완료로 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1411" />
-            <source>Update folder</source>
-            <translation>폴더 업데이트</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="652" />
-            <source>Folder</source>
-            <translation>폴더</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="674" />
-            <source>Comic</source>
-            <translation>만화</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="802" />
-            <source>Upgrade failed</source>
-            <translation>업그레이드 실패</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="802" />
-            <source>There were errors during library upgrade in: </source>
-            <translation>라이브러리 업그레이드 중 오류 발생: </translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="831" />
-            <source>Update needed</source>
-            <translation>업데이트 필요</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="831" />
-            <source>This library was created with a previous version of YACReaderLibrary. It needs to be updated. Update now?</source>
-            <translation>이 라이브러리는 YACReaderLibrary의 이전 버전으로 만들어졌습니다. 업데이트가 필요합니다. 지금 업데이트하시겠습니까?</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="898" />
-            <source>Download new version</source>
-            <translation>새 버전 내려받기</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="898" />
-            <source>This library was created with a newer version of YACReaderLibrary. Download the new version now?</source>
-            <translation>이 라이브러리는 YACReaderLibrary의 최신 버전으로 만들어졌습니다. 지금 새 버전을 내려받으시겠습니까?</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="919" />
-            <source>Library not available</source>
-            <translation>라이브러리를 사용할 수 없습니다</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="919" />
-            <source>Library '%1' is no longer available. Do you want to remove it?</source>
-            <translation>'%1' 라이브러리를 더 이상 사용할 수 없습니다. 제거하시겠습니까?</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="938" />
-            <source>Old library</source>
-            <translation>오래된 라이브러리</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="938" />
-            <source>Library '%1' has been created with an older version of YACReaderLibrary. It must be created again. Do you want to create the library now?</source>
-            <translation>'%1' 라이브러리는 이전 버전의 YACReaderLibrary로 만들어졌습니다. 다시 만들어야 합니다. 지금 만드시겠습니까?</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="969" />
-            <location filename="library_window.cpp" line="1005" />
-            <source>Copying comics...</source>
-            <translation>만화 복사 중...</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="986" />
-            <location filename="library_window.cpp" line="1024" />
-            <source>Moving comics...</source>
-            <translation>만화 이동 중...</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1151" />
-            <source>Folder name:</source>
-            <translation>폴더 이름:</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1180" />
-            <source>No folder selected</source>
-            <translation>선택된 폴더 없음</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1180" />
-            <source>Please, select a folder first</source>
-            <translation>먼저 폴더를 선택하세요</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1184" />
-            <source>Error in path</source>
-            <translation>경로 오류</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1184" />
-            <source>There was an error accessing the folder's path</source>
-            <translation>폴더 경로에 접근하는 중 오류가 발생했습니다</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1186" />
-            <source>The selected folder and all its contents will be deleted from your disk. Are you sure?</source>
-            <translation>선택한 폴더와 그 안의 모든 내용이 디스크에서 삭제됩니다. 계속하시겠습니까?</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1212" />
-            <location filename="library_window.cpp" line="2174" />
-            <source>Unable to delete</source>
-            <translation>삭제할 수 없음</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1212" />
-            <source>There was an issue trying to delete the selected folders. Please, check for write permissions and be sure that any applications are using these folders or any of the contained files.</source>
-            <translation>선택한 폴더를 삭제하는 중 문제가 발생했습니다. 쓰기 권한을 확인하고, 다른 응용 프로그램이 이 폴더나 안의 파일을 사용 중인지 확인하세요.</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1224" />
-            <source>Add new reading lists</source>
-            <translation>새 읽기 목록 추가</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1225" />
-            <location filename="library_window.cpp" line="1274" />
-            <source>List name:</source>
-            <translation>목록 이름:</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1243" />
-            <source>Delete list/label</source>
-            <translation>목록/라벨 삭제</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1243" />
-            <source>The selected item will be deleted, your comics or folders will NOT be deleted from your disk. Are you sure?</source>
-            <translation>선택한 항목이 삭제됩니다. 디스크에서 만화나 폴더는 삭제되지 않습니다. 계속하시겠습니까?</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1273" />
-            <source>Rename list name</source>
-            <translation>목록 이름 변경</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="591" />
-            <location filename="library_window.cpp" line="1375" />
-            <location filename="library_window.cpp" line="1489" />
-            <location filename="library_window.cpp" line="2631" />
-            <source>Set type</source>
-            <translation>유형 설정</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1444" />
-            <source>Set custom cover</source>
-            <translation>사용자 지정 표지 설정</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1447" />
-            <source>Delete custom cover</source>
-            <translation>사용자 지정 표지 삭제</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1632" />
-            <source>Save covers</source>
-            <translation>표지 저장</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1651" />
-            <source>You are adding too many libraries.</source>
-            <translation>라이브러리를 너무 많이 추가하고 있습니다.</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1651" />
-            <source>You are adding too many libraries.
-
-You probably only need one library in your top level comics folder, you can browse any subfolders using the folders section in the left sidebar.
-
-YACReaderLibrary will not stop you from creating more libraries but you should keep the number of libraries low.</source>
-            <translation>라이브러리를 너무 많이 추가하고 있습니다.
-
-최상위 만화 폴더에 라이브러리 하나만 있으면 충분합니다. 좌측 사이드바의 폴더 섹션으로 하위 폴더를 탐색할 수 있습니다.
-
-YACReaderLibrary는 라이브러리를 더 만드는 것을 막지 않지만, 라이브러리 수는 적게 유지하는 것이 좋습니다.</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1711" />
-            <location filename="library_window.cpp" line="1713" />
-            <source>YACReader not found</source>
-            <translation>YACReader를 찾을 수 없음</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1711" />
-            <source>YACReader not found. YACReader should be installed in the same folder as YACReaderLibrary.</source>
-            <translation>YACReader를 찾을 수 없습니다. YACReader는 YACReaderLibrary와 같은 폴더에 설치되어야 합니다.</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1713" />
-            <source>YACReader not found. There might be a problem with your YACReader installation.</source>
-            <translation>YACReader를 찾을 수 없습니다. YACReader 설치에 문제가 있을 수 있습니다.</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1720" />
-            <source>Error</source>
-            <translation>오류</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1720" />
-            <source>Error opening comic with third party reader.</source>
-            <translation>타사 뷰어로 만화를 여는 중 오류가 발생했습니다.</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1807" />
-            <source>Library not found</source>
-            <translation>라이브러리를 찾을 수 없음</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1807" />
-            <source>The selected folder doesn't contain any library.</source>
-            <translation>선택한 폴더에 라이브러리가 없습니다.</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1861" />
-            <source> library?</source>
-            <translation>라이브러리?</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1862" />
-            <source>Remove and delete metadata</source>
-            <translation>제거 및 메타데이터 삭제</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1932" />
-            <source>Library info</source>
-            <translation>라이브러리 정보</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2174" />
-            <source>There was an issue trying to delete the selected comics. Please, check for write permissions in the selected files or containing folder.</source>
-            <translation>선택한 만화를 삭제하는 중 문제가 발생했습니다. 선택한 파일이나 포함된 폴더의 쓰기 권한을 확인하세요.</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2205" />
-            <source>Assign comics numbers</source>
-            <translation>만화에 번호 부여</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2206" />
-            <source>Assign numbers starting in:</source>
-            <translation>다음 번호부터 부여:</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2306" />
-            <source>Invalid image</source>
-            <translation>잘못된 이미지</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2306" />
-            <source>The selected file is not a valid image.</source>
-            <translation>선택한 파일이 유효한 이미지가 아닙니다.</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2312" />
-            <source>Error saving cover</source>
-            <translation>표지 저장 오류</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2312" />
-            <source>There was an error saving the cover image.</source>
-            <translation>표지 이미지를 저장하는 중 오류가 발생했습니다.</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2451" />
-            <source>Error creating the library</source>
-            <translation>라이브러리 생성 오류</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2456" />
-            <source>Error updating the library</source>
-            <translation>라이브러리 업데이트 오류</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2461" />
-            <source>Error opening the library</source>
-            <translation>라이브러리 열기 오류</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2510" />
-            <source>Delete comics</source>
-            <translation>만화 삭제</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2510" />
-            <source>All the selected comics will be deleted from your disk. Are you sure?</source>
-            <translation>선택한 만화가 모두 디스크에서 삭제됩니다. 확실합니까?</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2547" />
-            <source>Remove comics</source>
-            <translation>만화 제거</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2547" />
-            <source>Comics will only be deleted from the current label/list. Are you sure?</source>
-            <translation>만화가 현재 라벨/목록에서만 삭제됩니다. 확실합니까?</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2649" />
-            <source>Library name already exists</source>
-            <translation>라이브러리 이름 중복</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2649" />
-            <source>There is another library with the name '%1'.</source>
-            <translation>'%1' 이름의 라이브러리가 이미 있습니다.</translation>
-        </message>
-    </context>
-    <context>
-        <name>LibraryWindowActions</name>
-        <message>
-            <location filename="library_window_actions.cpp" line="39" />
-            <source>Create a new library</source>
-            <translation>새 라이브러리 만들기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="44" />
-            <source>Open an existing library</source>
-            <translation>기존 라이브러리 열기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="48" />
-            <location filename="library_window_actions.cpp" line="49" />
-            <source>Export comics info</source>
-            <translation>만화 정보 내보내기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="53" />
-            <location filename="library_window_actions.cpp" line="54" />
-            <source>Import comics info</source>
-            <translation>만화 정보 가져오기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="58" />
-            <source>Pack covers</source>
-            <translation>표지 묶기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="59" />
-            <source>Pack the covers of the selected library</source>
-            <translation>선택한 라이브러리의 표지 묶기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="63" />
-            <source>Unpack covers</source>
-            <translation>표지 풀기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="64" />
-            <source>Unpack a catalog</source>
-            <translation>카탈로그 풀기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="68" />
-            <source>Update library</source>
-            <translation>라이브러리 업데이트</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="69" />
-            <source>Update current library</source>
-            <translation>현재 라이브러리 업데이트</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="73" />
-            <source>Rename library</source>
-            <translation>라이브러리 이름 변경</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="74" />
-            <source>Rename current library</source>
-            <translation>현재 라이브러리 이름 변경</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="78" />
-            <source>Remove library</source>
-            <translation>라이브러리 제거</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="79" />
-            <source>Remove current library from your collection</source>
-            <translation>내 컬렉션에서 현재 라이브러리 제거</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="83" />
-            <source>Rescan library for XML info</source>
-            <translation>XML 정보로 라이브러리 재검색</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="84" />
-            <source>Tries to find XML info embedded in comic files. You only need to do this if the library was created with 9.8.2 or earlier versions or if you are using third party software to embed XML info in the files.</source>
-            <translation>만화 파일에 포함된 XML 정보를 찾으려고 시도합니다. 9.8.2 이하 버전으로 만든 라이브러리이거나 타사 소프트웨어로 파일에 XML 정보를 포함한 경우에만 필요합니다.</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="88" />
-            <source>Show library info</source>
-            <translation>라이브러리 정보 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="89" />
-            <source>Show information about the current library</source>
-            <translation>현재 라이브러리에 대한 정보 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="93" />
-            <source>Open current comic</source>
-            <translation>현재 만화 열기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="94" />
-            <source>Open current comic on YACReader</source>
-            <translation>YACReader에서 현재 만화 열기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="98" />
-            <source>Save selected covers to...</source>
-            <translation>선택한 표지 저장...</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="99" />
-            <source>Save covers of the selected comics as JPG files</source>
-            <translation>선택한 만화의 표지를 JPG 파일로 저장</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="103" />
-            <location filename="library_window_actions.cpp" line="224" />
-            <source>Set as read</source>
-            <translation>읽음으로 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="104" />
-            <source>Set comic as read</source>
-            <translation>만화를 읽음으로 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="108" />
-            <location filename="library_window_actions.cpp" line="229" />
-            <source>Set as unread</source>
-            <translation>읽지 않음으로 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="109" />
-            <source>Set comic as unread</source>
-            <translation>만화를 읽지 않음으로 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="113" />
-            <location filename="library_window_actions.cpp" line="244" />
-            <source>manga</source>
-            <translation>망가</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="114" />
-            <source>Set issue as manga</source>
-            <translation>만화를 망가로 설정</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="118" />
-            <location filename="library_window_actions.cpp" line="249" />
-            <source>comic</source>
-            <translation>만화</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="119" />
-            <source>Set issue as normal</source>
-            <translation>만화를 일반으로 설정</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="123" />
-            <source>western manga</source>
-            <translation>서양 만화</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="124" />
-            <source>Set issue as western manga</source>
-            <translation>만화를 서양 만화로 설정</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="129" />
-            <location filename="library_window_actions.cpp" line="259" />
-            <source>web comic</source>
-            <translation>웹 만화</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="130" />
-            <source>Set issue as web comic</source>
-            <translation>만화를 웹 만화로 설정</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="135" />
-            <location filename="library_window_actions.cpp" line="264" />
-            <source>yonkoma</source>
-            <translation>4컷 만화</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="136" />
-            <source>Set issue as yonkoma</source>
-            <translation>만화를 4컷 만화로 설정</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="140" />
-            <source>Show/Hide marks</source>
-            <translation>읽음 마크 표시/숨김</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="141" />
-            <source>Show or hide read marks</source>
-            <translation>읽음 마크를 표시하거나 숨김</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="147" />
-            <source>Show/Hide recent indicator</source>
-            <translation>신규 표시 표시/숨김</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="148" />
-            <source>Show or hide recent indicator</source>
-            <translation>신규 표시를 표시하거나 숨김</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="155" />
-            <location filename="library_window_actions.cpp" line="156" />
-            <source>Fullscreen mode on/off</source>
-            <translation>전체화면 모드 켜기/끄기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="161" />
-            <source>Help, About YACReader</source>
-            <translation>도움말, YACReader 정보</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="165" />
-            <source>Add new folder</source>
-            <translation>새 폴더 추가</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="168" />
-            <source>Add new folder to the current library</source>
-            <translation>현재 라이브러리에 새 폴더 추가</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="170" />
-            <source>Delete folder</source>
-            <translation>폴더 삭제</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="173" />
-            <source>Delete current folder from disk</source>
-            <translation>현재 폴더를 디스크에서 삭제</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="178" />
-            <source>Select root node</source>
-            <translation>루트 노드 선택</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="181" />
-            <source>Expand all nodes</source>
-            <translation>모든 노드 펼치기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="186" />
-            <source>Collapse all nodes</source>
-            <translation>모든 노드 접기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="191" />
-            <source>Show options dialog</source>
-            <translation>환경설정 다이얼로그 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="196" />
-            <source>Show comics server options dialog</source>
-            <translation>만화 서버 환경설정 다이얼로그 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="200" />
-            <location filename="library_window_actions.cpp" line="201" />
-            <source>Change between comics views</source>
-            <translation>만화 보기 전환</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="209" />
-            <source>Open folder...</source>
-            <translation>폴더 열기...</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="214" />
-            <source>Set as uncompleted</source>
-            <translation>미완료로 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="219" />
-            <source>Set as completed</source>
-            <translation>완료로 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="234" />
-            <source>Set custom cover</source>
-            <translation>사용자 지정 표지 설정</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="239" />
-            <source>Delete custom cover</source>
-            <translation>사용자 지정 표지 삭제</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="254" />
-            <source>western manga (left to right)</source>
-            <translation>서양 만화 (왼쪽 → 오른쪽)</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="271" />
-            <source>Open containing folder...</source>
-            <translation>포함된 폴더 열기...</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="276" />
-            <source>Reset comic rating</source>
-            <translation>만화 평점 초기화</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="282" />
-            <source>Select all comics</source>
-            <translation>모든 만화 선택</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="287" />
-            <source>Edit</source>
-            <translation>편집</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="292" />
-            <source>Assign current order to comics</source>
-            <translation>만화에 현재 순서 적용</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="297" />
-            <source>Update cover</source>
-            <translation>표지 업데이트</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="303" />
-            <source>Delete selected comics</source>
-            <translation>선택한 만화 삭제</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="308" />
-            <source>Delete metadata from selected comics</source>
-            <translation>선택한 만화에서 메타데이터 삭제</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="315" />
-            <source>Download tags from Comic Vine</source>
-            <translation>Comic Vine에서 태그 내려받기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="318" />
-            <source>Focus search line</source>
-            <translation>검색창으로 이동</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="324" />
-            <source>Focus comics view</source>
-            <translation>만화 보기로 이동</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="329" />
-            <source>Edit shortcuts</source>
-            <translation>단축키 편집</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="335" />
-            <source>&amp;Quit</source>
-            <translation>끝내기(&amp;Q)</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="342" />
-            <source>Update folder</source>
-            <translation>폴더 업데이트</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="344" />
-            <source>Update current folder</source>
-            <translation>현재 폴더 업데이트</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="348" />
-            <source>Scan legacy XML metadata</source>
-            <translation>레거시 XML 메타데이터 스캔</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="352" />
-            <source>Add new reading list</source>
-            <translation>새 읽기 목록 추가</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="355" />
-            <source>Add a new reading list to the current library</source>
-            <translation>현재 라이브러리에 새 읽기 목록 추가</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="357" />
-            <source>Remove reading list</source>
-            <translation>읽기 목록 제거</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="360" />
-            <source>Remove current reading list from the library</source>
-            <translation>라이브러리에서 현재 읽기 목록 제거</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="362" />
-            <source>Add new label</source>
-            <translation>새 라벨 추가</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="365" />
-            <source>Add a new label to this library</source>
-            <translation>이 라이브러리에 새 라벨 추가</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="367" />
-            <source>Rename selected list</source>
-            <translation>선택한 목록 이름 변경</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="370" />
-            <source>Rename any selected labels or lists</source>
-            <translation>선택한 라벨이나 목록 이름 변경</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="373" />
-            <source>Add to...</source>
-            <translation>추가...</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="375" />
-            <source>Favorites</source>
-            <translation>즐겨찾기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="378" />
-            <source>Add selected comics to favorites list</source>
-            <translation>선택한 만화를 즐겨찾기 목록에 추가</translation>
-        </message>
-    </context>
-    <context>
-        <name>LocalComicListModel</name>
-        <message>
-            <location filename="comic_vine/model/local_comic_list_model.cpp" line="72" />
-            <source>file name</source>
-            <translation>파일 이름</translation>
-        </message>
-    </context>
-    <context>
-        <name>NoLibrariesWidget</name>
-        <message>
-            <location filename="no_libraries_widget.cpp" line="20" />
-            <source>You don't have any libraries yet</source>
-            <translation>아직 라이브러리가 없습니다</translation>
-        </message>
-        <message>
-            <location filename="no_libraries_widget.cpp" line="22" />
-            <source>&lt;p&gt;You can create a library in any folder, YACReaderLibrary will import all comics and folders from this folder. If you have created any library in the past you can open them.&lt;/p&gt;&lt;p&gt;Don't forget that you can use YACReader as a stand alone application for reading the comics on your computer.&lt;/p&gt;</source>
-            <translation>&lt;p&gt;아무 폴더에 라이브러리를 만들 수 있고, YACReaderLibrary가 그 폴더의 모든 만화와 하위 폴더를 가져옵니다. 이전에 만든 라이브러리가 있으면 열 수 있습니다.&lt;/p&gt;&lt;p&gt;YACReader는 단독 응용 프로그램으로 컴퓨터의 만화를 보는 데도 쓸 수 있습니다.&lt;/p&gt;</translation>
-        </message>
-        <message>
-            <location filename="no_libraries_widget.cpp" line="26" />
-            <source>create your first library</source>
-            <translation>첫 라이브러리 만들기</translation>
-        </message>
-        <message>
-            <location filename="no_libraries_widget.cpp" line="28" />
-            <source>add an existing one</source>
-            <translation>기존 라이브러리 추가</translation>
-        </message>
-    </context>
-    <context>
-        <name>NoSearchResultsWidget</name>
-        <message>
-            <location filename="no_search_results_widget.cpp" line="9" />
-            <source>No results</source>
-            <translation>결과 없음</translation>
-        </message>
-    </context>
-    <context>
-        <name>OptionsDialog</name>
-        <message>
-            <location filename="options_dialog.cpp" line="169" />
-            <location filename="../YACReader/options_dialog.cpp" line="44" />
-            <source>Language</source>
-            <translation>언어</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="171" />
-            <location filename="../YACReader/options_dialog.cpp" line="46" />
-            <source>Application language</source>
-            <translation>응용 프로그램 언어</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="173" />
-            <location filename="../YACReader/options_dialog.cpp" line="48" />
-            <source>System default</source>
-            <translation>시스템 기본값</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="183" />
-            <source>Tray icon settings (experimental)</source>
-            <translation>트레이 아이콘 설정 (실험적)</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="186" />
-            <source>Close to tray</source>
-            <translation>트레이로 최소화</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="187" />
-            <source>Start into the system tray</source>
-            <translation>시스템 트레이에서 시작</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="205" />
-            <source>Edit Comic Vine API key</source>
-            <translation>Comic Vine API 키 편집</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="208" />
-            <source>Comic Vine API key</source>
-            <translation>Comic Vine API 키</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="213" />
-            <source>ComicInfo.xml legacy support</source>
-            <translation>ComicInfo.xml 레거시 지원</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="215" />
-            <source>Import metadata from ComicInfo.xml when adding new comics</source>
-            <oldsource>Import metada from ComicInfo.xml when adding new comics</oldsource>
-            <translation>새 만화 추가 시 ComicInfo.xml에서 메타데이터 가져오기</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="225" />
-            <source>Consider 'recent' items added or updated since X days ago</source>
-            <translation>X일 전부터 추가되거나 업데이트된 항목을 '최근'으로 간주</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="237" />
-            <source>Third party reader</source>
-            <translation>타사 뷰어</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="239" />
-            <source>Write {comic_file_path} where the path should go in the command</source>
-            <translation>명령어에서 경로가 들어갈 자리에 {comic_file_path}를 입력하세요</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="240" />
-            <location filename="../YACReader/options_dialog.cpp" line="87" />
-            <source>Clear</source>
-            <translation>지우기</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="265" />
-            <source>Update libraries at startup</source>
-            <translation>시작 시 라이브러리 업데이트</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="270" />
-            <source>Try to detect changes automatically</source>
-            <translation>변경 사항 자동 감지 시도</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="275" />
-            <source>Update libraries periodically</source>
-            <translation>라이브러리 주기적으로 업데이트</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="281" />
-            <source>Interval:</source>
-            <translation>간격:</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="283" />
-            <source>30 minutes</source>
-            <translation>30분</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="284" />
-            <source>1 hour</source>
-            <translation>1시간</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="285" />
-            <source>2 hours</source>
-            <translation>2시간</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="286" />
-            <source>4 hours</source>
-            <translation>4시간</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="287" />
-            <source>8 hours</source>
-            <translation>8시간</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="288" />
-            <source>12 hours</source>
-            <translation>12시간</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="289" />
-            <source>daily</source>
-            <translation>매일</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="296" />
-            <source>Update libraries at certain time</source>
-            <translation>특정 시간에 라이브러리 업데이트</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="302" />
-            <source>Time:</source>
-            <translation>시간:</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="329" />
-            <source>WARNING! During library updates writes to the database are disabled!
-Don't schedule updates while you may be using the app actively.
-During automatic updates the app will block some of the actions until the update is finished.
-To stop an automatic update tap on the loading indicator next to the Libraries title.</source>
-            <oldsource>WARNING! During library updates writes to the database are disabled!
-Don't schedule updates while you may be using the app actively.
-To stop an automatic update tap on the loading indicator next to the Libraries title.</oldsource>
-            <translation>주의! 라이브러리를 업데이트하는 동안에는 데이터베이스에 기록할 수 없습니다.
-앱을 적극적으로 사용 중일 때는 업데이트를 예약하지 마세요.
-자동 업데이트가 진행되는 동안에는 일부 기능이 잠시 차단될 수 있습니다.
-자동 업데이트를 중단하려면 라이브러리 제목 옆에 표시되는 로딩 아이콘을 눌러주세요.</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="337" />
-            <source>Modifications detection</source>
-            <translation>수정 감지</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="339" />
-            <source>Compare the modified date of files when updating a library (not recommended)</source>
-            <translation>라이브러리 업데이트 시 파일 수정 날짜 비교 (권장하지 않음)</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="378" />
-            <source>Enable background image</source>
-            <translation>배경 이미지 사용</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="380" />
-            <source>Opacity level</source>
-            <translation>불투명도</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="385" />
-            <source>Blur level</source>
-            <translation>흐림 정도</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="390" />
-            <source>Use selected comic cover as background</source>
-            <translation>선택한 만화 표지를 배경으로 사용</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="392" />
-            <source>Restore defautls</source>
-            <translation>기본값으로 복원</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="403" />
-            <source>Background</source>
-            <translation>배경</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="406" />
-            <source>Display continue reading banner</source>
-            <translation>이어 읽기 배너 표시</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="407" />
-            <source>Display current comic banner</source>
-            <translation>현재 만화 배너 표시</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="413" />
-            <source>Continue reading</source>
-            <translation>이어 읽기</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="29" />
-            <source>Comic Flow</source>
-            <translation>코믹 플로우</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="28" />
-            <location filename="options_dialog.cpp" line="334" />
-            <source>Libraries</source>
-            <translation>라이브러리</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="30" />
-            <source>Grid view</source>
-            <translation>격자 보기</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="27" />
-            <location filename="../YACReader/options_dialog.cpp" line="253" />
-            <source>General</source>
-            <translation>일반</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="31" />
-            <location filename="../YACReader/options_dialog.cpp" line="256" />
-            <source>Appearance</source>
-            <translation>외관</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="44" />
-            <location filename="../YACReader/options_dialog.cpp" line="271" />
-            <source>Options</source>
-            <translation>환경설정</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="37" />
-            <source>My comics path</source>
-            <translation>내 만화 경로</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="57" />
-            <source>Display</source>
-            <translation>표시</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="59" />
-            <source>Show time in current page information label</source>
-            <translation>현재 페이지 정보 라벨에 시간 표시</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="65" />
-            <source>"Go to flow" size</source>
-            <translation>페이지 흐름 크기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="83" />
-            <source>Background color</source>
-            <translation>배경색</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="86" />
-            <source>Choose</source>
-            <translation>선택</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="95" />
-            <source>Scroll behaviour</source>
-            <translation>스크롤 동작</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="98" />
-            <source>Disable scroll animations and smooth scrolling</source>
-            <translation>스크롤 애니메이션과 부드러운 스크롤 끄기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="99" />
-            <source>Do not turn page using scroll</source>
-            <translation>스크롤로 페이지 넘기지 않기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="100" />
-            <source>Use single scroll step to turn page</source>
-            <translation>한 단계 스크롤로 페이지 넘기기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="108" />
-            <source>Mouse mode</source>
-            <translation>마우스 모드</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="111" />
-            <source>Only Back/Forward buttons can turn pages</source>
-            <translation>뒤로/앞으로 버튼만 페이지 넘김</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="112" />
-            <source>Use the Left/Right buttons to turn pages.</source>
-            <translation>왼쪽/오른쪽 버튼으로 페이지 넘김.</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="113" />
-            <source>Click left or right half of the screen to turn pages.</source>
-            <translation>화면 왼쪽 또는 오른쪽 절반을 클릭하여 페이지 넘김.</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="139" />
-            <source>Quick Navigation Mode</source>
-            <translation>빠른 탐색 모드</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="140" />
-            <source>Disable mouse over activation</source>
-            <translation>마우스 오버 활성화 끄기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="177" />
-            <source>Brightness</source>
-            <translation>밝기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="178" />
-            <source>Contrast</source>
-            <translation>대비</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="179" />
-            <source>Gamma</source>
-            <translation>감마</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="183" />
-            <source>Reset</source>
-            <translation>초기화</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="188" />
-            <source>Image options</source>
-            <translation>이미지 옵션</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="192" />
-            <source>Fit options</source>
-            <translation>맞춤 옵션</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="194" />
-            <source>Enlarge images to fit width/height</source>
-            <translation>작은 그림도 꽉차게 보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="205" />
-            <source>Double Page options</source>
-            <translation>두 페이지 옵션</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="207" />
-            <source>Show covers as single page</source>
-            <translation>표지를 한 장으로 표시</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="218" />
-            <source>Scaling</source>
-            <translation>스케일링</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="220" />
-            <source>Scaling method</source>
-            <translation>스케일링 방법</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="222" />
-            <source>Nearest (fast, low quality)</source>
-            <translation>빠른 모드 (빠름, 저화질)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="223" />
-            <source>Bilinear</source>
-            <translation>보통 모드 (중간 품질)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="224" />
-            <source>Lanczos (better quality)</source>
-            <translation>고화질 모드 (더 좋은 화질)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="254" />
-            <source>Page Flow</source>
-            <translation>페이지 플로우</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="255" />
-            <source>Image adjustment</source>
-            <translation>이미지 조정</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="35" />
-            <location filename="../YACReader/options_dialog.cpp" line="262" />
-            <source>Restart is needed</source>
-            <translation>재시작이 필요합니다</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="285" />
-            <source>Comics directory</source>
-            <translation>만화 폴더</translation>
-        </message>
-    </context>
-    <context>
-        <name>PropertiesDialog</name>
-        <message>
-            <location filename="properties_dialog.cpp" line="88" />
-            <source>General info</source>
-            <translation>일반 정보</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="90" />
-            <source>Authors</source>
-            <translation>작가진</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="91" />
-            <source>Publishing</source>
-            <translation>출판</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="89" />
-            <source>Plot</source>
-            <translation>줄거리</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="92" />
-            <source>Notes</source>
-            <translation>메모</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="101" />
-            <source>Cover page</source>
-            <translation>표지 페이지</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="110" />
-            <source>Load previous page as cover</source>
-            <translation>이전 페이지를 표지로 불러오기</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="114" />
-            <source>Load next page as cover</source>
-            <translation>다음 페이지를 표지로 불러오기</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="119" />
-            <source>Reset cover to the default image</source>
-            <translation>표지를 기본 이미지로 초기화</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="124" />
-            <source>Load custom cover image</source>
-            <translation>사용자 지정 표지 이미지 불러오기</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="168" />
-            <source>Series:</source>
-            <translation>시리즈:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="169" />
-            <source>Title:</source>
-            <translation>제목:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="173" />
-            <location filename="properties_dialog.cpp" line="187" />
-            <location filename="properties_dialog.cpp" line="198" />
-            <source>of:</source>
-            <translation> / </translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="178" />
-            <source>Issue number:</source>
-            <translation>이슈 번호:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="180" />
-            <source>Volume:</source>
-            <translation>볼륨:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="185" />
-            <source>Arc number:</source>
-            <translation>아크 번호:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="191" />
-            <source>Story arc:</source>
-            <translation>스토리 아크:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="196" />
-            <source>alt. number:</source>
-            <translation>대체 번호:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="202" />
-            <source>Alternate series:</source>
-            <translation>대체 시리즈:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="204" />
-            <source>Series Group:</source>
-            <translation>시리즈 그룹:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="206" />
-            <source>Genre:</source>
-            <translation>장르:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="208" />
-            <source>Size:</source>
-            <translation>크기:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="228" />
-            <source>Writer(s):</source>
-            <translation>글:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="231" />
-            <source>Penciller(s):</source>
-            <translation>밑그림:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="238" />
-            <source>Inker(s):</source>
-            <translation>펜선:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="241" />
-            <source>Colorist(s):</source>
-            <translation>채색:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="248" />
-            <source>Letterer(s):</source>
-            <translation>식자:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="251" />
-            <source>Cover Artist(s):</source>
-            <translation>표지 그림:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="258" />
-            <source>Editor(s):</source>
-            <translation>편집:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="261" />
-            <source>Imprint:</source>
-            <translation>임프린트:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="282" />
-            <source>Day:</source>
-            <translation>일:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="286" />
-            <source>Month:</source>
-            <translation>월:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="290" />
-            <source>Year:</source>
-            <translation>연도:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="298" />
-            <source>Publisher:</source>
-            <translation>출판사:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="299" />
-            <source>Format:</source>
-            <translation>형식:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="300" />
-            <source>Color/BW:</source>
-            <translation>컬러/흑백:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="301" />
-            <source>Age rating:</source>
-            <translation>연령 등급:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="302" />
-            <source>Type:</source>
-            <translation>유형:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="303" />
-            <source>Language (ISO):</source>
-            <translation>언어 (ISO):</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="324" />
-            <source>Synopsis:</source>
-            <translation>줄거리:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="331" />
-            <source>Characters:</source>
-            <translation>등장인물:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="334" />
-            <source>Teams:</source>
-            <translation>팀:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="340" />
-            <source>Locations:</source>
-            <translation>장소:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="346" />
-            <source>Main character or team:</source>
-            <translation>주요 등장인물 또는 팀:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="368" />
-            <source>Review:</source>
-            <translation>리뷰:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="369" />
-            <source>Notes:</source>
-            <translation>메모:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="370" />
-            <source>Tags:</source>
-            <translation>태그:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="468" />
-            <source>Comic Vine link: &lt;a style='color: #FFCB00; text-decoration:none; font-weight:bold;' href="http://www.comicvine.com/comic/4000-%1/"&gt; view &lt;/a&gt;</source>
-            <translation>Comic Vine 링크: &lt;a style='color: #FFCB00; text-decoration:none; font-weight:bold;' href="http://www.comicvine.com/comic/4000-%1/"&gt; 보기 &lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="488" />
-            <source>Not found</source>
-            <translation>찾을 수 없음</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="488" />
-            <source>Comic not found. You should update your library.</source>
-            <translation>만화를 찾을 수 없습니다. 라이브러리를 업데이트하세요.</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="623" />
-            <source>Edit selected comics information</source>
-            <translation>선택한 만화 정보 편집</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="1241" />
-            <source>Invalid cover</source>
-            <translation>잘못된 표지</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="1241" />
-            <source>The image is invalid.</source>
-            <translation>이미지가 유효하지 않습니다.</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="585" />
-            <source>Edit comic information</source>
-            <translation>만화 정보 편집</translation>
-        </message>
-    </context>
-    <context>
-        <name>QCoreApplication</name>
-        <message>
-            <location filename="../YACReaderLibraryServer/main.cpp" line="82" />
-            <source>
-YACReaderLibraryServer is the headless (no gui) version of YACReaderLibrary.
-
-This appplication supports persistent settings, to set them up edit this file %1
-To learn about the available settings please check the documentation at https://raw.githubusercontent.com/YACReader/yacreader/develop/YACReaderLibraryServer/SETTINGS_README.md</source>
-            <translation>
-YACReaderLibraryServer는 YACReaderLibrary의 헤드리스(GUI 없는) 버전입니다.
-
-이 응용 프로그램은 영구 설정을 지원합니다. 설정을 변경하려면 다음 파일을 편집하세요: %1
-사용 가능한 설정 문서는 다음에서 확인할 수 있습니다: https://raw.githubusercontent.com/YACReader/yacreader/develop/YACReaderLibraryServer/SETTINGS_README.md</translation>
-        </message>
-    </context>
-    <context>
-        <name>QObject</name>
-        <message>
-            <location filename="../common/exit_check.cpp" line="13" />
-            <source>7z lib not found</source>
-            <translation>7z 라이브러리를 찾을 수 없습니다</translation>
-        </message>
-        <message>
-            <location filename="../common/exit_check.cpp" line="13" />
-            <source>unable to load 7z lib from ./utils</source>
-            <translation>./utils에서 7z 라이브러리를 불러올 수 없습니다</translation>
-        </message>
-        <message>
-            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41" />
-            <source>Trace</source>
-            <translation>추적</translation>
-        </message>
-        <message>
-            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43" />
-            <source>Debug</source>
-            <translation>디버그</translation>
-        </message>
-        <message>
-            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45" />
-            <source>Info</source>
-            <translation>정보</translation>
-        </message>
-        <message>
-            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47" />
-            <source>Warning</source>
-            <translation>경고</translation>
-        </message>
-        <message>
-            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49" />
-            <source>Error</source>
-            <translation>오류</translation>
-        </message>
-        <message>
-            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51" />
-            <source>Fatal</source>
-            <translation>치명적 오류</translation>
-        </message>
-        <message>
-            <location filename="../common/yacreader_global_gui.cpp" line="94" />
-            <source>Select custom cover</source>
-            <translation>사용자 지정 표지 선택</translation>
-        </message>
-        <message>
-            <location filename="../common/yacreader_global_gui.cpp" line="94" />
-            <source>Images (%1)</source>
-            <translation>이미지 (%1)</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_repository.cpp" line="113" />
-            <source>The file could not be read or is not valid JSON.</source>
-            <translation>파일을 읽을 수 없거나 유효한 JSON이 아닙니다.</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_repository.cpp" line="122" />
-            <source>This theme is for %1, not %2.</source>
-            <translation>이 테마는 %2가 아닌 %1용입니다.</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_sidebar.cpp" line="149" />
-            <source>Libraries</source>
-            <translation>라이브러리</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_sidebar.cpp" line="150" />
-            <source>Folders</source>
-            <translation>폴더</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_sidebar.cpp" line="151" />
-            <source>Reading Lists</source>
-            <translation>읽기 목록</translation>
-        </message>
-    </context>
-    <context>
-        <name>RenameLibraryDialog</name>
-        <message>
-            <location filename="rename_library_dialog.cpp" line="49" />
-            <source>Rename current library</source>
-            <translation>현재 라이브러리 이름 변경</translation>
-        </message>
-        <message>
-            <location filename="rename_library_dialog.cpp" line="24" />
-            <source>Cancel</source>
-            <translation>취소</translation>
-        </message>
-        <message>
-            <location filename="rename_library_dialog.cpp" line="20" />
-            <source>Rename</source>
-            <translation>이름 변경</translation>
-        </message>
-        <message>
-            <location filename="rename_library_dialog.cpp" line="15" />
-            <source>New Library Name : </source>
-            <translation>새 라이브러리 이름: </translation>
-        </message>
-    </context>
-    <context>
-        <name>ScraperResultsPaginator</name>
-        <message>
-            <location filename="comic_vine/scraper_results_paginator.cpp" line="19" />
-            <source>Number of volumes found : %1</source>
-            <translation>검색된 볼륨 수 : %1</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/scraper_results_paginator.cpp" line="20" />
-            <location filename="comic_vine/scraper_results_paginator.cpp" line="44" />
-            <source>page %1 of %2</source>
-            <translation>%1 / %2 페이지</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/scraper_results_paginator.cpp" line="43" />
-            <source>Number of %1 found : %2</source>
-            <translation>검색된 %1 수 : %2</translation>
-        </message>
-    </context>
-    <context>
-        <name>SearchSingleComic</name>
-        <message>
-            <location filename="comic_vine/search_single_comic.cpp" line="14" />
-            <source>Please provide some additional information for this comic.</source>
-            <oldsource>Please provide some additional information.</oldsource>
-            <translation>이 만화에 대한 추가 정보를 입력하세요.</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/search_single_comic.cpp" line="18" />
-            <source>Series:</source>
-            <translation>시리즈:</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/search_single_comic.cpp" line="21" />
-            <source>Use exact match search. Disable if you want to find volumes that match some of the words in the name.</source>
-            <translation>정확히 일치 검색을 사용합니다. 이름의 일부 단어와 일치하는 볼륨을 찾으려면 비활성화하세요.</translation>
-        </message>
-    </context>
-    <context>
-        <name>SearchVolume</name>
-        <message>
-            <location filename="comic_vine/search_volume.cpp" line="12" />
-            <source>Please provide some additional information.</source>
-            <translation>추가 정보를 입력하세요.</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/search_volume.cpp" line="14" />
-            <source>Series:</source>
-            <translation>시리즈:</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/search_volume.cpp" line="17" />
-            <source>Use exact match search. Disable if you want to find volumes that match some of the words in the name.</source>
-            <translation>정확히 일치 검색을 사용합니다. 이름의 일부 단어와 일치하는 볼륨을 찾으려면 비활성화하세요.</translation>
-        </message>
-    </context>
-    <context>
-        <name>SelectComic</name>
-        <message>
-            <location filename="comic_vine/select_comic.cpp" line="16" />
-            <source>Please, select the right comic info.</source>
-            <translation>맞는 만화 정보를 선택하세요.</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/select_comic.cpp" line="37" />
-            <source>comics</source>
-            <translation>만화</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/select_comic.cpp" line="106" />
-            <source>loading cover</source>
-            <translation>표지 불러오는 중</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/select_comic.cpp" line="107" />
-            <source>loading description</source>
-            <translation>설명 불러오는 중</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/select_comic.cpp" line="157" />
-            <source>comic description unavailable</source>
-            <translation>만화 설명을 사용할 수 없음</translation>
-        </message>
-    </context>
-    <context>
-        <name>SelectVolume</name>
-        <message>
-            <location filename="comic_vine/select_volume.cpp" line="35" />
-            <source>Please, select the right series for your comic.</source>
-            <translation>만화에 맞는 시리즈를 선택하세요.</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/select_volume.cpp" line="54" />
-            <source>Filter:</source>
-            <translation>필터:</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/select_volume.cpp" line="65" />
-            <source>volumes</source>
-            <translation>볼륨</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/select_volume.cpp" line="148" />
-            <source>Nothing found, clear the filter if any.</source>
-            <translation>검색 결과 없음. 필터가 있으면 초기화하세요.</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/select_volume.cpp" line="154" />
-            <source>loading cover</source>
-            <translation>표지 불러오는 중</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/select_volume.cpp" line="155" />
-            <source>loading description</source>
-            <translation>설명 불러오는 중</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/select_volume.cpp" line="207" />
-            <source>volume description unavailable</source>
-            <translation>볼륨 설명을 사용할 수 없음</translation>
-        </message>
-    </context>
-    <context>
-        <name>SeriesQuestion</name>
-        <message>
-            <location filename="comic_vine/series_question.cpp" line="12" />
-            <source>You are trying to get information for various comics at once, are they part of the same series?</source>
-            <translation>여러 만화의 정보를 한 번에 가져오려고 합니다. 같은 시리즈에 속하는 만화입니까?</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/series_question.cpp" line="13" />
-            <source>yes</source>
-            <translation>예</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/series_question.cpp" line="14" />
-            <source>no</source>
-            <translation>아니오</translation>
-        </message>
-    </context>
-    <context>
-        <name>ServerConfigDialog</name>
-        <message>
-            <location filename="server_config_dialog.cpp" line="27" />
-            <source>set port</source>
-            <translation>포트 설정</translation>
-        </message>
-        <message>
-            <location filename="server_config_dialog.cpp" line="34" />
-            <source>Server connectivity information</source>
-            <translation>서버 연결 정보</translation>
-        </message>
-        <message>
-            <location filename="server_config_dialog.cpp" line="37" />
-            <source>Scan it!</source>
-            <translation>스캔하세요!</translation>
-        </message>
-        <message>
-            <location filename="server_config_dialog.cpp" line="42" />
-            <source>YACReader is available for iOS and Android devices.&lt;br/&gt;Discover it for &lt;a href='https://ios.yacreader.com' style='color:rgb(193, 148, 65)'&gt;iOS&lt;/a&gt; or &lt;a href='https://android.yacreader.com' style='color:rgb(193, 148, 65)'&gt;Android&lt;/a&gt;.</source>
-            <translation>YACReader는 iOS와 Android 기기에서도 사용할 수 있습니다.&lt;br/&gt;&lt;a href='https://ios.yacreader.com' style='color:rgb(193, 148, 65)'&gt;iOS&lt;/a&gt; 또는 &lt;a href='https://android.yacreader.com' style='color:rgb(193, 148, 65)'&gt;Android&lt;/a&gt;에서 확인하세요.</translation>
-        </message>
-        <message>
-            <location filename="server_config_dialog.cpp" line="48" />
-            <source>Choose an IP address</source>
-            <translation>IP 주소 선택</translation>
-        </message>
-        <message>
-            <location filename="server_config_dialog.cpp" line="51" />
-            <source>Port</source>
-            <translation>포트</translation>
-        </message>
-        <message>
-            <location filename="server_config_dialog.cpp" line="83" />
-            <source>enable the server</source>
-            <translation>서버 사용</translation>
-        </message>
-    </context>
-    <context>
-        <name>SortVolumeComics</name>
-        <message>
-            <location filename="comic_vine/sort_volume_comics.cpp" line="59" />
-            <source>Please, sort the list of comics on the left until it matches the comics' information.</source>
-            <translation>왼쪽의 만화 목록을 만화 정보와 일치할 때까지 정렬하세요.</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/sort_volume_comics.cpp" line="61" />
-            <source>sort comics to match comic information</source>
-            <translation>만화 정보에 맞게 정렬</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/sort_volume_comics.cpp" line="98" />
-            <source>issues</source>
-            <translation>이슈</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/sort_volume_comics.cpp" line="126" />
-            <source>remove selected comics</source>
-            <translation>선택한 만화 제거</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/sort_volume_comics.cpp" line="127" />
-            <source>restore all removed comics</source>
-            <translation>제거한 만화 모두 복원</translation>
-        </message>
-    </context>
-    <context>
-        <name>ThemeEditorDialog</name>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="65" />
-            <source>Theme Editor</source>
-            <translation>테마 편집기</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="69" />
-            <source>+</source>
-            <translation>+</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="70" />
-            <source>-</source>
-            <translation>-</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="71" />
-            <source>i</source>
-            <translation>i</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="75" />
-            <source>Expand all</source>
-            <translation>모두 펼치기</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="76" />
-            <source>Collapse all</source>
-            <translation>모두 접기</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="77" />
-            <source>Hold to flash the selected value in the UI (magenta / toggled / 0↔10). Releases restore the original.</source>
-            <translation>누르고 있으면 UI에서 선택한 값이 깜박입니다 (마젠타 / 토글 / 0↔10). 놓으면 원래대로 돌아갑니다.</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="82" />
-            <source>Search…</source>
-            <translation>검색…</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="100" />
-            <source>Light</source>
-            <translation>밝은</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="101" />
-            <source>Dark</source>
-            <translation>어두운</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="104" />
-            <source>ID:</source>
-            <translation>ID:</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="105" />
-            <source>Display name:</source>
-            <translation>표시 이름:</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="106" />
-            <source>Variant:</source>
-            <translation>변형:</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="108" />
-            <source>Theme info</source>
-            <translation>테마 정보</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="129" />
-            <source>Parameter</source>
-            <translation>매개변수</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="129" />
-            <source>Value</source>
-            <translation>값</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="153" />
-            <source>Save and apply</source>
-            <translation>저장 후 적용</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="154" />
-            <source>Export to file...</source>
-            <translation>파일로 내보내기...</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="155" />
-            <source>Load from file...</source>
-            <translation>파일에서 불러오기...</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="156" />
-            <source>Close</source>
-            <translation>닫기</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="213" />
-            <source>Double-click to edit color</source>
-            <translation>두 번 클릭하여 색 편집</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="215" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="267" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="268" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="462" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="467" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="498" />
-            <source>true</source>
-            <translation>true</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="215" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="268" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="467" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="498" />
-            <source>false</source>
-            <translation>false</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="218" />
-            <source>Double-click to toggle</source>
-            <translation>두 번 클릭하여 전환</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="222" />
-            <source>Double-click to edit value</source>
-            <translation>두 번 클릭하여 값 편집</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="236" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="283" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="288" />
-            <source>Edit: %1</source>
-            <translation>편집: %1</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="402" />
-            <source>Save theme</source>
-            <translation>테마 저장</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="402" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="417" />
-            <source>JSON files (*.json);;All files (*)</source>
-            <translation>JSON 파일 (*.json);;모든 파일 (*)</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="408" />
-            <source>Save failed</source>
-            <translation>저장 실패</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="408" />
-            <source>Could not open file for writing:
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="289"/>
+        <source>Import failed</source>
+        <translation>가져오기 실패</translation>
+    </message>
+</context>
+<context>
+    <name>BookmarksDialog</name>
+    <message>
+        <location filename="bookmarks_dialog.cpp" line="27"/>
+        <source>Lastest Page</source>
+        <translation>마지막 페이지</translation>
+    </message>
+    <message>
+        <location filename="bookmarks_dialog.cpp" line="77"/>
+        <source>Close</source>
+        <translation>닫기</translation>
+    </message>
+    <message>
+        <location filename="bookmarks_dialog.cpp" line="87"/>
+        <source>Click on any image to go to the bookmark</source>
+        <translation>이미지를 클릭하면 책갈피로 이동합니다</translation>
+    </message>
+    <message>
+        <location filename="bookmarks_dialog.cpp" line="109"/>
+        <location filename="bookmarks_dialog.cpp" line="126"/>
+        <source>Loading...</source>
+        <translation>불러오는 중...</translation>
+    </message>
+</context>
+<context>
+    <name>ContinuousPageWidget</name>
+    <message>
+        <location filename="continuous_page_widget.cpp" line="157"/>
+        <source>Loading page %1</source>
+        <translation>페이지 %1 불러오는 중</translation>
+    </message>
+</context>
+<context>
+    <name>EditShortcutsDialog</name>
+    <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="19"/>
+        <source>Restore defaults</source>
+        <translation>기본값으로 복원</translation>
+    </message>
+    <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="20"/>
+        <source>To change a shortcut, double click in the key combination and type the new keys.</source>
+        <translation>단축키를 바꾸려면 키 조합을 더블 클릭하고 새 키를 입력하세요.</translation>
+    </message>
+    <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="67"/>
+        <source>Shortcuts settings</source>
+        <translation>단축키 설정</translation>
+    </message>
+    <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="118"/>
+        <source>Shortcut in use</source>
+        <translation>사용 중인 단축키</translation>
+    </message>
+    <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="118"/>
+        <source>The shortcut &quot;%1&quot; is already assigned to other function</source>
+        <translation>&quot;%1&quot; 단축키는 이미 다른 기능이 사용 중입니다</translation>
+    </message>
+</context>
+<context>
+    <name>FileComic</name>
+    <message>
+        <location filename="../common/comic.cpp" line="564"/>
+        <source>7z not found</source>
+        <translation>7z를 찾을 수 없습니다</translation>
+    </message>
+    <message>
+        <location filename="../common/comic.cpp" line="456"/>
+        <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
+        <translation>%1번 페이지에서 CRC 오류 발생: 일부 페이지가 올바르게 표시되지 않을 수 있습니다</translation>
+    </message>
+    <message>
+        <location filename="../common/comic.cpp" line="463"/>
+        <source>Unknown error opening the file</source>
+        <translation>파일을 여는 중 알 수 없는 오류가 발생했습니다</translation>
+    </message>
+    <message>
+        <location filename="../common/comic.cpp" line="570"/>
+        <source>Format not supported</source>
+        <translation>지원하지 않는 형식입니다</translation>
+    </message>
+</context>
+<context>
+    <name>GoToDialog</name>
+    <message>
+        <location filename="goto_dialog.cpp" line="16"/>
+        <source>Page : </source>
+        <translation>페이지: </translation>
+    </message>
+    <message>
+        <location filename="goto_dialog.cpp" line="24"/>
+        <source>Go To</source>
+        <translation>이동</translation>
+    </message>
+    <message>
+        <location filename="goto_dialog.cpp" line="26"/>
+        <source>Cancel</source>
+        <translation>취소</translation>
+    </message>
+    <message>
+        <location filename="goto_dialog.cpp" line="40"/>
+        <location filename="goto_dialog.cpp" line="70"/>
+        <source>Total pages : </source>
+        <translation>전체 페이지: </translation>
+    </message>
+    <message>
+        <location filename="goto_dialog.cpp" line="52"/>
+        <source>Go to...</source>
+        <translation>이동...</translation>
+    </message>
+</context>
+<context>
+    <name>GoToFlowToolBar</name>
+    <message>
+        <location filename="goto_flow_toolbar.cpp" line="32"/>
+        <source>Page : </source>
+        <translation>페이지: </translation>
+    </message>
+</context>
+<context>
+    <name>HelpAboutDialog</name>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="22"/>
+        <source>About</source>
+        <translation>정보</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="25"/>
+        <source>Help</source>
+        <translation>도움말</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="28"/>
+        <source>System info</source>
+        <translation>시스템 정보</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsDialog</name>
+    <message>
+        <location filename="options_dialog.cpp" line="45"/>
+        <source>Language</source>
+        <translation>언어</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="47"/>
+        <source>Application language</source>
+        <translation>응용 프로그램 언어</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="49"/>
+        <source>System default</source>
+        <translation>시스템 기본값</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="88"/>
+        <source>Clear</source>
+        <translation>지우기</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="254"/>
+        <source>General</source>
+        <translation>일반</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="257"/>
+        <source>Appearance</source>
+        <translation>외관</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="272"/>
+        <source>Options</source>
+        <translation>환경설정</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="38"/>
+        <source>My comics path</source>
+        <translation>내 만화 경로</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="58"/>
+        <source>Display</source>
+        <translation>표시</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="60"/>
+        <source>Show time in current page information label</source>
+        <translation>현재 페이지 정보 라벨에 시간 표시</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="66"/>
+        <source>&quot;Go to flow&quot; size</source>
+        <translation>페이지 흐름 크기</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="84"/>
+        <source>Background color</source>
+        <translation>배경색</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="87"/>
+        <source>Choose</source>
+        <translation>선택</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="96"/>
+        <source>Scroll behaviour</source>
+        <translation>스크롤 동작</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="99"/>
+        <source>Disable scroll animations and smooth scrolling</source>
+        <translation>스크롤 애니메이션과 부드러운 스크롤 끄기</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="100"/>
+        <source>Do not turn page using scroll</source>
+        <translation>스크롤로 페이지 넘기지 않기</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="101"/>
+        <source>Use single scroll step to turn page</source>
+        <translation>한 단계 스크롤로 페이지 넘기기</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="109"/>
+        <source>Mouse mode</source>
+        <translation>마우스 모드</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="112"/>
+        <source>Only Back/Forward buttons can turn pages</source>
+        <translation>뒤로/앞으로 버튼만 페이지 넘김</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="113"/>
+        <source>Use the Left/Right buttons to turn pages.</source>
+        <translation>왼쪽/오른쪽 버튼으로 페이지 넘김.</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="114"/>
+        <source>Click left or right half of the screen to turn pages.</source>
+        <translation>화면 왼쪽 또는 오른쪽 절반을 클릭하여 페이지 넘김.</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="140"/>
+        <source>Quick Navigation Mode</source>
+        <translation>빠른 탐색 모드</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="141"/>
+        <source>Disable mouse over activation</source>
+        <translation>마우스 오버 활성화 끄기</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="178"/>
+        <source>Brightness</source>
+        <translation>밝기</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="179"/>
+        <source>Contrast</source>
+        <translation>대비</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="180"/>
+        <source>Gamma</source>
+        <translation>감마</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="184"/>
+        <source>Reset</source>
+        <translation>초기화</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="189"/>
+        <source>Image options</source>
+        <translation>이미지 옵션</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="193"/>
+        <source>Fit options</source>
+        <translation>맞춤 옵션</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="195"/>
+        <source>Enlarge images to fit width/height</source>
+        <translation>작은 그림도 꽉차게 보기</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="206"/>
+        <source>Double Page options</source>
+        <translation>두 페이지 옵션</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="208"/>
+        <source>Show covers as single page</source>
+        <translation>표지를 한 장으로 표시</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="219"/>
+        <source>Scaling</source>
+        <translation>스케일링</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="221"/>
+        <source>Scaling method</source>
+        <translation>스케일링 방법</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="223"/>
+        <source>Nearest (fast, low quality)</source>
+        <translation>빠른 모드 (빠름, 저화질)</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="224"/>
+        <source>Bilinear</source>
+        <translation>보통 모드 (중간 품질)</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="225"/>
+        <source>Lanczos (better quality)</source>
+        <translation>고화질 모드 (더 좋은 화질)</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="255"/>
+        <source>Page Flow</source>
+        <translation>페이지 플로우</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="256"/>
+        <source>Image adjustment</source>
+        <translation>이미지 조정</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="263"/>
+        <source>Restart is needed</source>
+        <translation>재시작이 필요합니다</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="290"/>
+        <source>Comics directory</source>
+        <translation>만화 폴더</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
+        <source>7z lib not found</source>
+        <translation>7z 라이브러리를 찾을 수 없습니다</translation>
+    </message>
+    <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
+        <source>unable to load 7z lib from ./utils</source>
+        <translation>./utils에서 7z 라이브러리를 불러올 수 없습니다</translation>
+    </message>
+    <message>
+        <location filename="../common/yacreader_global_gui.cpp" line="94"/>
+        <source>Select custom cover</source>
+        <translation>사용자 지정 표지 선택</translation>
+    </message>
+    <message>
+        <location filename="../common/yacreader_global_gui.cpp" line="94"/>
+        <source>Images (%1)</source>
+        <translation>이미지 (%1)</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_repository.cpp" line="151"/>
+        <source>The file could not be read or is not valid JSON.</source>
+        <translation>파일을 읽을 수 없거나 유효한 JSON이 아닙니다.</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_repository.cpp" line="160"/>
+        <source>This theme is for %1, not %2.</source>
+        <translation>이 테마는 %2가 아닌 %1용입니다.</translation>
+    </message>
+</context>
+<context>
+    <name>ThemeEditorDialog</name>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="59"/>
+        <source>Theme Editor</source>
+        <translation>테마 편집기</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="63"/>
+        <source>+</source>
+        <translation>+</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="64"/>
+        <source>-</source>
+        <translation>-</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="65"/>
+        <source>i</source>
+        <translation>i</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="69"/>
+        <source>Expand all</source>
+        <translation>모두 펼치기</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="70"/>
+        <source>Collapse all</source>
+        <translation>모두 접기</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="71"/>
+        <source>Hold to flash the selected value in the UI (magenta / toggled / 0↔10). Releases restore the original.</source>
+        <translation>누르고 있으면 UI에서 선택한 값이 깜박입니다 (마젠타 / 토글 / 0↔10). 놓으면 원래대로 돌아갑니다.</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="76"/>
+        <source>Search…</source>
+        <translation>검색…</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="94"/>
+        <source>Light</source>
+        <translation>밝은</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="95"/>
+        <source>Dark</source>
+        <translation>어두운</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="98"/>
+        <source>ID:</source>
+        <translation>ID:</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="99"/>
+        <source>Display name:</source>
+        <translation>표시 이름:</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="100"/>
+        <source>Variant:</source>
+        <translation>변형:</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="102"/>
+        <source>Theme info</source>
+        <translation>테마 정보</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="125"/>
+        <source>Parameter</source>
+        <translation>매개변수</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="125"/>
+        <source>Value</source>
+        <translation>값</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="149"/>
+        <source>Save and apply</source>
+        <translation>저장 후 적용</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="150"/>
+        <source>Export to file...</source>
+        <translation>파일로 내보내기...</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="151"/>
+        <source>Load from file...</source>
+        <translation>파일에서 불러오기...</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="152"/>
+        <source>Close</source>
+        <translation>닫기</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="209"/>
+        <source>Double-click to edit color</source>
+        <translation>두 번 클릭하여 색 편집</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="211"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="264"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="265"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="459"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="464"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="495"/>
+        <source>true</source>
+        <translation>true</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="211"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="265"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="464"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="495"/>
+        <source>false</source>
+        <translation>false</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="214"/>
+        <source>Double-click to toggle</source>
+        <translation>두 번 클릭하여 전환</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="218"/>
+        <source>Double-click to edit value</source>
+        <translation>두 번 클릭하여 값 편집</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="232"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="280"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="285"/>
+        <source>Edit: %1</source>
+        <translation>편집: %1</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="399"/>
+        <source>Save theme</source>
+        <translation>테마 저장</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="399"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="414"/>
+        <source>JSON files (*.json);;All files (*)</source>
+        <translation>JSON 파일 (*.json);;모든 파일 (*)</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="405"/>
+        <source>Save failed</source>
+        <translation>저장 실패</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="405"/>
+        <source>Could not open file for writing:
 %1</source>
-            <translation>쓰기 위해 파일을 열 수 없습니다:
+        <translation>쓰기 위해 파일을 열 수 없습니다:
 %1</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="417" />
-            <source>Load theme</source>
-            <translation>테마 불러오기</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="423" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="430" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="434" />
-            <source>Load failed</source>
-            <translation>불러오기 실패</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="423" />
-            <source>Could not open file:
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="414"/>
+        <source>Load theme</source>
+        <translation>테마 불러오기</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="420"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="427"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="431"/>
+        <source>Load failed</source>
+        <translation>불러오기 실패</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="420"/>
+        <source>Could not open file:
 %1</source>
-            <translation>파일을 열 수 없습니다:
+        <translation>파일을 열 수 없습니다:
 %1</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="430" />
-            <source>Invalid JSON:
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="427"/>
+        <source>Invalid JSON:
 %1</source>
-            <translation>잘못된 JSON:
+        <translation>잘못된 JSON:
 %1</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="434" />
-            <source>Expected a JSON object.</source>
-            <translation>JSON 객체가 필요합니다.</translation>
-        </message>
-    </context>
-    <context>
-        <name>TitleHeader</name>
-        <message>
-            <location filename="comic_vine/title_header.cpp" line="27" />
-            <source>SEARCH</source>
-            <translation>검색</translation>
-        </message>
-    </context>
-    <context>
-        <name>UpdateLibraryDialog</name>
-        <message>
-            <location filename="create_library_dialog.cpp" line="170" />
-            <source>Cancel</source>
-            <translation>취소</translation>
-        </message>
-        <message>
-            <location filename="create_library_dialog.cpp" line="164" />
-            <source>Updating....</source>
-            <translation>업데이트 중...</translation>
-        </message>
-        <message>
-            <location filename="create_library_dialog.cpp" line="189" />
-            <source>Update library</source>
-            <translation>라이브러리 업데이트</translation>
-        </message>
-    </context>
-    <context>
-        <name>Viewer</name>
-        <message>
-            <location filename="../YACReader/viewer.cpp" line="60" />
-            <location filename="../YACReader/viewer.cpp" line="1367" />
-            <source>Press 'O' to open comic.</source>
-            <translation>'O'를 눌러 만화를 열어보세요.</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/viewer.cpp" line="262" />
-            <source>Not found</source>
-            <translation>찾을 수 없음</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/viewer.cpp" line="262" />
-            <source>Comic not found</source>
-            <translation>만화를 찾을 수 없습니다</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/viewer.cpp" line="268" />
-            <source>Error opening comic</source>
-            <translation>만화를 여는 중 오류가 발생했습니다</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/viewer.cpp" line="274" />
-            <source>CRC Error</source>
-            <translation>CRC 오류</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/viewer.cpp" line="1383" />
-            <source>Loading...please wait!</source>
-            <translation>불러오는 중... 잠시 기다려주세요!</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/viewer.cpp" line="1394" />
-            <source>Page not available!</source>
-            <translation>페이지를 불러올 수 없습니다!</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/viewer.cpp" line="1602" />
-            <source>Cover!</source>
-            <translation>표지!</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/viewer.cpp" line="1616" />
-            <source>Last page!</source>
-            <translation>마지막 페이지!</translation>
-        </message>
-    </context>
-    <context>
-        <name>VolumeComicsModel</name>
-        <message>
-            <location filename="comic_vine/model/volume_comics_model.cpp" line="120" />
-            <source>title</source>
-            <translation>제목</translation>
-        </message>
-    </context>
-    <context>
-        <name>VolumesModel</name>
-        <message>
-            <location filename="comic_vine/model/volumes_model.cpp" line="118" />
-            <source>year</source>
-            <translation>연도</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/model/volumes_model.cpp" line="120" />
-            <source>issues</source>
-            <translation>이슈</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/model/volumes_model.cpp" line="122" />
-            <source>publisher</source>
-            <translation>출판사</translation>
-        </message>
-    </context>
-    <context>
-        <name>YACReader3DFlowConfigWidget</name>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="19" />
-            <source>Presets:</source>
-            <translation>프리셋:</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="21" />
-            <source>Classic look</source>
-            <translation>클래식 스타일</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="24" />
-            <source>Stripe look</source>
-            <translation>줄무늬 스타일</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="27" />
-            <source>Overlapped Stripe look</source>
-            <translation>겹친 줄무늬 스타일</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="30" />
-            <source>Modern look</source>
-            <translation>모던 스타일</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="33" />
-            <source>Roulette look</source>
-            <translation>룰렛 스타일</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="77" />
-            <source>Show advanced settings</source>
-            <translation>고급 설정 보기</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="86" />
-            <source>Custom:</source>
-            <translation>사용자 지정:</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="89" />
-            <source>View angle</source>
-            <translation>시야각</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="95" />
-            <source>Position</source>
-            <translation>위치</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="101" />
-            <source>Cover gap</source>
-            <translation>표지 간격</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="107" />
-            <source>Central gap</source>
-            <translation>중앙 간격</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="113" />
-            <source>Zoom</source>
-            <translation>확대/축소</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="119" />
-            <source>Y offset</source>
-            <translation>Y축 오프셋</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="125" />
-            <source>Z offset</source>
-            <translation>Z축 오프셋</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="131" />
-            <source>Cover Angle</source>
-            <translation>표지 각도</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="137" />
-            <source>Visibility</source>
-            <translation>가시성</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="143" />
-            <source>Light</source>
-            <translation>조명</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="149" />
-            <source>Max angle</source>
-            <translation>최대 각도</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="181" />
-            <source>Low Performance</source>
-            <translation>저성능</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="183" />
-            <source>High Performance</source>
-            <translation>고성능</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="194" />
-            <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
-            <translation>수직 동기화 사용 (전체화면 결의 이미지 품질 향상, 성능 저하)</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="202" />
-            <source>Performance:</source>
-            <translation>성능:</translation>
-        </message>
-    </context>
-    <context>
-        <name>YACReader::MainWindowViewer</name>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="190" />
-            <source>&amp;Open</source>
-            <translation>열기(&amp;O)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="191" />
-            <source>Open a comic</source>
-            <translation>만화 열기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="197" />
-            <source>New instance</source>
-            <translation>새 창</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="216" />
-            <source>Open Folder</source>
-            <translation>폴더 열기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="217" />
-            <source>Open image folder</source>
-            <translation>이미지 폴더 열기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="222" />
-            <source>Open latest comic</source>
-            <translation>마지막 만화 열기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="223" />
-            <source>Open the latest comic opened in the previous reading session</source>
-            <translation>이전 작업에서 마지막으로 열었던 만화 열기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="235" />
-            <source>Clear</source>
-            <translation>지우기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="236" />
-            <source>Clear open recent list</source>
-            <translation>최근 목록 지우기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="239" />
-            <source>Save</source>
-            <translation>저장</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="240" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="945" />
-            <source>Save current page</source>
-            <translation>현재 페이지 저장</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="245" />
-            <source>Previous Comic</source>
-            <translation>이전 만화</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="246" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1733" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1737" />
-            <source>Open previous comic</source>
-            <translation>이전 만화 열기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="251" />
-            <source>Next Comic</source>
-            <translation>다음 만화</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="252" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1732" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1738" />
-            <source>Open next comic</source>
-            <translation>다음 만화 열기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="257" />
-            <source>&amp;Previous</source>
-            <translation>이전(&amp;P)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="259" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1735" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1739" />
-            <source>Go to previous page</source>
-            <translation>이전 페이지로 이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="264" />
-            <source>&amp;Next</source>
-            <translation>다음(&amp;N)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="266" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1734" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1740" />
-            <source>Go to next page</source>
-            <translation>다음 페이지로 이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="271" />
-            <source>Fit Height</source>
-            <translation>꽉차게 보기 (높이 맞춤)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="272" />
-            <source>Fit image to height</source>
-            <translation>이미지를 높이에 맞춤</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="278" />
-            <source>Fit Width</source>
-            <translation>꽉차게 보기 (폭 맞춤)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="279" />
-            <source>Fit image to width</source>
-            <translation>이미지를 폭에 맞춤</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="285" />
-            <source>Show full size</source>
-            <translation>원본 크기 (100%)로 보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="292" />
-            <source>Fit to page</source>
-            <translation>꽉차게 보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="298" />
-            <source>Continuous scroll</source>
-            <translation>연속 스크롤</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="299" />
-            <source>Switch to continuous scroll mode</source>
-            <translation>연속 스크롤 모드로 전환</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="331" />
-            <source>Reset zoom</source>
-            <translation>확대/축소 초기화</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="336" />
-            <source>Show zoom slider</source>
-            <translation>확대/축소 슬라이더 보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="338" />
-            <source>Zoom+</source>
-            <translation>확대+</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="343" />
-            <source>Zoom-</source>
-            <translation>축소-</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="348" />
-            <source>Rotate image to the left</source>
-            <translation>이미지 왼쪽으로 회전</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="353" />
-            <source>Rotate image to the right</source>
-            <translation>이미지 오른쪽으로 회전</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="358" />
-            <source>Double page mode</source>
-            <translation>두 페이지씩 보기 (왼쪽 → 오른쪽)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="359" />
-            <source>Switch to double page mode</source>
-            <translation>두 페이지씩 보기로 전환</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="367" />
-            <source>Double page manga mode</source>
-            <translation>두 페이지씩 보기 (왼쪽 ← 오른쪽)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="368" />
-            <source>Reverse reading order in double page mode</source>
-            <translation>두 페이지씩 보기에서 읽기 순서 뒤집기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="376" />
-            <source>Go To</source>
-            <translation>이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="377" />
-            <source>Go to page ...</source>
-            <translation>페이지로 이동...</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="382" />
-            <source>Options</source>
-            <translation>환경설정</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="383" />
-            <source>YACReader options</source>
-            <translation>YACReader 환경설정</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="389" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="684" />
-            <source>Help</source>
-            <translation>도움말</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="390" />
-            <source>Help, About YACReader</source>
-            <translation>도움말, YACReader 정보</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="395" />
-            <source>Magnifying glass</source>
-            <translation>돋보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="396" />
-            <source>Switch Magnifying glass</source>
-            <translation>돋보기 전환</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="402" />
-            <source>Set bookmark</source>
-            <translation>책갈피 설정</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="403" />
-            <source>Set a bookmark on the current page</source>
-            <translation>현재 페이지에 책갈피 설정</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="411" />
-            <source>Show bookmarks</source>
-            <translation>책갈피 보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="412" />
-            <source>Show the bookmarks of the current comic</source>
-            <translation>현재 만화의 책갈피 보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="417" />
-            <source>Show keyboard shortcuts</source>
-            <translation>키보드 단축키 보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="422" />
-            <source>Show Info</source>
-            <translation>정보 보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="427" />
-            <source>Close</source>
-            <translation>닫기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="432" />
-            <source>Show Dictionary</source>
-            <translation>사전 보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="438" />
-            <source>Show go to flow</source>
-            <translation>페이지 흐름 보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="443" />
-            <source>Edit shortcuts</source>
-            <translation>단축키 편집</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="464" />
-            <source>&amp;File</source>
-            <translation>파일(&amp;F)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="479" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="638" />
-            <source>Open recent</source>
-            <translation>최근 항목 열기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="627" />
-            <source>File</source>
-            <translation>파일</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="648" />
-            <source>Edit</source>
-            <translation>편집</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="652" />
-            <source>View</source>
-            <translation>보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="669" />
-            <source>Go</source>
-            <translation>이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="677" />
-            <source>Window</source>
-            <translation>창</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="794" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="796" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="798" />
-            <source>Open Comic</source>
-            <translation>만화 열기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="794" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="796" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="798" />
-            <source>Comic files</source>
-            <translation>만화 파일</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="889" />
-            <source>Open folder</source>
-            <translation>폴더 열기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="945" />
-            <source>page_%1.jpg</source>
-            <translation>page_%1.jpg</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="945" />
-            <source>Image files (*.jpg)</source>
-            <translation>이미지 파일 (*.jpg)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1151" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1164" />
-            <source>Comics</source>
-            <translation>만화</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1152" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1180" />
-            <source>General</source>
-            <translation>일반</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1153" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1218" />
-            <source>Magnifiying glass</source>
-            <translation>돋보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1154" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1229" />
-            <source>Page adjustement</source>
-            <translation>페이지 조정</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1155" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1307" />
-            <source>Reading</source>
-            <translation>읽기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1174" />
-            <source>Toggle fullscreen mode</source>
-            <translation>전체화면 전환</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1177" />
-            <source>Hide/show toolbar</source>
-            <translation>도구 모음 표시/숨김</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1199" />
-            <source>Size up magnifying glass</source>
-            <translation>돋보기 크게</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1202" />
-            <source>Size down magnifying glass</source>
-            <translation>돋보기 작게</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1205" />
-            <source>Zoom in magnifying glass</source>
-            <translation>돋보기 확대</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1208" />
-            <source>Zoom out magnifying glass</source>
-            <translation>돋보기 축소</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1211" />
-            <source>Reset magnifying glass</source>
-            <translation>돋보기 초기화</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1225" />
-            <source>Toggle between fit to width and fit to height</source>
-            <translation>폭 맞춤 / 높이 맞춤 전환</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1247" />
-            <source>Autoscroll down</source>
-            <translation>아래로 자동 스크롤</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1250" />
-            <source>Autoscroll up</source>
-            <translation>위로 자동 스크롤</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1253" />
-            <source>Autoscroll forward, horizontal first</source>
-            <translation>세로 우선으로 정방향 자동 스크롤</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1257" />
-            <source>Autoscroll backward, horizontal first</source>
-            <translation>가로 우선으로 정방향 자동 스크롤</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1261" />
-            <source>Autoscroll forward, vertical first</source>
-            <translation>세로 우선으로 역방향 자동 스크롤</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1265" />
-            <source>Autoscroll backward, vertical first</source>
-            <translation>가로 우선으로 역방향 자동 스크롤</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1269" />
-            <source>Move down</source>
-            <translation>아래로 이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1272" />
-            <source>Move up</source>
-            <translation>위로 이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1275" />
-            <source>Move left</source>
-            <translation>왼쪽으로 이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1278" />
-            <source>Move right</source>
-            <translation>오른쪽으로 이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1281" />
-            <source>Go to the first page</source>
-            <translation>첫 페이지로 이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1284" />
-            <source>Go to the last page</source>
-            <translation>마지막 페이지로 이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1287" />
-            <source>Offset double page to the left</source>
-            <translation>두 페이지 왼쪽으로 이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1289" />
-            <source>Offset double page to the right</source>
-            <translation>두 페이지 오른쪽으로 이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1356" />
-            <source>There is a new version available</source>
-            <translation>새 버전을 내려받으시겠습니까?</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1357" />
-            <source>Do you want to download the new version?</source>
-            <translation>새 버전을 내려받으시겠습니까?</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1360" />
-            <source>Remind me in 14 days</source>
-            <translation>14일 후에 다시 알림</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1361" />
-            <source>Not now</source>
-            <translation>나중에</translation>
-        </message>
-    </context>
-    <context>
-        <name>YACReader::TrayIconController</name>
-        <message>
-            <location filename="trayicon_controller.cpp" line="52" />
-            <source>&amp;Restore</source>
-            <translation>복원(&amp;R)</translation>
-        </message>
-        <message>
-            <location filename="trayicon_controller.cpp" line="79" />
-            <source>Systray</source>
-            <translation>시스템 트레이</translation>
-        </message>
-        <message>
-            <location filename="trayicon_controller.cpp" line="80" />
-            <source>YACReaderLibrary will keep running in the system tray. To terminate the program, choose &lt;b&gt;Quit&lt;/b&gt; in the context menu of the system tray icon.</source>
-            <translation>YACReaderLibrary는 시스템 트레이에서 계속 실행됩니다. 프로그램을 종료하려면 시스템 트레이 아이콘의 컨텍스트 메뉴에서 &lt;b&gt;끝내기&lt;/b&gt;를 선택하세요.</translation>
-        </message>
-    </context>
-    <context>
-        <name>YACReaderFieldEdit</name>
-        <message>
-            <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9" />
-            <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28" />
-            <source>Click to overwrite</source>
-            <translation>클릭해서 덮어쓰기</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11" />
-            <source>Restore to default</source>
-            <translation>기본값으로 복원</translation>
-        </message>
-    </context>
-    <context>
-        <name>YACReaderFieldPlainTextEdit</name>
-        <message>
-            <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9" />
-            <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19" />
-            <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44" />
-            <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50" />
-            <source>Click to overwrite</source>
-            <translation>클릭해서 덮어쓰기</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10" />
-            <source>Restore to default</source>
-            <translation>기본값으로 복원</translation>
-        </message>
-    </context>
-    <context>
-        <name>YACReaderFlowConfigWidget</name>
-        <message>
-            <source>CoverFlow look</source>
-            <translation type="vanished">코버플로 스타일</translation>
-        </message>
-        <message>
-            <source>How to show covers:</source>
-            <translation type="vanished">표지 표시 방식:</translation>
-        </message>
-        <message>
-            <source>Stripe look</source>
-            <translation type="vanished">줄무늬 스타일</translation>
-        </message>
-        <message>
-            <source>Overlapped Stripe look</source>
-            <translation type="vanished">겹친 줄무늬 스타일</translation>
-        </message>
-    </context>
-    <context>
-        <name>YACReaderGLFlowConfigWidget</name>
-        <message>
-            <source>Stripe look</source>
-            <translation type="vanished">줄무늬 스타일</translation>
-        </message>
-        <message>
-            <source>Overlapped Stripe look</source>
-            <translation type="vanished">겹친 줄무늬 스타일</translation>
-        </message>
-    </context>
-    <context>
-        <name>YACReaderOptionsDialog</name>
-        <message>
-            <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="19" />
-            <source>Save</source>
-            <translation>저장</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="20" />
-            <source>Cancel</source>
-            <translation>취소</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="25" />
-            <source>Edit shortcuts</source>
-            <translation>단축키 편집</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28" />
-            <source>Shortcuts</source>
-            <translation>단축키</translation>
-        </message>
-    </context>
-    <context>
-        <name>YACReaderSearchLineEdit</name>
-        <message>
-            <location filename="../custom_widgets/yacreader_search_line_edit.cpp" line="31" />
-            <source>type to search</source>
-            <translation>검색어 입력</translation>
-        </message>
-    </context>
-    <context>
-        <name>YACReaderSlider</name>
-        <message>
-            <location filename="../YACReader/width_slider.cpp" line="49" />
-            <source>Reset</source>
-            <translation>초기화</translation>
-        </message>
-    </context>
-    <context>
-        <name>YACReaderTranslator</name>
-        <message>
-            <location filename="../YACReader/translator.cpp" line="42" />
-            <source>YACReader translator</source>
-            <translation>YACReader 번역기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/translator.cpp" line="82" />
-            <location filename="../YACReader/translator.cpp" line="188" />
-            <source>Translation</source>
-            <translation>번역</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/translator.cpp" line="102" />
-            <source>clear</source>
-            <translation>지우기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/translator.cpp" line="197" />
-            <source>Service not available</source>
-            <translation>서비스를 사용할 수 없습니다</translation>
-        </message>
-    </context>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="431"/>
+        <source>Expected a JSON object.</source>
+        <translation>JSON 객체가 필요합니다.</translation>
+    </message>
+</context>
+<context>
+    <name>Viewer</name>
+    <message>
+        <location filename="viewer.cpp" line="60"/>
+        <location filename="viewer.cpp" line="1407"/>
+        <source>Press &apos;O&apos; to open comic.</source>
+        <translation>&apos;O&apos;를 눌러 만화를 열어보세요.</translation>
+    </message>
+    <message>
+        <location filename="viewer.cpp" line="262"/>
+        <source>Not found</source>
+        <translation>찾을 수 없음</translation>
+    </message>
+    <message>
+        <location filename="viewer.cpp" line="262"/>
+        <source>Comic not found</source>
+        <translation>만화를 찾을 수 없습니다</translation>
+    </message>
+    <message>
+        <location filename="viewer.cpp" line="268"/>
+        <source>Error opening comic</source>
+        <translation>만화를 여는 중 오류가 발생했습니다</translation>
+    </message>
+    <message>
+        <location filename="viewer.cpp" line="274"/>
+        <source>CRC Error</source>
+        <translation>CRC 오류</translation>
+    </message>
+    <message>
+        <location filename="viewer.cpp" line="1423"/>
+        <source>Loading...please wait!</source>
+        <translation>불러오는 중... 잠시 기다려주세요!</translation>
+    </message>
+    <message>
+        <location filename="viewer.cpp" line="1434"/>
+        <source>Page not available!</source>
+        <translation>페이지를 불러올 수 없습니다!</translation>
+    </message>
+    <message>
+        <location filename="viewer.cpp" line="1642"/>
+        <source>Cover!</source>
+        <translation>표지!</translation>
+    </message>
+    <message>
+        <location filename="viewer.cpp" line="1656"/>
+        <source>Last page!</source>
+        <translation>마지막 페이지!</translation>
+    </message>
+</context>
+<context>
+    <name>YACReader3DFlowConfigWidget</name>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="19"/>
+        <source>Presets:</source>
+        <translation>프리셋:</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="21"/>
+        <source>Classic look</source>
+        <translation>클래식 스타일</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="24"/>
+        <source>Stripe look</source>
+        <translation>줄무늬 스타일</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="27"/>
+        <source>Overlapped Stripe look</source>
+        <translation>겹친 줄무늬 스타일</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="30"/>
+        <source>Modern look</source>
+        <translation>모던 스타일</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="33"/>
+        <source>Roulette look</source>
+        <translation>룰렛 스타일</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="77"/>
+        <source>Show advanced settings</source>
+        <translation>고급 설정 보기</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="86"/>
+        <source>Custom:</source>
+        <translation>사용자 지정:</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="89"/>
+        <source>View angle</source>
+        <translation>시야각</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="95"/>
+        <source>Position</source>
+        <translation>위치</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="101"/>
+        <source>Cover gap</source>
+        <translation>표지 간격</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="107"/>
+        <source>Central gap</source>
+        <translation>중앙 간격</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="113"/>
+        <source>Zoom</source>
+        <translation>확대/축소</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="119"/>
+        <source>Y offset</source>
+        <translation>Y축 오프셋</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="125"/>
+        <source>Z offset</source>
+        <translation>Z축 오프셋</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="131"/>
+        <source>Cover Angle</source>
+        <translation>표지 각도</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="137"/>
+        <source>Visibility</source>
+        <translation>가시성</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="143"/>
+        <source>Light</source>
+        <translation>조명</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="149"/>
+        <source>Max angle</source>
+        <translation>최대 각도</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="181"/>
+        <source>Low Performance</source>
+        <translation>저성능</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="183"/>
+        <source>High Performance</source>
+        <translation>고성능</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="194"/>
+        <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
+        <translation>수직 동기화 사용 (전체화면 결의 이미지 품질 향상, 성능 저하)</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="202"/>
+        <source>Performance:</source>
+        <translation>성능:</translation>
+    </message>
+</context>
+<context>
+    <name>YACReader::MainWindowViewer</name>
+    <message>
+        <location filename="main_window_viewer.cpp" line="319"/>
+        <source>&amp;Open</source>
+        <translation>열기(&amp;O)</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="320"/>
+        <source>Open a comic</source>
+        <translation>만화 열기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="326"/>
+        <source>New instance</source>
+        <translation>새 창</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="345"/>
+        <source>Open Folder</source>
+        <translation>폴더 열기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="346"/>
+        <source>Open image folder</source>
+        <translation>이미지 폴더 열기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="351"/>
+        <source>Open latest comic</source>
+        <translation>마지막 만화 열기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="352"/>
+        <source>Open the latest comic opened in the previous reading session</source>
+        <translation>이전 작업에서 마지막으로 열었던 만화 열기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="364"/>
+        <source>Clear</source>
+        <translation>지우기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="365"/>
+        <source>Clear open recent list</source>
+        <translation>최근 목록 지우기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="368"/>
+        <source>Save</source>
+        <translation>저장</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="369"/>
+        <location filename="main_window_viewer.cpp" line="1083"/>
+        <source>Save current page</source>
+        <translation>현재 페이지 저장</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="374"/>
+        <location filename="main_window_viewer.cpp" line="1107"/>
+        <location filename="main_window_viewer.cpp" line="1130"/>
+        <location filename="main_window_viewer.cpp" line="1148"/>
+        <source>Extract page(s)</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="375"/>
+        <source>Extract page(s) from the original source</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="380"/>
+        <source>Previous Comic</source>
+        <translation>이전 만화</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="381"/>
+        <location filename="main_window_viewer.cpp" line="1879"/>
+        <location filename="main_window_viewer.cpp" line="1883"/>
+        <source>Open previous comic</source>
+        <translation>이전 만화 열기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="386"/>
+        <source>Next Comic</source>
+        <translation>다음 만화</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="387"/>
+        <location filename="main_window_viewer.cpp" line="1878"/>
+        <location filename="main_window_viewer.cpp" line="1884"/>
+        <source>Open next comic</source>
+        <translation>다음 만화 열기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="392"/>
+        <source>&amp;Previous</source>
+        <translation>이전(&amp;P)</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="394"/>
+        <location filename="main_window_viewer.cpp" line="1881"/>
+        <location filename="main_window_viewer.cpp" line="1885"/>
+        <source>Go to previous page</source>
+        <translation>이전 페이지로 이동</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="399"/>
+        <source>&amp;Next</source>
+        <translation>다음(&amp;N)</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="401"/>
+        <location filename="main_window_viewer.cpp" line="1880"/>
+        <location filename="main_window_viewer.cpp" line="1886"/>
+        <source>Go to next page</source>
+        <translation>다음 페이지로 이동</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="406"/>
+        <source>Fit Height</source>
+        <translation>꽉차게 보기 (높이 맞춤)</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="407"/>
+        <source>Fit image to height</source>
+        <translation>이미지를 높이에 맞춤</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="413"/>
+        <source>Fit Width</source>
+        <translation>꽉차게 보기 (폭 맞춤)</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="414"/>
+        <source>Fit image to width</source>
+        <translation>이미지를 폭에 맞춤</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="420"/>
+        <source>Show full size</source>
+        <translation>원본 크기 (100%)로 보기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="427"/>
+        <source>Fit to page</source>
+        <translation>꽉차게 보기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="433"/>
+        <source>Continuous scroll</source>
+        <translation>연속 스크롤</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="434"/>
+        <source>Switch to continuous scroll mode</source>
+        <translation>연속 스크롤 모드로 전환</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="466"/>
+        <source>Reset zoom</source>
+        <translation>확대/축소 초기화</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="471"/>
+        <source>Show zoom slider</source>
+        <translation>확대/축소 슬라이더 보기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="473"/>
+        <source>Zoom+</source>
+        <translation>확대+</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="478"/>
+        <source>Zoom-</source>
+        <translation>축소-</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="483"/>
+        <source>Rotate image to the left</source>
+        <translation>이미지 왼쪽으로 회전</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="488"/>
+        <source>Rotate image to the right</source>
+        <translation>이미지 오른쪽으로 회전</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="493"/>
+        <source>Double page mode</source>
+        <translation>두 페이지씩 보기 (왼쪽 → 오른쪽)</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="494"/>
+        <source>Switch to double page mode</source>
+        <translation>두 페이지씩 보기로 전환</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="502"/>
+        <source>Double page manga mode</source>
+        <translation>두 페이지씩 보기 (왼쪽 ← 오른쪽)</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="503"/>
+        <source>Reverse reading order in double page mode</source>
+        <translation>두 페이지씩 보기에서 읽기 순서 뒤집기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="511"/>
+        <source>Go To</source>
+        <translation>이동</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="512"/>
+        <source>Go to page ...</source>
+        <translation>페이지로 이동...</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="517"/>
+        <source>Options</source>
+        <translation>환경설정</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="518"/>
+        <source>YACReader options</source>
+        <translation>YACReader 환경설정</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="524"/>
+        <location filename="main_window_viewer.cpp" line="822"/>
+        <source>Help</source>
+        <translation>도움말</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="525"/>
+        <source>Help, About YACReader</source>
+        <translation>도움말, YACReader 정보</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="530"/>
+        <source>Magnifying glass</source>
+        <translation>돋보기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="531"/>
+        <source>Switch Magnifying glass</source>
+        <translation>돋보기 전환</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="537"/>
+        <source>Set bookmark</source>
+        <translation>책갈피 설정</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="538"/>
+        <source>Set a bookmark on the current page</source>
+        <translation>현재 페이지에 책갈피 설정</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="546"/>
+        <source>Show bookmarks</source>
+        <translation>책갈피 보기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="547"/>
+        <source>Show the bookmarks of the current comic</source>
+        <translation>현재 만화의 책갈피 보기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="552"/>
+        <source>Show keyboard shortcuts</source>
+        <translation>키보드 단축키 보기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="557"/>
+        <source>Show Info</source>
+        <translation>정보 보기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="562"/>
+        <source>Close</source>
+        <translation>닫기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="567"/>
+        <source>Show Dictionary</source>
+        <translation>사전 보기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="573"/>
+        <source>Show go to flow</source>
+        <translation>페이지 흐름 보기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="578"/>
+        <source>Edit shortcuts</source>
+        <translation>단축키 편집</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="599"/>
+        <source>&amp;File</source>
+        <translation>파일(&amp;F)</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="614"/>
+        <location filename="main_window_viewer.cpp" line="776"/>
+        <source>Open recent</source>
+        <translation>최근 항목 열기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="764"/>
+        <source>File</source>
+        <translation>파일</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="786"/>
+        <source>Edit</source>
+        <translation>편집</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="790"/>
+        <source>View</source>
+        <translation>보기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="807"/>
+        <source>Go</source>
+        <translation>이동</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="815"/>
+        <source>Window</source>
+        <translation>창</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="932"/>
+        <location filename="main_window_viewer.cpp" line="934"/>
+        <location filename="main_window_viewer.cpp" line="936"/>
+        <source>Open Comic</source>
+        <translation>만화 열기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="932"/>
+        <location filename="main_window_viewer.cpp" line="934"/>
+        <location filename="main_window_viewer.cpp" line="936"/>
+        <source>Comic files</source>
+        <translation>만화 파일</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1024"/>
+        <source>Open folder</source>
+        <translation>폴더 열기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1094"/>
+        <source>Overwrite file?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1094"/>
+        <source>The file already exists. Do you want to overwrite it?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1130"/>
+        <source>The current page could not be extracted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1135"/>
+        <source>Overwrite files?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1135"/>
+        <source>Some files already exist. Do you want to overwrite them?</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1148"/>
+        <source>Some pages could not be extracted.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1293"/>
+        <location filename="main_window_viewer.cpp" line="1306"/>
+        <source>Comics</source>
+        <translation>만화</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1294"/>
+        <location filename="main_window_viewer.cpp" line="1323"/>
+        <source>General</source>
+        <translation>일반</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1295"/>
+        <location filename="main_window_viewer.cpp" line="1361"/>
+        <source>Magnifiying glass</source>
+        <translation>돋보기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1296"/>
+        <location filename="main_window_viewer.cpp" line="1372"/>
+        <source>Page adjustement</source>
+        <translation>페이지 조정</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1297"/>
+        <location filename="main_window_viewer.cpp" line="1450"/>
+        <source>Reading</source>
+        <translation>읽기</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1317"/>
+        <source>Toggle fullscreen mode</source>
+        <translation>전체화면 전환</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1320"/>
+        <source>Hide/show toolbar</source>
+        <translation>도구 모음 표시/숨김</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1342"/>
+        <source>Size up magnifying glass</source>
+        <translation>돋보기 크게</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1345"/>
+        <source>Size down magnifying glass</source>
+        <translation>돋보기 작게</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1348"/>
+        <source>Zoom in magnifying glass</source>
+        <translation>돋보기 확대</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1351"/>
+        <source>Zoom out magnifying glass</source>
+        <translation>돋보기 축소</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1354"/>
+        <source>Reset magnifying glass</source>
+        <translation>돋보기 초기화</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1368"/>
+        <source>Toggle between fit to width and fit to height</source>
+        <translation>폭 맞춤 / 높이 맞춤 전환</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1390"/>
+        <source>Autoscroll down</source>
+        <translation>아래로 자동 스크롤</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1393"/>
+        <source>Autoscroll up</source>
+        <translation>위로 자동 스크롤</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1396"/>
+        <source>Autoscroll forward, horizontal first</source>
+        <translation>세로 우선으로 정방향 자동 스크롤</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1400"/>
+        <source>Autoscroll backward, horizontal first</source>
+        <translation>가로 우선으로 정방향 자동 스크롤</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1404"/>
+        <source>Autoscroll forward, vertical first</source>
+        <translation>세로 우선으로 역방향 자동 스크롤</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1408"/>
+        <source>Autoscroll backward, vertical first</source>
+        <translation>가로 우선으로 역방향 자동 스크롤</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1412"/>
+        <source>Move down</source>
+        <translation>아래로 이동</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1415"/>
+        <source>Move up</source>
+        <translation>위로 이동</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1418"/>
+        <source>Move left</source>
+        <translation>왼쪽으로 이동</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1421"/>
+        <source>Move right</source>
+        <translation>오른쪽으로 이동</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1424"/>
+        <source>Go to the first page</source>
+        <translation>첫 페이지로 이동</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1427"/>
+        <source>Go to the last page</source>
+        <translation>마지막 페이지로 이동</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1430"/>
+        <source>Offset double page to the left</source>
+        <translation>두 페이지 왼쪽으로 이동</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1432"/>
+        <source>Offset double page to the right</source>
+        <translation>두 페이지 오른쪽으로 이동</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1499"/>
+        <source>There is a new version available</source>
+        <translation>새 버전을 내려받으시겠습니까?</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1500"/>
+        <source>Do you want to download the new version?</source>
+        <translation>새 버전을 내려받으시겠습니까?</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1503"/>
+        <source>Remind me in 14 days</source>
+        <translation>14일 후에 다시 알림</translation>
+    </message>
+    <message>
+        <location filename="main_window_viewer.cpp" line="1504"/>
+        <source>Not now</source>
+        <translation>나중에</translation>
+    </message>
+</context>
+<context>
+    <name>YACReader::WhatsNewDialog</name>
+    <message>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="183"/>
+        <source>Release notes are not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="239"/>
+        <source>Previous versions</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderFieldEdit</name>
+    <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28"/>
+        <source>Click to overwrite</source>
+        <translation>클릭해서 덮어쓰기</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11"/>
+        <source>Restore to default</source>
+        <translation>기본값으로 복원</translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderFieldPlainTextEdit</name>
+    <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50"/>
+        <source>Click to overwrite</source>
+        <translation>클릭해서 덮어쓰기</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10"/>
+        <source>Restore to default</source>
+        <translation>기본값으로 복원</translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderOptionsDialog</name>
+    <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="19"/>
+        <source>Save</source>
+        <translation>저장</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="20"/>
+        <source>Cancel</source>
+        <translation>취소</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="25"/>
+        <source>Edit shortcuts</source>
+        <translation>단축키 편집</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28"/>
+        <source>Shortcuts</source>
+        <translation>단축키</translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderSlider</name>
+    <message>
+        <location filename="width_slider.cpp" line="51"/>
+        <source>Reset</source>
+        <translation>초기화</translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderTranslator</name>
+    <message>
+        <location filename="translator.cpp" line="40"/>
+        <source>YACReader translator</source>
+        <translation>YACReader 번역기</translation>
+    </message>
+    <message>
+        <location filename="translator.cpp" line="80"/>
+        <location filename="translator.cpp" line="186"/>
+        <source>Translation</source>
+        <translation>번역</translation>
+    </message>
+    <message>
+        <location filename="translator.cpp" line="100"/>
+        <source>clear</source>
+        <translation>지우기</translation>
+    </message>
+    <message>
+        <location filename="translator.cpp" line="195"/>
+        <source>Service not available</source>
+        <translation>서비스를 사용할 수 없습니다</translation>
+    </message>
+</context>
 </TS>

--- a/YACReader/yacreader_ko.ts
+++ b/YACReader/yacreader_ko.ts
@@ -1,0 +1,3892 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+    <context>
+        <name>ActionsShortcutsModel</name>
+        <message>
+            <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="73" />
+            <source>None</source>
+            <translation>없음</translation>
+        </message>
+    </context>
+    <context>
+        <name>AddLabelDialog</name>
+        <message>
+            <location filename="add_label_dialog.cpp" line="25" />
+            <source>Label name:</source>
+            <translation>라벨 이름:</translation>
+        </message>
+        <message>
+            <location filename="add_label_dialog.cpp" line="28" />
+            <source>Choose a color:</source>
+            <translation>색상 선택:</translation>
+        </message>
+        <message>
+            <location filename="add_label_dialog.cpp" line="42" />
+            <source>accept</source>
+            <translation>확인</translation>
+        </message>
+        <message>
+            <location filename="add_label_dialog.cpp" line="43" />
+            <source>cancel</source>
+            <translation>취소</translation>
+        </message>
+    </context>
+    <context>
+        <name>AddLibraryDialog</name>
+        <message>
+            <location filename="add_library_dialog.cpp" line="26" />
+            <source>Add</source>
+            <translation>추가</translation>
+        </message>
+        <message>
+            <location filename="add_library_dialog.cpp" line="64" />
+            <source>Add an existing library</source>
+            <translation>기존 라이브러리 추가</translation>
+        </message>
+        <message>
+            <location filename="add_library_dialog.cpp" line="30" />
+            <source>Cancel</source>
+            <translation>취소</translation>
+        </message>
+        <message>
+            <location filename="add_library_dialog.cpp" line="16" />
+            <source>Comics folder : </source>
+            <translation>만화 폴더: </translation>
+        </message>
+        <message>
+            <location filename="add_library_dialog.cpp" line="21" />
+            <source>Library name : </source>
+            <translation>라이브러리 이름: </translation>
+        </message>
+    </context>
+    <context>
+        <name>ApiKeyDialog</name>
+        <message>
+            <location filename="comic_vine/api_key_dialog.cpp" line="32" />
+            <source>Cancel</source>
+            <translation>취소</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/api_key_dialog.cpp" line="21" />
+            <source>Before you can connect to Comic Vine, you need your own API key. Please, get one free &lt;a href="http://www.comicvine.com/api/"&gt;here&lt;/a&gt;</source>
+            <translation>Comic Vine에 연결하려면 본인의 API 키가 필요합니다. &lt;a href="http://www.comicvine.com/api/"&gt;여기&lt;/a&gt;에서 무료로 발급받으세요.</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/api_key_dialog.cpp" line="25" />
+            <source>Paste here your Comic Vine API key</source>
+            <translation>Comic Vine API 키를 여기 붙여넣으세요</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/api_key_dialog.cpp" line="28" />
+            <source>Accept</source>
+            <translation>확인</translation>
+        </message>
+    </context>
+    <context>
+        <name>AppearanceTabWidget</name>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="38" />
+            <source>Color scheme</source>
+            <translation>색 구성표</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="46" />
+            <source>System</source>
+            <translation>시스템</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="47" />
+            <source>Light</source>
+            <translation>밝은</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="48" />
+            <source>Dark</source>
+            <translation>어두운</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="49" />
+            <source>Custom</source>
+            <translation>사용자 지정</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="105" />
+            <source>Remove</source>
+            <translation>제거</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="107" />
+            <source>Remove this user-imported theme</source>
+            <translation>사용자 가져온 이 테마 제거</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="115" />
+            <source>Light:</source>
+            <translation>밝은:</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="116" />
+            <source>Dark:</source>
+            <translation>어두운:</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="117" />
+            <source>Custom:</source>
+            <translation>사용자 지정:</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="119" />
+            <source>Import theme...</source>
+            <translation>테마 가져오기...</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="121" />
+            <source>Theme</source>
+            <translation>테마</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="173" />
+            <source>Theme editor</source>
+            <translation>테마 편집기</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="175" />
+            <source>Open Theme Editor...</source>
+            <translation>테마 편집기 열기...</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="184" />
+            <source>Theme editor error</source>
+            <translation>테마 편집기 오류</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="185" />
+            <source>The current theme JSON could not be loaded.</source>
+            <translation>현재 테마 JSON을 불러올 수 없습니다.</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="279" />
+            <source>Import theme</source>
+            <translation>테마 가져오기</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="279" />
+            <source>JSON files (*.json);;All files (*)</source>
+            <translation>JSON 파일 (*.json);;모든 파일 (*)</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="287" />
+            <source>Could not import theme from:
+%1</source>
+            <translation>다음에서 테마를 가져올 수 없습니다:
+%1</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="288" />
+            <source>Could not import theme from:
+%1
+
+%2</source>
+            <translation>다음에서 테마를 가져올 수 없습니다:
+%1
+
+%2</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="289" />
+            <source>Import failed</source>
+            <translation>가져오기 실패</translation>
+        </message>
+    </context>
+    <context>
+        <name>BookmarksDialog</name>
+        <message>
+            <location filename="../YACReader/bookmarks_dialog.cpp" line="25" />
+            <source>Lastest Page</source>
+            <translation>마지막 페이지</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/bookmarks_dialog.cpp" line="75" />
+            <source>Close</source>
+            <translation>닫기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/bookmarks_dialog.cpp" line="85" />
+            <source>Click on any image to go to the bookmark</source>
+            <translation>이미지를 클릭하면 책갈피로 이동합니다</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/bookmarks_dialog.cpp" line="107" />
+            <location filename="../YACReader/bookmarks_dialog.cpp" line="124" />
+            <source>Loading...</source>
+            <translation>불러오는 중...</translation>
+        </message>
+    </context>
+    <context>
+        <name>ClassicComicsView</name>
+        <message>
+            <location filename="classic_comics_view.cpp" line="85" />
+            <source>Hide comic flow</source>
+            <translation>만화 흐름 숨기기</translation>
+        </message>
+    </context>
+    <context>
+        <name>ComicInfoView</name>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="302" />
+            <source>Characters</source>
+            <translation>등장인물</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="334" />
+            <source>Main character or team</source>
+            <translation>주요 등장인물 또는 팀</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="359" />
+            <source>Teams</source>
+            <translation>팀</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="393" />
+            <source>Locations</source>
+            <translation>장소</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="425" />
+            <source>Authors</source>
+            <translation>작가진</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="457" />
+            <source>writer</source>
+            <translation>글</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="479" />
+            <source>penciller</source>
+            <translation>밑그림</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="501" />
+            <source>inker</source>
+            <translation>펜선</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="523" />
+            <source>colorist</source>
+            <translation>채색</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="545" />
+            <source>letterer</source>
+            <translation>식자</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="567" />
+            <source>cover artist</source>
+            <translation>표지 그림</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="589" />
+            <source>editor</source>
+            <translation>편집</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="611" />
+            <source>imprint</source>
+            <translation>출판 브랜드</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="626" />
+            <source>Publisher</source>
+            <translation>출판사</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="678" />
+            <source>color</source>
+            <translation>컬러</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="678" />
+            <source>b/w</source>
+            <translation>흑백</translation>
+        </message>
+    </context>
+    <context>
+        <name>ComicModel</name>
+        <message>
+            <location filename="db/comic_model.cpp" line="364" />
+            <source>yes</source>
+            <translation>예</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="364" />
+            <source>no</source>
+            <translation>아니오</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="395" />
+            <source>Title</source>
+            <translation>제목</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="397" />
+            <source>File Name</source>
+            <translation>파일 이름</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="399" />
+            <source>Pages</source>
+            <translation>페이지</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="401" />
+            <source>Size</source>
+            <translation>크기</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="403" />
+            <source>Read</source>
+            <translation>읽음</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="405" />
+            <source>Current Page</source>
+            <translation>현재 페이지</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="407" />
+            <source>Publication Date</source>
+            <translation>출판일</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="409" />
+            <source>Rating</source>
+            <translation>평점</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="411" />
+            <source>Series</source>
+            <translation>시리즈</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="413" />
+            <source>Volume</source>
+            <translation>볼륨</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="415" />
+            <source>Story Arc</source>
+            <translation>스토리 아크</translation>
+        </message>
+    </context>
+    <context>
+        <name>ComicVineDialog</name>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="54" />
+            <source>skip</source>
+            <translation>건너뛰기</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="55" />
+            <source>back</source>
+            <translation>뒤로</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="56" />
+            <source>next</source>
+            <translation>다음</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="57" />
+            <source>search</source>
+            <translation>검색</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="58" />
+            <source>close</source>
+            <translation>닫기</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="134" />
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="588" />
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="627" />
+            <source>Looking for volume...</source>
+            <translation>볼륨 검색 중...</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="132" />
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="546" />
+            <source>comic %1 of %2 - %3</source>
+            <translation>%1 / %2 만화 - %3</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="249" />
+            <source>%1 comics selected</source>
+            <translation>만화 %1개 선택됨</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="280" />
+            <source>Error connecting to ComicVine</source>
+            <translation>Comic Vine 연결 오류</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="460" />
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="486" />
+            <source>Retrieving tags for : %1</source>
+            <translation>태그 가져오는 중 : %1</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="607" />
+            <source>Retrieving volume info...</source>
+            <translation>볼륨 정보 가져오는 중...</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="639" />
+            <source>Looking for comic...</source>
+            <translation>만화 검색 중...</translation>
+        </message>
+    </context>
+    <context>
+        <name>ContinuousPageWidget</name>
+        <message>
+            <location filename="../YACReader/continuous_page_widget.cpp" line="156" />
+            <source>Loading page %1</source>
+            <translation>페이지 %1 불러오는 중</translation>
+        </message>
+    </context>
+    <context>
+        <name>CreateLibraryDialog</name>
+        <message>
+            <location filename="create_library_dialog.cpp" line="76" />
+            <source>Create new library</source>
+            <translation>새 라이브러리 만들기</translation>
+        </message>
+        <message>
+            <location filename="create_library_dialog.cpp" line="34" />
+            <source>Cancel</source>
+            <translation>취소</translation>
+        </message>
+        <message>
+            <location filename="create_library_dialog.cpp" line="30" />
+            <source>Create</source>
+            <translation>만들기</translation>
+        </message>
+        <message>
+            <location filename="create_library_dialog.cpp" line="20" />
+            <source>Comics folder : </source>
+            <translation>만화 폴더: </translation>
+        </message>
+        <message>
+            <location filename="create_library_dialog.cpp" line="25" />
+            <source>Library Name : </source>
+            <translation>라이브러리 이름: </translation>
+        </message>
+        <message>
+            <location filename="create_library_dialog.cpp" line="56" />
+            <source>Create a library could take several minutes. You can stop the process and update the library later for completing the task.</source>
+            <translation>라이브러리 생성은 몇 분 걸릴 수 있습니다. 작업을 중지하고 나중에 라이브러리를 업데이트하여 완료할 수 있습니다.</translation>
+        </message>
+        <message>
+            <location filename="create_library_dialog.cpp" line="104" />
+            <source>Path not found</source>
+            <translation>경로를 찾을 수 없음</translation>
+        </message>
+        <message>
+            <location filename="create_library_dialog.cpp" line="104" />
+            <source>The selected path does not exist or is not a valid path. Be sure that you have write access to this folder</source>
+            <translation>선택한 경로가 존재하지 않거나 올바르지 않습니다. 이 폴더에 쓰기 권한이 있는지 확인하세요</translation>
+        </message>
+    </context>
+    <context>
+        <name>EditShortcutsDialog</name>
+        <message>
+            <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="23" />
+            <source>Restore defaults</source>
+            <translation>기본값으로 복원</translation>
+        </message>
+        <message>
+            <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="24" />
+            <source>To change a shortcut, double click in the key combination and type the new keys.</source>
+            <translation>단축키를 바꾸려면 키 조합을 더블 클릭하고 새 키를 입력하세요.</translation>
+        </message>
+        <message>
+            <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="71" />
+            <source>Shortcuts settings</source>
+            <translation>단축키 설정</translation>
+        </message>
+        <message>
+            <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="122" />
+            <source>Shortcut in use</source>
+            <translation>사용 중인 단축키</translation>
+        </message>
+        <message>
+            <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="122" />
+            <source>The shortcut "%1" is already assigned to other function</source>
+            <translation>"%1" 단축키는 이미 다른 기능이 사용 중입니다</translation>
+        </message>
+    </context>
+    <context>
+        <name>EmptyFolderWidget</name>
+        <message>
+            <location filename="empty_folder_widget.cpp" line="8" />
+            <source>This folder doesn't contain comics yet</source>
+            <translation>이 폴더에는 아직 만화가 없습니다</translation>
+        </message>
+    </context>
+    <context>
+        <name>EmptyLabelWidget</name>
+        <message>
+            <location filename="empty_label_widget.cpp" line="7" />
+            <source>This label doesn't contain comics yet</source>
+            <translation>이 라벨에 아직 만화가 없습니다</translation>
+        </message>
+    </context>
+    <context>
+        <name>EmptyReadingListWidget</name>
+        <message>
+            <location filename="empty_reading_list_widget.cpp" line="8" />
+            <source>This reading list does not contain any comics yet</source>
+            <translation>이 읽기 목록에 아직 만화가 없습니다</translation>
+        </message>
+    </context>
+    <context>
+        <name>EmptySpecialListWidget</name>
+        <message>
+            <location filename="empty_special_list.cpp" line="13" />
+            <source>No favorites</source>
+            <translation>즐겨찾기 없음</translation>
+        </message>
+        <message>
+            <location filename="empty_special_list.cpp" line="20" />
+            <source>You are not reading anything yet, come on!!</source>
+            <translation>아직 읽고 있는 만화가 없습니다. 지금 시작해보세요!!</translation>
+        </message>
+        <message>
+            <location filename="empty_special_list.cpp" line="27" />
+            <source>There are no recent comics!</source>
+            <translation>최근 본 만화가 없습니다!</translation>
+        </message>
+    </context>
+    <context>
+        <name>ExportComicsInfoDialog</name>
+        <message>
+            <location filename="export_comics_info_dialog.cpp" line="22" />
+            <source>Cancel</source>
+            <translation>취소</translation>
+        </message>
+        <message>
+            <location filename="export_comics_info_dialog.cpp" line="18" />
+            <source>Create</source>
+            <translation>생성</translation>
+        </message>
+        <message>
+            <location filename="export_comics_info_dialog.cpp" line="14" />
+            <source>Output file : </source>
+            <translation>출력 파일: </translation>
+        </message>
+        <message>
+            <location filename="export_comics_info_dialog.cpp" line="55" />
+            <source>Export comics info</source>
+            <translation>만화 정보 내보내기</translation>
+        </message>
+        <message>
+            <location filename="export_comics_info_dialog.cpp" line="72" />
+            <source>Destination database name</source>
+            <translation>대상 데이터베이스 이름</translation>
+        </message>
+        <message>
+            <location filename="export_comics_info_dialog.cpp" line="87" />
+            <source>Problem found while writing</source>
+            <translation>쓰기 중 문제 발생</translation>
+        </message>
+        <message>
+            <location filename="export_comics_info_dialog.cpp" line="87" />
+            <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
+            <translation>출력 파일에 선택한 경로가 존재하지 않거나 올바르지 않습니다. 이 폴더에 쓰기 권한이 있는지 확인하세요</translation>
+        </message>
+    </context>
+    <context>
+        <name>ExportLibraryDialog</name>
+        <message>
+            <location filename="export_library_dialog.cpp" line="19" />
+            <source>Cancel</source>
+            <translation>취소</translation>
+        </message>
+        <message>
+            <location filename="export_library_dialog.cpp" line="15" />
+            <source>Create</source>
+            <translation>생성</translation>
+        </message>
+        <message>
+            <location filename="export_library_dialog.cpp" line="11" />
+            <source>Output folder : </source>
+            <translation>출력 폴더: </translation>
+        </message>
+        <message>
+            <location filename="export_library_dialog.cpp" line="58" />
+            <source>Create covers package</source>
+            <translation>표지 패키지 생성</translation>
+        </message>
+        <message>
+            <location filename="export_library_dialog.cpp" line="82" />
+            <source>Destination directory</source>
+            <translation>대상 폴더</translation>
+        </message>
+        <message>
+            <location filename="export_library_dialog.cpp" line="77" />
+            <source>Problem found while writing</source>
+            <translation>쓰기 중 문제 발생</translation>
+        </message>
+        <message>
+            <location filename="export_library_dialog.cpp" line="77" />
+            <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
+            <translation>출력 파일에 선택한 경로가 존재하지 않거나 올바르지 않습니다. 이 폴더에 쓰기 권한이 있는지 확인하세요</translation>
+        </message>
+    </context>
+    <context>
+        <name>FileComic</name>
+        <message>
+            <location filename="../common/comic.cpp" line="562" />
+            <source>7z not found</source>
+            <translation>7z를 찾을 수 없습니다</translation>
+        </message>
+        <message>
+            <location filename="../common/comic.cpp" line="454" />
+            <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
+            <translation>%1번 페이지에서 CRC 오류 발생: 일부 페이지가 올바르게 표시되지 않을 수 있습니다</translation>
+        </message>
+        <message>
+            <location filename="../common/comic.cpp" line="461" />
+            <source>Unknown error opening the file</source>
+            <translation>파일을 여는 중 알 수 없는 오류가 발생했습니다</translation>
+        </message>
+        <message>
+            <location filename="../common/comic.cpp" line="568" />
+            <source>Format not supported</source>
+            <translation>지원하지 않는 형식입니다</translation>
+        </message>
+    </context>
+    <context>
+        <name>FolderContentView</name>
+        <message>
+            <location filename="qml/FolderContentView.qml" line="223" />
+            <source>Continue Reading...</source>
+            <translation>이어 읽기...</translation>
+        </message>
+    </context>
+    <context>
+        <name>GoToDialog</name>
+        <message>
+            <location filename="../YACReader/goto_dialog.cpp" line="15" />
+            <source>Page : </source>
+            <translation>페이지: </translation>
+        </message>
+        <message>
+            <location filename="../YACReader/goto_dialog.cpp" line="23" />
+            <source>Go To</source>
+            <translation>이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/goto_dialog.cpp" line="25" />
+            <source>Cancel</source>
+            <translation>취소</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/goto_dialog.cpp" line="39" />
+            <location filename="../YACReader/goto_dialog.cpp" line="71" />
+            <source>Total pages : </source>
+            <translation>전체 페이지: </translation>
+        </message>
+        <message>
+            <location filename="../YACReader/goto_dialog.cpp" line="53" />
+            <source>Go to...</source>
+            <translation>이동...</translation>
+        </message>
+    </context>
+    <context>
+        <name>GoToFlowToolBar</name>
+        <message>
+            <location filename="../YACReader/goto_flow_toolbar.cpp" line="25" />
+            <source>Page : </source>
+            <translation>페이지: </translation>
+        </message>
+    </context>
+    <context>
+        <name>GridComicsView</name>
+        <message>
+            <location filename="grid_comics_view.cpp" line="77" />
+            <source>Show info</source>
+            <translation>정보 보기</translation>
+        </message>
+    </context>
+    <context>
+        <name>HelpAboutDialog</name>
+        <message>
+            <location filename="../custom_widgets/help_about_dialog.cpp" line="23" />
+            <source>About</source>
+            <translation>정보</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/help_about_dialog.cpp" line="26" />
+            <source>Help</source>
+            <translation>도움말</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/help_about_dialog.cpp" line="29" />
+            <source>System info</source>
+            <translation>시스템 정보</translation>
+        </message>
+    </context>
+    <context>
+        <name>ImportComicsInfoDialog</name>
+        <message>
+            <location filename="import_comics_info_dialog.cpp" line="24" />
+            <source>Cancel</source>
+            <translation>취소</translation>
+        </message>
+        <message>
+            <location filename="import_comics_info_dialog.cpp" line="14" />
+            <source>Import comics info</source>
+            <translation>만화 정보 가져오기</translation>
+        </message>
+        <message>
+            <location filename="import_comics_info_dialog.cpp" line="16" />
+            <source>Info database location : </source>
+            <translation>정보 데이터베이스 경로: </translation>
+        </message>
+        <message>
+            <location filename="import_comics_info_dialog.cpp" line="20" />
+            <source>Import</source>
+            <translation>가져오기</translation>
+        </message>
+        <message>
+            <location filename="import_comics_info_dialog.cpp" line="80" />
+            <source>Comics info file (*.ydb)</source>
+            <translation>만화 정보 파일 (*.ydb)</translation>
+        </message>
+    </context>
+    <context>
+        <name>ImportLibraryDialog</name>
+        <message>
+            <location filename="import_library_dialog.cpp" line="26" />
+            <source>Destination folder : </source>
+            <translation>대상 폴더: </translation>
+        </message>
+        <message>
+            <location filename="import_library_dialog.cpp" line="34" />
+            <source>Cancel</source>
+            <translation>취소</translation>
+        </message>
+        <message>
+            <location filename="import_library_dialog.cpp" line="30" />
+            <source>Unpack</source>
+            <translation>풀기</translation>
+        </message>
+        <message>
+            <location filename="import_library_dialog.cpp" line="115" />
+            <source>Compresed library covers (*.clc)</source>
+            <translation>압축된 라이브러리 표지 (*.clc)</translation>
+        </message>
+        <message>
+            <location filename="import_library_dialog.cpp" line="22" />
+            <source>Package location : </source>
+            <translation>패키지 경로: </translation>
+        </message>
+        <message>
+            <location filename="import_library_dialog.cpp" line="17" />
+            <source>Library Name : </source>
+            <translation>라이브러리 이름: </translation>
+        </message>
+        <message>
+            <location filename="import_library_dialog.cpp" line="85" />
+            <source>Extract a catalog</source>
+            <translation>카탈로그 추출</translation>
+        </message>
+    </context>
+    <context>
+        <name>ImportWidget</name>
+        <message>
+            <location filename="import_widget.cpp" line="131" />
+            <source>stop</source>
+            <translation>중지</translation>
+        </message>
+        <message>
+            <location filename="import_widget.cpp" line="171" />
+            <source>Some of the comics being added...</source>
+            <translation>일부 만화를 추가하는 중...</translation>
+        </message>
+        <message>
+            <location filename="import_widget.cpp" line="318" />
+            <source>Importing comics</source>
+            <translation>만화 가져오는 중</translation>
+        </message>
+        <message>
+            <location filename="import_widget.cpp" line="319" />
+            <source>&lt;p&gt;YACReaderLibrary is now creating a new library.&lt;/p&gt;&lt;p&gt;Create a library could take several minutes. You can stop the process and update the library later for completing the task.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;YACReaderLibrary가 새 라이브러리를 만들고 있습니다.&lt;/p&gt;&lt;p&gt;라이브러리 생성은 몇 분 걸릴 수 있습니다. 작업을 중지하고 나중에 라이브러리를 업데이트하여 작업을 완료할 수 있습니다.&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <location filename="import_widget.cpp" line="330" />
+            <source>Updating the library</source>
+            <translation>라이브러리 업데이트 중</translation>
+        </message>
+        <message>
+            <location filename="import_widget.cpp" line="331" />
+            <source>&lt;p&gt;The current library is being updated. For faster updates, please, update your libraries frequently.&lt;/p&gt;&lt;p&gt;You can stop the process and continue updating this library later.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;현재 라이브러리를 업데이트하고 있습니다. 더 빠른 업데이트를 위해 라이브러리를 자주 업데이트하세요.&lt;/p&gt;&lt;p&gt;작업을 중지하고 나중에 이 라이브러리 업데이트를 계속할 수 있습니다.&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <location filename="import_widget.cpp" line="342" />
+            <source>Upgrading the library</source>
+            <translation>라이브러리 업그레이드 중</translation>
+        </message>
+        <message>
+            <location filename="import_widget.cpp" line="343" />
+            <source>&lt;p&gt;The current library is being upgraded, please wait.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;현재 라이브러리를 업그레이드하고 있습니다. 잠시만 기다려주세요.&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <location filename="import_widget.cpp" line="354" />
+            <source>Scanning the library</source>
+            <translation>라이브러리 스캔 중</translation>
+        </message>
+        <message>
+            <location filename="import_widget.cpp" line="355" />
+            <source>&lt;p&gt;Current library is being scanned for legacy XML metadata information.&lt;/p&gt;&lt;p&gt;This is only needed once, and only if the library was crated with YACReaderLibrary 9.8.2 or earlier.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;현재 라이브러리에서 레거시 XML 메타데이터 정보를 스캔하고 있습니다.&lt;/p&gt;&lt;p&gt;이 작업은 한 번만 필요하며, 라이브러리가 YACReaderLibrary 9.8.2 또는 이전 버전으로 만들어진 경우에만 해당됩니다.&lt;/p&gt;</translation>
+        </message>
+    </context>
+    <context>
+        <name>LibraryWindow</name>
+        <message>
+            <source>Remove current library from your collection</source>
+            <translation type="vanished">내 컬렉션에서 현재 라이브러리 제거</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="626" />
+            <source>Library</source>
+            <translation>라이브러리</translation>
+        </message>
+        <message>
+            <source>Rename current library</source>
+            <translation type="vanished">현재 라이브러리 이름 변경</translation>
+        </message>
+        <message>
+            <source>Open current comic on YACReader</source>
+            <translation type="vanished">YACReader에서 현재 만화 열기</translation>
+        </message>
+        <message>
+            <source>Update current library</source>
+            <translation type="vanished">현재 라이브러리 업데이트</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1408" />
+            <source>Open folder...</source>
+            <translation>폴더 열기...</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="545" />
+            <location filename="library_window.cpp" line="1310" />
+            <location filename="library_window.cpp" line="1435" />
+            <source>western manga (left to right)</source>
+            <translation>서양 만화 (왼쪽 → 오른쪽)</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="551" />
+            <location filename="library_window.cpp" line="1316" />
+            <location filename="library_window.cpp" line="1441" />
+            <source>4koma (top to botom)</source>
+            <oldsource>4koma (top to botom</oldsource>
+            <translation>4컷 (위 → 아래)</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1861" />
+            <source>Do you want remove </source>
+            <translation>다음을 제거하시겠습니까: </translation>
+        </message>
+        <message>
+            <source>Expand all nodes</source>
+            <translation type="vanished">모든 노드 펼치기</translation>
+        </message>
+        <message>
+            <source>Show options dialog</source>
+            <translation type="vanished">환경설정 다이얼로그 표시</translation>
+        </message>
+        <message>
+            <source>Create a new library</source>
+            <translation type="vanished">새 라이브러리 만들기</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="223" />
+            <source>YACReader Library</source>
+            <translation>YACReader Library</translation>
+        </message>
+        <message>
+            <source>Open an existing library</source>
+            <translation type="vanished">기존 라이브러리 열기</translation>
+        </message>
+        <message>
+            <source>Pack the covers of the selected library</source>
+            <translation type="vanished">선택한 라이브러리의 표지 묶기</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="542" />
+            <location filename="library_window.cpp" line="1307" />
+            <location filename="library_window.cpp" line="1429" />
+            <source>manga</source>
+            <translation>망가</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="539" />
+            <location filename="library_window.cpp" line="1304" />
+            <location filename="library_window.cpp" line="1432" />
+            <source>comic</source>
+            <translation>만화</translation>
+        </message>
+        <message>
+            <source>Help, About YACReader</source>
+            <translation type="vanished">도움말, YACReader 정보</translation>
+        </message>
+        <message>
+            <source>Select root node</source>
+            <translation type="vanished">루트 노드 선택</translation>
+        </message>
+        <message>
+            <source>Unpack a catalog</source>
+            <translation type="vanished">카탈로그 풀기</translation>
+        </message>
+        <message>
+            <source>Open containing folder...</source>
+            <translation type="vanished">포함된 폴더 열기...</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1861" />
+            <source>Are you sure?</source>
+            <translation>확실합니까?</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1414" />
+            <source>Rescan library for XML info</source>
+            <translation>XML 정보로 라이브러리 재검색</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1423" />
+            <source>Set as read</source>
+            <translation>읽음으로 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1426" />
+            <location filename="library_window.cpp" line="1567" />
+            <source>Set as unread</source>
+            <translation>읽지 않음으로 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="548" />
+            <location filename="library_window.cpp" line="1313" />
+            <location filename="library_window.cpp" line="1438" />
+            <source>web comic</source>
+            <translation>웹 만화</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1150" />
+            <source>Add new folder</source>
+            <translation>새 폴더 추가</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1186" />
+            <source>Delete folder</source>
+            <translation>폴더 삭제</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1417" />
+            <source>Set as uncompleted</source>
+            <translation>미완료로 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1420" />
+            <source>Set as completed</source>
+            <translation>완료로 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1411" />
+            <source>Update folder</source>
+            <translation>폴더 업데이트</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="652" />
+            <source>Folder</source>
+            <translation>폴더</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="674" />
+            <source>Comic</source>
+            <translation>만화</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="802" />
+            <source>Upgrade failed</source>
+            <translation>업그레이드 실패</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="802" />
+            <source>There were errors during library upgrade in: </source>
+            <translation>라이브러리 업그레이드 중 오류 발생: </translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="831" />
+            <source>Update needed</source>
+            <translation>업데이트 필요</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="831" />
+            <source>This library was created with a previous version of YACReaderLibrary. It needs to be updated. Update now?</source>
+            <translation>이 라이브러리는 YACReaderLibrary의 이전 버전으로 만들어졌습니다. 업데이트가 필요합니다. 지금 업데이트하시겠습니까?</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="898" />
+            <source>Download new version</source>
+            <translation>새 버전 내려받기</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="898" />
+            <source>This library was created with a newer version of YACReaderLibrary. Download the new version now?</source>
+            <translation>이 라이브러리는 YACReaderLibrary의 최신 버전으로 만들어졌습니다. 지금 새 버전을 내려받으시겠습니까?</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="919" />
+            <source>Library not available</source>
+            <translation>라이브러리를 사용할 수 없습니다</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="919" />
+            <source>Library '%1' is no longer available. Do you want to remove it?</source>
+            <translation>'%1' 라이브러리를 더 이상 사용할 수 없습니다. 제거하시겠습니까?</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="938" />
+            <source>Old library</source>
+            <translation>오래된 라이브러리</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="938" />
+            <source>Library '%1' has been created with an older version of YACReaderLibrary. It must be created again. Do you want to create the library now?</source>
+            <translation>'%1' 라이브러리는 이전 버전의 YACReaderLibrary로 만들어졌습니다. 다시 만들어야 합니다. 지금 만드시겠습니까?</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="969" />
+            <location filename="library_window.cpp" line="1005" />
+            <source>Copying comics...</source>
+            <translation>만화 복사 중...</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="986" />
+            <location filename="library_window.cpp" line="1024" />
+            <source>Moving comics...</source>
+            <translation>만화 이동 중...</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1151" />
+            <source>Folder name:</source>
+            <translation>폴더 이름:</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1180" />
+            <source>No folder selected</source>
+            <translation>선택된 폴더 없음</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1180" />
+            <source>Please, select a folder first</source>
+            <translation>먼저 폴더를 선택하세요</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1184" />
+            <source>Error in path</source>
+            <translation>경로 오류</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1184" />
+            <source>There was an error accessing the folder's path</source>
+            <translation>폴더 경로에 접근하는 중 오류가 발생했습니다</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1186" />
+            <source>The selected folder and all its contents will be deleted from your disk. Are you sure?</source>
+            <translation>선택한 폴더와 그 안의 모든 내용이 디스크에서 삭제됩니다. 계속하시겠습니까?</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1212" />
+            <location filename="library_window.cpp" line="2174" />
+            <source>Unable to delete</source>
+            <translation>삭제할 수 없음</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1212" />
+            <source>There was an issue trying to delete the selected folders. Please, check for write permissions and be sure that any applications are using these folders or any of the contained files.</source>
+            <translation>선택한 폴더를 삭제하는 중 문제가 발생했습니다. 쓰기 권한을 확인하고, 다른 응용 프로그램이 이 폴더나 안의 파일을 사용 중인지 확인하세요.</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1224" />
+            <source>Add new reading lists</source>
+            <translation>새 읽기 목록 추가</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1225" />
+            <location filename="library_window.cpp" line="1274" />
+            <source>List name:</source>
+            <translation>목록 이름:</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1243" />
+            <source>Delete list/label</source>
+            <translation>목록/라벨 삭제</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1243" />
+            <source>The selected item will be deleted, your comics or folders will NOT be deleted from your disk. Are you sure?</source>
+            <translation>선택한 항목이 삭제됩니다. 디스크에서 만화나 폴더는 삭제되지 않습니다. 계속하시겠습니까?</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1273" />
+            <source>Rename list name</source>
+            <translation>목록 이름 변경</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="591" />
+            <location filename="library_window.cpp" line="1375" />
+            <location filename="library_window.cpp" line="1489" />
+            <location filename="library_window.cpp" line="2631" />
+            <source>Set type</source>
+            <translation>유형 설정</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1444" />
+            <source>Set custom cover</source>
+            <translation>사용자 지정 표지 설정</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1447" />
+            <source>Delete custom cover</source>
+            <translation>사용자 지정 표지 삭제</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1632" />
+            <source>Save covers</source>
+            <translation>표지 저장</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1651" />
+            <source>You are adding too many libraries.</source>
+            <translation>라이브러리를 너무 많이 추가하고 있습니다.</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1651" />
+            <source>You are adding too many libraries.
+
+You probably only need one library in your top level comics folder, you can browse any subfolders using the folders section in the left sidebar.
+
+YACReaderLibrary will not stop you from creating more libraries but you should keep the number of libraries low.</source>
+            <translation>라이브러리를 너무 많이 추가하고 있습니다.
+
+최상위 만화 폴더에 라이브러리 하나만 있으면 충분합니다. 좌측 사이드바의 폴더 섹션으로 하위 폴더를 탐색할 수 있습니다.
+
+YACReaderLibrary는 라이브러리를 더 만드는 것을 막지 않지만, 라이브러리 수는 적게 유지하는 것이 좋습니다.</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1711" />
+            <location filename="library_window.cpp" line="1713" />
+            <source>YACReader not found</source>
+            <translation>YACReader를 찾을 수 없음</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1711" />
+            <source>YACReader not found. YACReader should be installed in the same folder as YACReaderLibrary.</source>
+            <translation>YACReader를 찾을 수 없습니다. YACReader는 YACReaderLibrary와 같은 폴더에 설치되어야 합니다.</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1713" />
+            <source>YACReader not found. There might be a problem with your YACReader installation.</source>
+            <translation>YACReader를 찾을 수 없습니다. YACReader 설치에 문제가 있을 수 있습니다.</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1720" />
+            <source>Error</source>
+            <translation>오류</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1720" />
+            <source>Error opening comic with third party reader.</source>
+            <translation>타사 뷰어로 만화를 여는 중 오류가 발생했습니다.</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1807" />
+            <source>Library not found</source>
+            <translation>라이브러리를 찾을 수 없음</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1807" />
+            <source>The selected folder doesn't contain any library.</source>
+            <translation>선택한 폴더에 라이브러리가 없습니다.</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1861" />
+            <source> library?</source>
+            <translation>라이브러리?</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1862" />
+            <source>Remove and delete metadata</source>
+            <translation>제거 및 메타데이터 삭제</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1932" />
+            <source>Library info</source>
+            <translation>라이브러리 정보</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2174" />
+            <source>There was an issue trying to delete the selected comics. Please, check for write permissions in the selected files or containing folder.</source>
+            <translation>선택한 만화를 삭제하는 중 문제가 발생했습니다. 선택한 파일이나 포함된 폴더의 쓰기 권한을 확인하세요.</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2205" />
+            <source>Assign comics numbers</source>
+            <translation>만화에 번호 부여</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2206" />
+            <source>Assign numbers starting in:</source>
+            <translation>다음 번호부터 부여:</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2306" />
+            <source>Invalid image</source>
+            <translation>잘못된 이미지</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2306" />
+            <source>The selected file is not a valid image.</source>
+            <translation>선택한 파일이 유효한 이미지가 아닙니다.</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2312" />
+            <source>Error saving cover</source>
+            <translation>표지 저장 오류</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2312" />
+            <source>There was an error saving the cover image.</source>
+            <translation>표지 이미지를 저장하는 중 오류가 발생했습니다.</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2451" />
+            <source>Error creating the library</source>
+            <translation>라이브러리 생성 오류</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2456" />
+            <source>Error updating the library</source>
+            <translation>라이브러리 업데이트 오류</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2461" />
+            <source>Error opening the library</source>
+            <translation>라이브러리 열기 오류</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2510" />
+            <source>Delete comics</source>
+            <translation>만화 삭제</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2510" />
+            <source>All the selected comics will be deleted from your disk. Are you sure?</source>
+            <translation>선택한 만화가 모두 디스크에서 삭제됩니다. 확실합니까?</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2547" />
+            <source>Remove comics</source>
+            <translation>만화 제거</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2547" />
+            <source>Comics will only be deleted from the current label/list. Are you sure?</source>
+            <translation>만화가 현재 라벨/목록에서만 삭제됩니다. 확실합니까?</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2649" />
+            <source>Library name already exists</source>
+            <translation>라이브러리 이름 중복</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2649" />
+            <source>There is another library with the name '%1'.</source>
+            <translation>'%1' 이름의 라이브러리가 이미 있습니다.</translation>
+        </message>
+    </context>
+    <context>
+        <name>LibraryWindowActions</name>
+        <message>
+            <location filename="library_window_actions.cpp" line="39" />
+            <source>Create a new library</source>
+            <translation>새 라이브러리 만들기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="44" />
+            <source>Open an existing library</source>
+            <translation>기존 라이브러리 열기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="48" />
+            <location filename="library_window_actions.cpp" line="49" />
+            <source>Export comics info</source>
+            <translation>만화 정보 내보내기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="53" />
+            <location filename="library_window_actions.cpp" line="54" />
+            <source>Import comics info</source>
+            <translation>만화 정보 가져오기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="58" />
+            <source>Pack covers</source>
+            <translation>표지 묶기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="59" />
+            <source>Pack the covers of the selected library</source>
+            <translation>선택한 라이브러리의 표지 묶기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="63" />
+            <source>Unpack covers</source>
+            <translation>표지 풀기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="64" />
+            <source>Unpack a catalog</source>
+            <translation>카탈로그 풀기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="68" />
+            <source>Update library</source>
+            <translation>라이브러리 업데이트</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="69" />
+            <source>Update current library</source>
+            <translation>현재 라이브러리 업데이트</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="73" />
+            <source>Rename library</source>
+            <translation>라이브러리 이름 변경</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="74" />
+            <source>Rename current library</source>
+            <translation>현재 라이브러리 이름 변경</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="78" />
+            <source>Remove library</source>
+            <translation>라이브러리 제거</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="79" />
+            <source>Remove current library from your collection</source>
+            <translation>내 컬렉션에서 현재 라이브러리 제거</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="83" />
+            <source>Rescan library for XML info</source>
+            <translation>XML 정보로 라이브러리 재검색</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="84" />
+            <source>Tries to find XML info embedded in comic files. You only need to do this if the library was created with 9.8.2 or earlier versions or if you are using third party software to embed XML info in the files.</source>
+            <translation>만화 파일에 포함된 XML 정보를 찾으려고 시도합니다. 9.8.2 이하 버전으로 만든 라이브러리이거나 타사 소프트웨어로 파일에 XML 정보를 포함한 경우에만 필요합니다.</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="88" />
+            <source>Show library info</source>
+            <translation>라이브러리 정보 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="89" />
+            <source>Show information about the current library</source>
+            <translation>현재 라이브러리에 대한 정보 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="93" />
+            <source>Open current comic</source>
+            <translation>현재 만화 열기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="94" />
+            <source>Open current comic on YACReader</source>
+            <translation>YACReader에서 현재 만화 열기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="98" />
+            <source>Save selected covers to...</source>
+            <translation>선택한 표지 저장...</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="99" />
+            <source>Save covers of the selected comics as JPG files</source>
+            <translation>선택한 만화의 표지를 JPG 파일로 저장</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="103" />
+            <location filename="library_window_actions.cpp" line="224" />
+            <source>Set as read</source>
+            <translation>읽음으로 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="104" />
+            <source>Set comic as read</source>
+            <translation>만화를 읽음으로 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="108" />
+            <location filename="library_window_actions.cpp" line="229" />
+            <source>Set as unread</source>
+            <translation>읽지 않음으로 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="109" />
+            <source>Set comic as unread</source>
+            <translation>만화를 읽지 않음으로 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="113" />
+            <location filename="library_window_actions.cpp" line="244" />
+            <source>manga</source>
+            <translation>망가</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="114" />
+            <source>Set issue as manga</source>
+            <translation>만화를 망가로 설정</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="118" />
+            <location filename="library_window_actions.cpp" line="249" />
+            <source>comic</source>
+            <translation>만화</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="119" />
+            <source>Set issue as normal</source>
+            <translation>만화를 일반으로 설정</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="123" />
+            <source>western manga</source>
+            <translation>서양 만화</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="124" />
+            <source>Set issue as western manga</source>
+            <translation>만화를 서양 만화로 설정</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="129" />
+            <location filename="library_window_actions.cpp" line="259" />
+            <source>web comic</source>
+            <translation>웹 만화</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="130" />
+            <source>Set issue as web comic</source>
+            <translation>만화를 웹 만화로 설정</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="135" />
+            <location filename="library_window_actions.cpp" line="264" />
+            <source>yonkoma</source>
+            <translation>4컷 만화</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="136" />
+            <source>Set issue as yonkoma</source>
+            <translation>만화를 4컷 만화로 설정</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="140" />
+            <source>Show/Hide marks</source>
+            <translation>읽음 마크 표시/숨김</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="141" />
+            <source>Show or hide read marks</source>
+            <translation>읽음 마크를 표시하거나 숨김</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="147" />
+            <source>Show/Hide recent indicator</source>
+            <translation>신규 표시 표시/숨김</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="148" />
+            <source>Show or hide recent indicator</source>
+            <translation>신규 표시를 표시하거나 숨김</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="155" />
+            <location filename="library_window_actions.cpp" line="156" />
+            <source>Fullscreen mode on/off</source>
+            <translation>전체화면 모드 켜기/끄기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="161" />
+            <source>Help, About YACReader</source>
+            <translation>도움말, YACReader 정보</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="165" />
+            <source>Add new folder</source>
+            <translation>새 폴더 추가</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="168" />
+            <source>Add new folder to the current library</source>
+            <translation>현재 라이브러리에 새 폴더 추가</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="170" />
+            <source>Delete folder</source>
+            <translation>폴더 삭제</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="173" />
+            <source>Delete current folder from disk</source>
+            <translation>현재 폴더를 디스크에서 삭제</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="178" />
+            <source>Select root node</source>
+            <translation>루트 노드 선택</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="181" />
+            <source>Expand all nodes</source>
+            <translation>모든 노드 펼치기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="186" />
+            <source>Collapse all nodes</source>
+            <translation>모든 노드 접기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="191" />
+            <source>Show options dialog</source>
+            <translation>환경설정 다이얼로그 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="196" />
+            <source>Show comics server options dialog</source>
+            <translation>만화 서버 환경설정 다이얼로그 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="200" />
+            <location filename="library_window_actions.cpp" line="201" />
+            <source>Change between comics views</source>
+            <translation>만화 보기 전환</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="209" />
+            <source>Open folder...</source>
+            <translation>폴더 열기...</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="214" />
+            <source>Set as uncompleted</source>
+            <translation>미완료로 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="219" />
+            <source>Set as completed</source>
+            <translation>완료로 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="234" />
+            <source>Set custom cover</source>
+            <translation>사용자 지정 표지 설정</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="239" />
+            <source>Delete custom cover</source>
+            <translation>사용자 지정 표지 삭제</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="254" />
+            <source>western manga (left to right)</source>
+            <translation>서양 만화 (왼쪽 → 오른쪽)</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="271" />
+            <source>Open containing folder...</source>
+            <translation>포함된 폴더 열기...</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="276" />
+            <source>Reset comic rating</source>
+            <translation>만화 평점 초기화</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="282" />
+            <source>Select all comics</source>
+            <translation>모든 만화 선택</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="287" />
+            <source>Edit</source>
+            <translation>편집</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="292" />
+            <source>Assign current order to comics</source>
+            <translation>만화에 현재 순서 적용</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="297" />
+            <source>Update cover</source>
+            <translation>표지 업데이트</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="303" />
+            <source>Delete selected comics</source>
+            <translation>선택한 만화 삭제</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="308" />
+            <source>Delete metadata from selected comics</source>
+            <translation>선택한 만화에서 메타데이터 삭제</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="315" />
+            <source>Download tags from Comic Vine</source>
+            <translation>Comic Vine에서 태그 내려받기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="318" />
+            <source>Focus search line</source>
+            <translation>검색창으로 이동</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="324" />
+            <source>Focus comics view</source>
+            <translation>만화 보기로 이동</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="329" />
+            <source>Edit shortcuts</source>
+            <translation>단축키 편집</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="335" />
+            <source>&amp;Quit</source>
+            <translation>끝내기(&amp;Q)</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="342" />
+            <source>Update folder</source>
+            <translation>폴더 업데이트</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="344" />
+            <source>Update current folder</source>
+            <translation>현재 폴더 업데이트</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="348" />
+            <source>Scan legacy XML metadata</source>
+            <translation>레거시 XML 메타데이터 스캔</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="352" />
+            <source>Add new reading list</source>
+            <translation>새 읽기 목록 추가</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="355" />
+            <source>Add a new reading list to the current library</source>
+            <translation>현재 라이브러리에 새 읽기 목록 추가</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="357" />
+            <source>Remove reading list</source>
+            <translation>읽기 목록 제거</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="360" />
+            <source>Remove current reading list from the library</source>
+            <translation>라이브러리에서 현재 읽기 목록 제거</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="362" />
+            <source>Add new label</source>
+            <translation>새 라벨 추가</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="365" />
+            <source>Add a new label to this library</source>
+            <translation>이 라이브러리에 새 라벨 추가</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="367" />
+            <source>Rename selected list</source>
+            <translation>선택한 목록 이름 변경</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="370" />
+            <source>Rename any selected labels or lists</source>
+            <translation>선택한 라벨이나 목록 이름 변경</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="373" />
+            <source>Add to...</source>
+            <translation>추가...</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="375" />
+            <source>Favorites</source>
+            <translation>즐겨찾기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="378" />
+            <source>Add selected comics to favorites list</source>
+            <translation>선택한 만화를 즐겨찾기 목록에 추가</translation>
+        </message>
+    </context>
+    <context>
+        <name>LocalComicListModel</name>
+        <message>
+            <location filename="comic_vine/model/local_comic_list_model.cpp" line="72" />
+            <source>file name</source>
+            <translation>파일 이름</translation>
+        </message>
+    </context>
+    <context>
+        <name>NoLibrariesWidget</name>
+        <message>
+            <location filename="no_libraries_widget.cpp" line="20" />
+            <source>You don't have any libraries yet</source>
+            <translation>아직 라이브러리가 없습니다</translation>
+        </message>
+        <message>
+            <location filename="no_libraries_widget.cpp" line="22" />
+            <source>&lt;p&gt;You can create a library in any folder, YACReaderLibrary will import all comics and folders from this folder. If you have created any library in the past you can open them.&lt;/p&gt;&lt;p&gt;Don't forget that you can use YACReader as a stand alone application for reading the comics on your computer.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;아무 폴더에 라이브러리를 만들 수 있고, YACReaderLibrary가 그 폴더의 모든 만화와 하위 폴더를 가져옵니다. 이전에 만든 라이브러리가 있으면 열 수 있습니다.&lt;/p&gt;&lt;p&gt;YACReader는 단독 응용 프로그램으로 컴퓨터의 만화를 보는 데도 쓸 수 있습니다.&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <location filename="no_libraries_widget.cpp" line="26" />
+            <source>create your first library</source>
+            <translation>첫 라이브러리 만들기</translation>
+        </message>
+        <message>
+            <location filename="no_libraries_widget.cpp" line="28" />
+            <source>add an existing one</source>
+            <translation>기존 라이브러리 추가</translation>
+        </message>
+    </context>
+    <context>
+        <name>NoSearchResultsWidget</name>
+        <message>
+            <location filename="no_search_results_widget.cpp" line="9" />
+            <source>No results</source>
+            <translation>결과 없음</translation>
+        </message>
+    </context>
+    <context>
+        <name>OptionsDialog</name>
+        <message>
+            <location filename="options_dialog.cpp" line="169" />
+            <location filename="../YACReader/options_dialog.cpp" line="44" />
+            <source>Language</source>
+            <translation>언어</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="171" />
+            <location filename="../YACReader/options_dialog.cpp" line="46" />
+            <source>Application language</source>
+            <translation>응용 프로그램 언어</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="173" />
+            <location filename="../YACReader/options_dialog.cpp" line="48" />
+            <source>System default</source>
+            <translation>시스템 기본값</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="183" />
+            <source>Tray icon settings (experimental)</source>
+            <translation>트레이 아이콘 설정 (실험적)</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="186" />
+            <source>Close to tray</source>
+            <translation>트레이로 최소화</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="187" />
+            <source>Start into the system tray</source>
+            <translation>시스템 트레이에서 시작</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="205" />
+            <source>Edit Comic Vine API key</source>
+            <translation>Comic Vine API 키 편집</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="208" />
+            <source>Comic Vine API key</source>
+            <translation>Comic Vine API 키</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="213" />
+            <source>ComicInfo.xml legacy support</source>
+            <translation>ComicInfo.xml 레거시 지원</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="215" />
+            <source>Import metadata from ComicInfo.xml when adding new comics</source>
+            <oldsource>Import metada from ComicInfo.xml when adding new comics</oldsource>
+            <translation>새 만화 추가 시 ComicInfo.xml에서 메타데이터 가져오기</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="225" />
+            <source>Consider 'recent' items added or updated since X days ago</source>
+            <translation>X일 전부터 추가되거나 업데이트된 항목을 '최근'으로 간주</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="237" />
+            <source>Third party reader</source>
+            <translation>타사 뷰어</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="239" />
+            <source>Write {comic_file_path} where the path should go in the command</source>
+            <translation>명령어에서 경로가 들어갈 자리에 {comic_file_path}를 입력하세요</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="240" />
+            <location filename="../YACReader/options_dialog.cpp" line="87" />
+            <source>Clear</source>
+            <translation>지우기</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="265" />
+            <source>Update libraries at startup</source>
+            <translation>시작 시 라이브러리 업데이트</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="270" />
+            <source>Try to detect changes automatically</source>
+            <translation>변경 사항 자동 감지 시도</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="275" />
+            <source>Update libraries periodically</source>
+            <translation>라이브러리 주기적으로 업데이트</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="281" />
+            <source>Interval:</source>
+            <translation>간격:</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="283" />
+            <source>30 minutes</source>
+            <translation>30분</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="284" />
+            <source>1 hour</source>
+            <translation>1시간</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="285" />
+            <source>2 hours</source>
+            <translation>2시간</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="286" />
+            <source>4 hours</source>
+            <translation>4시간</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="287" />
+            <source>8 hours</source>
+            <translation>8시간</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="288" />
+            <source>12 hours</source>
+            <translation>12시간</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="289" />
+            <source>daily</source>
+            <translation>매일</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="296" />
+            <source>Update libraries at certain time</source>
+            <translation>특정 시간에 라이브러리 업데이트</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="302" />
+            <source>Time:</source>
+            <translation>시간:</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="329" />
+            <source>WARNING! During library updates writes to the database are disabled!
+Don't schedule updates while you may be using the app actively.
+During automatic updates the app will block some of the actions until the update is finished.
+To stop an automatic update tap on the loading indicator next to the Libraries title.</source>
+            <oldsource>WARNING! During library updates writes to the database are disabled!
+Don't schedule updates while you may be using the app actively.
+To stop an automatic update tap on the loading indicator next to the Libraries title.</oldsource>
+            <translation>주의! 라이브러리를 업데이트하는 동안에는 데이터베이스에 기록할 수 없습니다.
+앱을 적극적으로 사용 중일 때는 업데이트를 예약하지 마세요.
+자동 업데이트가 진행되는 동안에는 일부 기능이 잠시 차단될 수 있습니다.
+자동 업데이트를 중단하려면 라이브러리 제목 옆에 표시되는 로딩 아이콘을 눌러주세요.</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="337" />
+            <source>Modifications detection</source>
+            <translation>수정 감지</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="339" />
+            <source>Compare the modified date of files when updating a library (not recommended)</source>
+            <translation>라이브러리 업데이트 시 파일 수정 날짜 비교 (권장하지 않음)</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="378" />
+            <source>Enable background image</source>
+            <translation>배경 이미지 사용</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="380" />
+            <source>Opacity level</source>
+            <translation>불투명도</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="385" />
+            <source>Blur level</source>
+            <translation>흐림 정도</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="390" />
+            <source>Use selected comic cover as background</source>
+            <translation>선택한 만화 표지를 배경으로 사용</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="392" />
+            <source>Restore defautls</source>
+            <translation>기본값으로 복원</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="403" />
+            <source>Background</source>
+            <translation>배경</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="406" />
+            <source>Display continue reading banner</source>
+            <translation>이어 읽기 배너 표시</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="407" />
+            <source>Display current comic banner</source>
+            <translation>현재 만화 배너 표시</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="413" />
+            <source>Continue reading</source>
+            <translation>이어 읽기</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="29" />
+            <source>Comic Flow</source>
+            <translation>코믹 플로우</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="28" />
+            <location filename="options_dialog.cpp" line="334" />
+            <source>Libraries</source>
+            <translation>라이브러리</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="30" />
+            <source>Grid view</source>
+            <translation>격자 보기</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="27" />
+            <location filename="../YACReader/options_dialog.cpp" line="253" />
+            <source>General</source>
+            <translation>일반</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="31" />
+            <location filename="../YACReader/options_dialog.cpp" line="256" />
+            <source>Appearance</source>
+            <translation>외관</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="44" />
+            <location filename="../YACReader/options_dialog.cpp" line="271" />
+            <source>Options</source>
+            <translation>환경설정</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="37" />
+            <source>My comics path</source>
+            <translation>내 만화 경로</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="57" />
+            <source>Display</source>
+            <translation>표시</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="59" />
+            <source>Show time in current page information label</source>
+            <translation>현재 페이지 정보 라벨에 시간 표시</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="65" />
+            <source>"Go to flow" size</source>
+            <translation>페이지 흐름 크기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="83" />
+            <source>Background color</source>
+            <translation>배경색</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="86" />
+            <source>Choose</source>
+            <translation>선택</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="95" />
+            <source>Scroll behaviour</source>
+            <translation>스크롤 동작</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="98" />
+            <source>Disable scroll animations and smooth scrolling</source>
+            <translation>스크롤 애니메이션과 부드러운 스크롤 끄기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="99" />
+            <source>Do not turn page using scroll</source>
+            <translation>스크롤로 페이지 넘기지 않기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="100" />
+            <source>Use single scroll step to turn page</source>
+            <translation>한 단계 스크롤로 페이지 넘기기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="108" />
+            <source>Mouse mode</source>
+            <translation>마우스 모드</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="111" />
+            <source>Only Back/Forward buttons can turn pages</source>
+            <translation>뒤로/앞으로 버튼만 페이지 넘김</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="112" />
+            <source>Use the Left/Right buttons to turn pages.</source>
+            <translation>왼쪽/오른쪽 버튼으로 페이지 넘김.</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="113" />
+            <source>Click left or right half of the screen to turn pages.</source>
+            <translation>화면 왼쪽 또는 오른쪽 절반을 클릭하여 페이지 넘김.</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="139" />
+            <source>Quick Navigation Mode</source>
+            <translation>빠른 탐색 모드</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="140" />
+            <source>Disable mouse over activation</source>
+            <translation>마우스 오버 활성화 끄기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="177" />
+            <source>Brightness</source>
+            <translation>밝기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="178" />
+            <source>Contrast</source>
+            <translation>대비</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="179" />
+            <source>Gamma</source>
+            <translation>감마</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="183" />
+            <source>Reset</source>
+            <translation>초기화</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="188" />
+            <source>Image options</source>
+            <translation>이미지 옵션</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="192" />
+            <source>Fit options</source>
+            <translation>맞춤 옵션</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="194" />
+            <source>Enlarge images to fit width/height</source>
+            <translation>작은 그림도 꽉차게 보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="205" />
+            <source>Double Page options</source>
+            <translation>두 페이지 옵션</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="207" />
+            <source>Show covers as single page</source>
+            <translation>표지를 한 장으로 표시</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="218" />
+            <source>Scaling</source>
+            <translation>스케일링</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="220" />
+            <source>Scaling method</source>
+            <translation>스케일링 방법</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="222" />
+            <source>Nearest (fast, low quality)</source>
+            <translation>빠른 모드 (빠름, 저화질)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="223" />
+            <source>Bilinear</source>
+            <translation>보통 모드 (중간 품질)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="224" />
+            <source>Lanczos (better quality)</source>
+            <translation>고화질 모드 (더 좋은 화질)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="254" />
+            <source>Page Flow</source>
+            <translation>페이지 플로우</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="255" />
+            <source>Image adjustment</source>
+            <translation>이미지 조정</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="35" />
+            <location filename="../YACReader/options_dialog.cpp" line="262" />
+            <source>Restart is needed</source>
+            <translation>재시작이 필요합니다</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="285" />
+            <source>Comics directory</source>
+            <translation>만화 폴더</translation>
+        </message>
+    </context>
+    <context>
+        <name>PropertiesDialog</name>
+        <message>
+            <location filename="properties_dialog.cpp" line="88" />
+            <source>General info</source>
+            <translation>일반 정보</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="90" />
+            <source>Authors</source>
+            <translation>작가진</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="91" />
+            <source>Publishing</source>
+            <translation>출판</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="89" />
+            <source>Plot</source>
+            <translation>줄거리</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="92" />
+            <source>Notes</source>
+            <translation>메모</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="101" />
+            <source>Cover page</source>
+            <translation>표지 페이지</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="110" />
+            <source>Load previous page as cover</source>
+            <translation>이전 페이지를 표지로 불러오기</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="114" />
+            <source>Load next page as cover</source>
+            <translation>다음 페이지를 표지로 불러오기</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="119" />
+            <source>Reset cover to the default image</source>
+            <translation>표지를 기본 이미지로 초기화</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="124" />
+            <source>Load custom cover image</source>
+            <translation>사용자 지정 표지 이미지 불러오기</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="168" />
+            <source>Series:</source>
+            <translation>시리즈:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="169" />
+            <source>Title:</source>
+            <translation>제목:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="173" />
+            <location filename="properties_dialog.cpp" line="187" />
+            <location filename="properties_dialog.cpp" line="198" />
+            <source>of:</source>
+            <translation> / </translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="178" />
+            <source>Issue number:</source>
+            <translation>이슈 번호:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="180" />
+            <source>Volume:</source>
+            <translation>볼륨:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="185" />
+            <source>Arc number:</source>
+            <translation>아크 번호:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="191" />
+            <source>Story arc:</source>
+            <translation>스토리 아크:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="196" />
+            <source>alt. number:</source>
+            <translation>대체 번호:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="202" />
+            <source>Alternate series:</source>
+            <translation>대체 시리즈:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="204" />
+            <source>Series Group:</source>
+            <translation>시리즈 그룹:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="206" />
+            <source>Genre:</source>
+            <translation>장르:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="208" />
+            <source>Size:</source>
+            <translation>크기:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="228" />
+            <source>Writer(s):</source>
+            <translation>글:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="231" />
+            <source>Penciller(s):</source>
+            <translation>밑그림:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="238" />
+            <source>Inker(s):</source>
+            <translation>펜선:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="241" />
+            <source>Colorist(s):</source>
+            <translation>채색:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="248" />
+            <source>Letterer(s):</source>
+            <translation>식자:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="251" />
+            <source>Cover Artist(s):</source>
+            <translation>표지 그림:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="258" />
+            <source>Editor(s):</source>
+            <translation>편집:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="261" />
+            <source>Imprint:</source>
+            <translation>임프린트:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="282" />
+            <source>Day:</source>
+            <translation>일:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="286" />
+            <source>Month:</source>
+            <translation>월:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="290" />
+            <source>Year:</source>
+            <translation>연도:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="298" />
+            <source>Publisher:</source>
+            <translation>출판사:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="299" />
+            <source>Format:</source>
+            <translation>형식:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="300" />
+            <source>Color/BW:</source>
+            <translation>컬러/흑백:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="301" />
+            <source>Age rating:</source>
+            <translation>연령 등급:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="302" />
+            <source>Type:</source>
+            <translation>유형:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="303" />
+            <source>Language (ISO):</source>
+            <translation>언어 (ISO):</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="324" />
+            <source>Synopsis:</source>
+            <translation>줄거리:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="331" />
+            <source>Characters:</source>
+            <translation>등장인물:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="334" />
+            <source>Teams:</source>
+            <translation>팀:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="340" />
+            <source>Locations:</source>
+            <translation>장소:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="346" />
+            <source>Main character or team:</source>
+            <translation>주요 등장인물 또는 팀:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="368" />
+            <source>Review:</source>
+            <translation>리뷰:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="369" />
+            <source>Notes:</source>
+            <translation>메모:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="370" />
+            <source>Tags:</source>
+            <translation>태그:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="468" />
+            <source>Comic Vine link: &lt;a style='color: #FFCB00; text-decoration:none; font-weight:bold;' href="http://www.comicvine.com/comic/4000-%1/"&gt; view &lt;/a&gt;</source>
+            <translation>Comic Vine 링크: &lt;a style='color: #FFCB00; text-decoration:none; font-weight:bold;' href="http://www.comicvine.com/comic/4000-%1/"&gt; 보기 &lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="488" />
+            <source>Not found</source>
+            <translation>찾을 수 없음</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="488" />
+            <source>Comic not found. You should update your library.</source>
+            <translation>만화를 찾을 수 없습니다. 라이브러리를 업데이트하세요.</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="623" />
+            <source>Edit selected comics information</source>
+            <translation>선택한 만화 정보 편집</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="1241" />
+            <source>Invalid cover</source>
+            <translation>잘못된 표지</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="1241" />
+            <source>The image is invalid.</source>
+            <translation>이미지가 유효하지 않습니다.</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="585" />
+            <source>Edit comic information</source>
+            <translation>만화 정보 편집</translation>
+        </message>
+    </context>
+    <context>
+        <name>QCoreApplication</name>
+        <message>
+            <location filename="../YACReaderLibraryServer/main.cpp" line="82" />
+            <source>
+YACReaderLibraryServer is the headless (no gui) version of YACReaderLibrary.
+
+This appplication supports persistent settings, to set them up edit this file %1
+To learn about the available settings please check the documentation at https://raw.githubusercontent.com/YACReader/yacreader/develop/YACReaderLibraryServer/SETTINGS_README.md</source>
+            <translation>
+YACReaderLibraryServer는 YACReaderLibrary의 헤드리스(GUI 없는) 버전입니다.
+
+이 응용 프로그램은 영구 설정을 지원합니다. 설정을 변경하려면 다음 파일을 편집하세요: %1
+사용 가능한 설정 문서는 다음에서 확인할 수 있습니다: https://raw.githubusercontent.com/YACReader/yacreader/develop/YACReaderLibraryServer/SETTINGS_README.md</translation>
+        </message>
+    </context>
+    <context>
+        <name>QObject</name>
+        <message>
+            <location filename="../common/exit_check.cpp" line="13" />
+            <source>7z lib not found</source>
+            <translation>7z 라이브러리를 찾을 수 없습니다</translation>
+        </message>
+        <message>
+            <location filename="../common/exit_check.cpp" line="13" />
+            <source>unable to load 7z lib from ./utils</source>
+            <translation>./utils에서 7z 라이브러리를 불러올 수 없습니다</translation>
+        </message>
+        <message>
+            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41" />
+            <source>Trace</source>
+            <translation>추적</translation>
+        </message>
+        <message>
+            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43" />
+            <source>Debug</source>
+            <translation>디버그</translation>
+        </message>
+        <message>
+            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45" />
+            <source>Info</source>
+            <translation>정보</translation>
+        </message>
+        <message>
+            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47" />
+            <source>Warning</source>
+            <translation>경고</translation>
+        </message>
+        <message>
+            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49" />
+            <source>Error</source>
+            <translation>오류</translation>
+        </message>
+        <message>
+            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51" />
+            <source>Fatal</source>
+            <translation>치명적 오류</translation>
+        </message>
+        <message>
+            <location filename="../common/yacreader_global_gui.cpp" line="94" />
+            <source>Select custom cover</source>
+            <translation>사용자 지정 표지 선택</translation>
+        </message>
+        <message>
+            <location filename="../common/yacreader_global_gui.cpp" line="94" />
+            <source>Images (%1)</source>
+            <translation>이미지 (%1)</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_repository.cpp" line="113" />
+            <source>The file could not be read or is not valid JSON.</source>
+            <translation>파일을 읽을 수 없거나 유효한 JSON이 아닙니다.</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_repository.cpp" line="122" />
+            <source>This theme is for %1, not %2.</source>
+            <translation>이 테마는 %2가 아닌 %1용입니다.</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_sidebar.cpp" line="149" />
+            <source>Libraries</source>
+            <translation>라이브러리</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_sidebar.cpp" line="150" />
+            <source>Folders</source>
+            <translation>폴더</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_sidebar.cpp" line="151" />
+            <source>Reading Lists</source>
+            <translation>읽기 목록</translation>
+        </message>
+    </context>
+    <context>
+        <name>RenameLibraryDialog</name>
+        <message>
+            <location filename="rename_library_dialog.cpp" line="49" />
+            <source>Rename current library</source>
+            <translation>현재 라이브러리 이름 변경</translation>
+        </message>
+        <message>
+            <location filename="rename_library_dialog.cpp" line="24" />
+            <source>Cancel</source>
+            <translation>취소</translation>
+        </message>
+        <message>
+            <location filename="rename_library_dialog.cpp" line="20" />
+            <source>Rename</source>
+            <translation>이름 변경</translation>
+        </message>
+        <message>
+            <location filename="rename_library_dialog.cpp" line="15" />
+            <source>New Library Name : </source>
+            <translation>새 라이브러리 이름: </translation>
+        </message>
+    </context>
+    <context>
+        <name>ScraperResultsPaginator</name>
+        <message>
+            <location filename="comic_vine/scraper_results_paginator.cpp" line="19" />
+            <source>Number of volumes found : %1</source>
+            <translation>검색된 볼륨 수 : %1</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/scraper_results_paginator.cpp" line="20" />
+            <location filename="comic_vine/scraper_results_paginator.cpp" line="44" />
+            <source>page %1 of %2</source>
+            <translation>%1 / %2 페이지</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/scraper_results_paginator.cpp" line="43" />
+            <source>Number of %1 found : %2</source>
+            <translation>검색된 %1 수 : %2</translation>
+        </message>
+    </context>
+    <context>
+        <name>SearchSingleComic</name>
+        <message>
+            <location filename="comic_vine/search_single_comic.cpp" line="14" />
+            <source>Please provide some additional information for this comic.</source>
+            <oldsource>Please provide some additional information.</oldsource>
+            <translation>이 만화에 대한 추가 정보를 입력하세요.</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/search_single_comic.cpp" line="18" />
+            <source>Series:</source>
+            <translation>시리즈:</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/search_single_comic.cpp" line="21" />
+            <source>Use exact match search. Disable if you want to find volumes that match some of the words in the name.</source>
+            <translation>정확히 일치 검색을 사용합니다. 이름의 일부 단어와 일치하는 볼륨을 찾으려면 비활성화하세요.</translation>
+        </message>
+    </context>
+    <context>
+        <name>SearchVolume</name>
+        <message>
+            <location filename="comic_vine/search_volume.cpp" line="12" />
+            <source>Please provide some additional information.</source>
+            <translation>추가 정보를 입력하세요.</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/search_volume.cpp" line="14" />
+            <source>Series:</source>
+            <translation>시리즈:</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/search_volume.cpp" line="17" />
+            <source>Use exact match search. Disable if you want to find volumes that match some of the words in the name.</source>
+            <translation>정확히 일치 검색을 사용합니다. 이름의 일부 단어와 일치하는 볼륨을 찾으려면 비활성화하세요.</translation>
+        </message>
+    </context>
+    <context>
+        <name>SelectComic</name>
+        <message>
+            <location filename="comic_vine/select_comic.cpp" line="16" />
+            <source>Please, select the right comic info.</source>
+            <translation>맞는 만화 정보를 선택하세요.</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/select_comic.cpp" line="37" />
+            <source>comics</source>
+            <translation>만화</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/select_comic.cpp" line="106" />
+            <source>loading cover</source>
+            <translation>표지 불러오는 중</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/select_comic.cpp" line="107" />
+            <source>loading description</source>
+            <translation>설명 불러오는 중</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/select_comic.cpp" line="157" />
+            <source>comic description unavailable</source>
+            <translation>만화 설명을 사용할 수 없음</translation>
+        </message>
+    </context>
+    <context>
+        <name>SelectVolume</name>
+        <message>
+            <location filename="comic_vine/select_volume.cpp" line="35" />
+            <source>Please, select the right series for your comic.</source>
+            <translation>만화에 맞는 시리즈를 선택하세요.</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/select_volume.cpp" line="54" />
+            <source>Filter:</source>
+            <translation>필터:</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/select_volume.cpp" line="65" />
+            <source>volumes</source>
+            <translation>볼륨</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/select_volume.cpp" line="148" />
+            <source>Nothing found, clear the filter if any.</source>
+            <translation>검색 결과 없음. 필터가 있으면 초기화하세요.</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/select_volume.cpp" line="154" />
+            <source>loading cover</source>
+            <translation>표지 불러오는 중</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/select_volume.cpp" line="155" />
+            <source>loading description</source>
+            <translation>설명 불러오는 중</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/select_volume.cpp" line="207" />
+            <source>volume description unavailable</source>
+            <translation>볼륨 설명을 사용할 수 없음</translation>
+        </message>
+    </context>
+    <context>
+        <name>SeriesQuestion</name>
+        <message>
+            <location filename="comic_vine/series_question.cpp" line="12" />
+            <source>You are trying to get information for various comics at once, are they part of the same series?</source>
+            <translation>여러 만화의 정보를 한 번에 가져오려고 합니다. 같은 시리즈에 속하는 만화입니까?</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/series_question.cpp" line="13" />
+            <source>yes</source>
+            <translation>예</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/series_question.cpp" line="14" />
+            <source>no</source>
+            <translation>아니오</translation>
+        </message>
+    </context>
+    <context>
+        <name>ServerConfigDialog</name>
+        <message>
+            <location filename="server_config_dialog.cpp" line="27" />
+            <source>set port</source>
+            <translation>포트 설정</translation>
+        </message>
+        <message>
+            <location filename="server_config_dialog.cpp" line="34" />
+            <source>Server connectivity information</source>
+            <translation>서버 연결 정보</translation>
+        </message>
+        <message>
+            <location filename="server_config_dialog.cpp" line="37" />
+            <source>Scan it!</source>
+            <translation>스캔하세요!</translation>
+        </message>
+        <message>
+            <location filename="server_config_dialog.cpp" line="42" />
+            <source>YACReader is available for iOS and Android devices.&lt;br/&gt;Discover it for &lt;a href='https://ios.yacreader.com' style='color:rgb(193, 148, 65)'&gt;iOS&lt;/a&gt; or &lt;a href='https://android.yacreader.com' style='color:rgb(193, 148, 65)'&gt;Android&lt;/a&gt;.</source>
+            <translation>YACReader는 iOS와 Android 기기에서도 사용할 수 있습니다.&lt;br/&gt;&lt;a href='https://ios.yacreader.com' style='color:rgb(193, 148, 65)'&gt;iOS&lt;/a&gt; 또는 &lt;a href='https://android.yacreader.com' style='color:rgb(193, 148, 65)'&gt;Android&lt;/a&gt;에서 확인하세요.</translation>
+        </message>
+        <message>
+            <location filename="server_config_dialog.cpp" line="48" />
+            <source>Choose an IP address</source>
+            <translation>IP 주소 선택</translation>
+        </message>
+        <message>
+            <location filename="server_config_dialog.cpp" line="51" />
+            <source>Port</source>
+            <translation>포트</translation>
+        </message>
+        <message>
+            <location filename="server_config_dialog.cpp" line="83" />
+            <source>enable the server</source>
+            <translation>서버 사용</translation>
+        </message>
+    </context>
+    <context>
+        <name>SortVolumeComics</name>
+        <message>
+            <location filename="comic_vine/sort_volume_comics.cpp" line="59" />
+            <source>Please, sort the list of comics on the left until it matches the comics' information.</source>
+            <translation>왼쪽의 만화 목록을 만화 정보와 일치할 때까지 정렬하세요.</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/sort_volume_comics.cpp" line="61" />
+            <source>sort comics to match comic information</source>
+            <translation>만화 정보에 맞게 정렬</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/sort_volume_comics.cpp" line="98" />
+            <source>issues</source>
+            <translation>이슈</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/sort_volume_comics.cpp" line="126" />
+            <source>remove selected comics</source>
+            <translation>선택한 만화 제거</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/sort_volume_comics.cpp" line="127" />
+            <source>restore all removed comics</source>
+            <translation>제거한 만화 모두 복원</translation>
+        </message>
+    </context>
+    <context>
+        <name>ThemeEditorDialog</name>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="65" />
+            <source>Theme Editor</source>
+            <translation>테마 편집기</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="69" />
+            <source>+</source>
+            <translation>+</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="70" />
+            <source>-</source>
+            <translation>-</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="71" />
+            <source>i</source>
+            <translation>i</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="75" />
+            <source>Expand all</source>
+            <translation>모두 펼치기</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="76" />
+            <source>Collapse all</source>
+            <translation>모두 접기</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="77" />
+            <source>Hold to flash the selected value in the UI (magenta / toggled / 0↔10). Releases restore the original.</source>
+            <translation>누르고 있으면 UI에서 선택한 값이 깜박입니다 (마젠타 / 토글 / 0↔10). 놓으면 원래대로 돌아갑니다.</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="82" />
+            <source>Search…</source>
+            <translation>검색…</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="100" />
+            <source>Light</source>
+            <translation>밝은</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="101" />
+            <source>Dark</source>
+            <translation>어두운</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="104" />
+            <source>ID:</source>
+            <translation>ID:</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="105" />
+            <source>Display name:</source>
+            <translation>표시 이름:</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="106" />
+            <source>Variant:</source>
+            <translation>변형:</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="108" />
+            <source>Theme info</source>
+            <translation>테마 정보</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="129" />
+            <source>Parameter</source>
+            <translation>매개변수</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="129" />
+            <source>Value</source>
+            <translation>값</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="153" />
+            <source>Save and apply</source>
+            <translation>저장 후 적용</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="154" />
+            <source>Export to file...</source>
+            <translation>파일로 내보내기...</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="155" />
+            <source>Load from file...</source>
+            <translation>파일에서 불러오기...</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="156" />
+            <source>Close</source>
+            <translation>닫기</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="213" />
+            <source>Double-click to edit color</source>
+            <translation>두 번 클릭하여 색 편집</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="215" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="267" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="268" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="462" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="467" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="498" />
+            <source>true</source>
+            <translation>true</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="215" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="268" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="467" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="498" />
+            <source>false</source>
+            <translation>false</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="218" />
+            <source>Double-click to toggle</source>
+            <translation>두 번 클릭하여 전환</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="222" />
+            <source>Double-click to edit value</source>
+            <translation>두 번 클릭하여 값 편집</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="236" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="283" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="288" />
+            <source>Edit: %1</source>
+            <translation>편집: %1</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="402" />
+            <source>Save theme</source>
+            <translation>테마 저장</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="402" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="417" />
+            <source>JSON files (*.json);;All files (*)</source>
+            <translation>JSON 파일 (*.json);;모든 파일 (*)</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="408" />
+            <source>Save failed</source>
+            <translation>저장 실패</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="408" />
+            <source>Could not open file for writing:
+%1</source>
+            <translation>쓰기 위해 파일을 열 수 없습니다:
+%1</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="417" />
+            <source>Load theme</source>
+            <translation>테마 불러오기</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="423" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="430" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="434" />
+            <source>Load failed</source>
+            <translation>불러오기 실패</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="423" />
+            <source>Could not open file:
+%1</source>
+            <translation>파일을 열 수 없습니다:
+%1</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="430" />
+            <source>Invalid JSON:
+%1</source>
+            <translation>잘못된 JSON:
+%1</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="434" />
+            <source>Expected a JSON object.</source>
+            <translation>JSON 객체가 필요합니다.</translation>
+        </message>
+    </context>
+    <context>
+        <name>TitleHeader</name>
+        <message>
+            <location filename="comic_vine/title_header.cpp" line="27" />
+            <source>SEARCH</source>
+            <translation>검색</translation>
+        </message>
+    </context>
+    <context>
+        <name>UpdateLibraryDialog</name>
+        <message>
+            <location filename="create_library_dialog.cpp" line="170" />
+            <source>Cancel</source>
+            <translation>취소</translation>
+        </message>
+        <message>
+            <location filename="create_library_dialog.cpp" line="164" />
+            <source>Updating....</source>
+            <translation>업데이트 중...</translation>
+        </message>
+        <message>
+            <location filename="create_library_dialog.cpp" line="189" />
+            <source>Update library</source>
+            <translation>라이브러리 업데이트</translation>
+        </message>
+    </context>
+    <context>
+        <name>Viewer</name>
+        <message>
+            <location filename="../YACReader/viewer.cpp" line="60" />
+            <location filename="../YACReader/viewer.cpp" line="1367" />
+            <source>Press 'O' to open comic.</source>
+            <translation>'O'를 눌러 만화를 열어보세요.</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/viewer.cpp" line="262" />
+            <source>Not found</source>
+            <translation>찾을 수 없음</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/viewer.cpp" line="262" />
+            <source>Comic not found</source>
+            <translation>만화를 찾을 수 없습니다</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/viewer.cpp" line="268" />
+            <source>Error opening comic</source>
+            <translation>만화를 여는 중 오류가 발생했습니다</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/viewer.cpp" line="274" />
+            <source>CRC Error</source>
+            <translation>CRC 오류</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/viewer.cpp" line="1383" />
+            <source>Loading...please wait!</source>
+            <translation>불러오는 중... 잠시 기다려주세요!</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/viewer.cpp" line="1394" />
+            <source>Page not available!</source>
+            <translation>페이지를 불러올 수 없습니다!</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/viewer.cpp" line="1602" />
+            <source>Cover!</source>
+            <translation>표지!</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/viewer.cpp" line="1616" />
+            <source>Last page!</source>
+            <translation>마지막 페이지!</translation>
+        </message>
+    </context>
+    <context>
+        <name>VolumeComicsModel</name>
+        <message>
+            <location filename="comic_vine/model/volume_comics_model.cpp" line="120" />
+            <source>title</source>
+            <translation>제목</translation>
+        </message>
+    </context>
+    <context>
+        <name>VolumesModel</name>
+        <message>
+            <location filename="comic_vine/model/volumes_model.cpp" line="118" />
+            <source>year</source>
+            <translation>연도</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/model/volumes_model.cpp" line="120" />
+            <source>issues</source>
+            <translation>이슈</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/model/volumes_model.cpp" line="122" />
+            <source>publisher</source>
+            <translation>출판사</translation>
+        </message>
+    </context>
+    <context>
+        <name>YACReader3DFlowConfigWidget</name>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="19" />
+            <source>Presets:</source>
+            <translation>프리셋:</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="21" />
+            <source>Classic look</source>
+            <translation>클래식 스타일</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="24" />
+            <source>Stripe look</source>
+            <translation>줄무늬 스타일</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="27" />
+            <source>Overlapped Stripe look</source>
+            <translation>겹친 줄무늬 스타일</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="30" />
+            <source>Modern look</source>
+            <translation>모던 스타일</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="33" />
+            <source>Roulette look</source>
+            <translation>룰렛 스타일</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="77" />
+            <source>Show advanced settings</source>
+            <translation>고급 설정 보기</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="86" />
+            <source>Custom:</source>
+            <translation>사용자 지정:</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="89" />
+            <source>View angle</source>
+            <translation>시야각</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="95" />
+            <source>Position</source>
+            <translation>위치</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="101" />
+            <source>Cover gap</source>
+            <translation>표지 간격</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="107" />
+            <source>Central gap</source>
+            <translation>중앙 간격</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="113" />
+            <source>Zoom</source>
+            <translation>확대/축소</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="119" />
+            <source>Y offset</source>
+            <translation>Y축 오프셋</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="125" />
+            <source>Z offset</source>
+            <translation>Z축 오프셋</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="131" />
+            <source>Cover Angle</source>
+            <translation>표지 각도</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="137" />
+            <source>Visibility</source>
+            <translation>가시성</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="143" />
+            <source>Light</source>
+            <translation>조명</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="149" />
+            <source>Max angle</source>
+            <translation>최대 각도</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="181" />
+            <source>Low Performance</source>
+            <translation>저성능</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="183" />
+            <source>High Performance</source>
+            <translation>고성능</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="194" />
+            <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
+            <translation>수직 동기화 사용 (전체화면 결의 이미지 품질 향상, 성능 저하)</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="202" />
+            <source>Performance:</source>
+            <translation>성능:</translation>
+        </message>
+    </context>
+    <context>
+        <name>YACReader::MainWindowViewer</name>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="190" />
+            <source>&amp;Open</source>
+            <translation>열기(&amp;O)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="191" />
+            <source>Open a comic</source>
+            <translation>만화 열기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="197" />
+            <source>New instance</source>
+            <translation>새 창</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="216" />
+            <source>Open Folder</source>
+            <translation>폴더 열기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="217" />
+            <source>Open image folder</source>
+            <translation>이미지 폴더 열기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="222" />
+            <source>Open latest comic</source>
+            <translation>마지막 만화 열기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="223" />
+            <source>Open the latest comic opened in the previous reading session</source>
+            <translation>이전 작업에서 마지막으로 열었던 만화 열기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="235" />
+            <source>Clear</source>
+            <translation>지우기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="236" />
+            <source>Clear open recent list</source>
+            <translation>최근 목록 지우기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="239" />
+            <source>Save</source>
+            <translation>저장</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="240" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="945" />
+            <source>Save current page</source>
+            <translation>현재 페이지 저장</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="245" />
+            <source>Previous Comic</source>
+            <translation>이전 만화</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="246" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1733" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1737" />
+            <source>Open previous comic</source>
+            <translation>이전 만화 열기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="251" />
+            <source>Next Comic</source>
+            <translation>다음 만화</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="252" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1732" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1738" />
+            <source>Open next comic</source>
+            <translation>다음 만화 열기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="257" />
+            <source>&amp;Previous</source>
+            <translation>이전(&amp;P)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="259" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1735" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1739" />
+            <source>Go to previous page</source>
+            <translation>이전 페이지로 이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="264" />
+            <source>&amp;Next</source>
+            <translation>다음(&amp;N)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="266" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1734" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1740" />
+            <source>Go to next page</source>
+            <translation>다음 페이지로 이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="271" />
+            <source>Fit Height</source>
+            <translation>꽉차게 보기 (높이 맞춤)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="272" />
+            <source>Fit image to height</source>
+            <translation>이미지를 높이에 맞춤</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="278" />
+            <source>Fit Width</source>
+            <translation>꽉차게 보기 (폭 맞춤)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="279" />
+            <source>Fit image to width</source>
+            <translation>이미지를 폭에 맞춤</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="285" />
+            <source>Show full size</source>
+            <translation>원본 크기 (100%)로 보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="292" />
+            <source>Fit to page</source>
+            <translation>꽉차게 보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="298" />
+            <source>Continuous scroll</source>
+            <translation>연속 스크롤</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="299" />
+            <source>Switch to continuous scroll mode</source>
+            <translation>연속 스크롤 모드로 전환</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="331" />
+            <source>Reset zoom</source>
+            <translation>확대/축소 초기화</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="336" />
+            <source>Show zoom slider</source>
+            <translation>확대/축소 슬라이더 보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="338" />
+            <source>Zoom+</source>
+            <translation>확대+</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="343" />
+            <source>Zoom-</source>
+            <translation>축소-</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="348" />
+            <source>Rotate image to the left</source>
+            <translation>이미지 왼쪽으로 회전</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="353" />
+            <source>Rotate image to the right</source>
+            <translation>이미지 오른쪽으로 회전</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="358" />
+            <source>Double page mode</source>
+            <translation>두 페이지씩 보기 (왼쪽 → 오른쪽)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="359" />
+            <source>Switch to double page mode</source>
+            <translation>두 페이지씩 보기로 전환</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="367" />
+            <source>Double page manga mode</source>
+            <translation>두 페이지씩 보기 (왼쪽 ← 오른쪽)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="368" />
+            <source>Reverse reading order in double page mode</source>
+            <translation>두 페이지씩 보기에서 읽기 순서 뒤집기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="376" />
+            <source>Go To</source>
+            <translation>이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="377" />
+            <source>Go to page ...</source>
+            <translation>페이지로 이동...</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="382" />
+            <source>Options</source>
+            <translation>환경설정</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="383" />
+            <source>YACReader options</source>
+            <translation>YACReader 환경설정</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="389" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="684" />
+            <source>Help</source>
+            <translation>도움말</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="390" />
+            <source>Help, About YACReader</source>
+            <translation>도움말, YACReader 정보</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="395" />
+            <source>Magnifying glass</source>
+            <translation>돋보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="396" />
+            <source>Switch Magnifying glass</source>
+            <translation>돋보기 전환</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="402" />
+            <source>Set bookmark</source>
+            <translation>책갈피 설정</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="403" />
+            <source>Set a bookmark on the current page</source>
+            <translation>현재 페이지에 책갈피 설정</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="411" />
+            <source>Show bookmarks</source>
+            <translation>책갈피 보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="412" />
+            <source>Show the bookmarks of the current comic</source>
+            <translation>현재 만화의 책갈피 보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="417" />
+            <source>Show keyboard shortcuts</source>
+            <translation>키보드 단축키 보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="422" />
+            <source>Show Info</source>
+            <translation>정보 보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="427" />
+            <source>Close</source>
+            <translation>닫기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="432" />
+            <source>Show Dictionary</source>
+            <translation>사전 보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="438" />
+            <source>Show go to flow</source>
+            <translation>페이지 흐름 보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="443" />
+            <source>Edit shortcuts</source>
+            <translation>단축키 편집</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="464" />
+            <source>&amp;File</source>
+            <translation>파일(&amp;F)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="479" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="638" />
+            <source>Open recent</source>
+            <translation>최근 항목 열기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="627" />
+            <source>File</source>
+            <translation>파일</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="648" />
+            <source>Edit</source>
+            <translation>편집</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="652" />
+            <source>View</source>
+            <translation>보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="669" />
+            <source>Go</source>
+            <translation>이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="677" />
+            <source>Window</source>
+            <translation>창</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="794" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="796" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="798" />
+            <source>Open Comic</source>
+            <translation>만화 열기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="794" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="796" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="798" />
+            <source>Comic files</source>
+            <translation>만화 파일</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="889" />
+            <source>Open folder</source>
+            <translation>폴더 열기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="945" />
+            <source>page_%1.jpg</source>
+            <translation>page_%1.jpg</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="945" />
+            <source>Image files (*.jpg)</source>
+            <translation>이미지 파일 (*.jpg)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1151" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1164" />
+            <source>Comics</source>
+            <translation>만화</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1152" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1180" />
+            <source>General</source>
+            <translation>일반</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1153" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1218" />
+            <source>Magnifiying glass</source>
+            <translation>돋보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1154" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1229" />
+            <source>Page adjustement</source>
+            <translation>페이지 조정</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1155" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1307" />
+            <source>Reading</source>
+            <translation>읽기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1174" />
+            <source>Toggle fullscreen mode</source>
+            <translation>전체화면 전환</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1177" />
+            <source>Hide/show toolbar</source>
+            <translation>도구 모음 표시/숨김</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1199" />
+            <source>Size up magnifying glass</source>
+            <translation>돋보기 크게</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1202" />
+            <source>Size down magnifying glass</source>
+            <translation>돋보기 작게</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1205" />
+            <source>Zoom in magnifying glass</source>
+            <translation>돋보기 확대</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1208" />
+            <source>Zoom out magnifying glass</source>
+            <translation>돋보기 축소</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1211" />
+            <source>Reset magnifying glass</source>
+            <translation>돋보기 초기화</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1225" />
+            <source>Toggle between fit to width and fit to height</source>
+            <translation>폭 맞춤 / 높이 맞춤 전환</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1247" />
+            <source>Autoscroll down</source>
+            <translation>아래로 자동 스크롤</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1250" />
+            <source>Autoscroll up</source>
+            <translation>위로 자동 스크롤</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1253" />
+            <source>Autoscroll forward, horizontal first</source>
+            <translation>세로 우선으로 정방향 자동 스크롤</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1257" />
+            <source>Autoscroll backward, horizontal first</source>
+            <translation>가로 우선으로 정방향 자동 스크롤</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1261" />
+            <source>Autoscroll forward, vertical first</source>
+            <translation>세로 우선으로 역방향 자동 스크롤</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1265" />
+            <source>Autoscroll backward, vertical first</source>
+            <translation>가로 우선으로 역방향 자동 스크롤</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1269" />
+            <source>Move down</source>
+            <translation>아래로 이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1272" />
+            <source>Move up</source>
+            <translation>위로 이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1275" />
+            <source>Move left</source>
+            <translation>왼쪽으로 이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1278" />
+            <source>Move right</source>
+            <translation>오른쪽으로 이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1281" />
+            <source>Go to the first page</source>
+            <translation>첫 페이지로 이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1284" />
+            <source>Go to the last page</source>
+            <translation>마지막 페이지로 이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1287" />
+            <source>Offset double page to the left</source>
+            <translation>두 페이지 왼쪽으로 이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1289" />
+            <source>Offset double page to the right</source>
+            <translation>두 페이지 오른쪽으로 이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1356" />
+            <source>There is a new version available</source>
+            <translation>새 버전을 내려받으시겠습니까?</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1357" />
+            <source>Do you want to download the new version?</source>
+            <translation>새 버전을 내려받으시겠습니까?</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1360" />
+            <source>Remind me in 14 days</source>
+            <translation>14일 후에 다시 알림</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1361" />
+            <source>Not now</source>
+            <translation>나중에</translation>
+        </message>
+    </context>
+    <context>
+        <name>YACReader::TrayIconController</name>
+        <message>
+            <location filename="trayicon_controller.cpp" line="52" />
+            <source>&amp;Restore</source>
+            <translation>복원(&amp;R)</translation>
+        </message>
+        <message>
+            <location filename="trayicon_controller.cpp" line="79" />
+            <source>Systray</source>
+            <translation>시스템 트레이</translation>
+        </message>
+        <message>
+            <location filename="trayicon_controller.cpp" line="80" />
+            <source>YACReaderLibrary will keep running in the system tray. To terminate the program, choose &lt;b&gt;Quit&lt;/b&gt; in the context menu of the system tray icon.</source>
+            <translation>YACReaderLibrary는 시스템 트레이에서 계속 실행됩니다. 프로그램을 종료하려면 시스템 트레이 아이콘의 컨텍스트 메뉴에서 &lt;b&gt;끝내기&lt;/b&gt;를 선택하세요.</translation>
+        </message>
+    </context>
+    <context>
+        <name>YACReaderFieldEdit</name>
+        <message>
+            <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9" />
+            <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28" />
+            <source>Click to overwrite</source>
+            <translation>클릭해서 덮어쓰기</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11" />
+            <source>Restore to default</source>
+            <translation>기본값으로 복원</translation>
+        </message>
+    </context>
+    <context>
+        <name>YACReaderFieldPlainTextEdit</name>
+        <message>
+            <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9" />
+            <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19" />
+            <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44" />
+            <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50" />
+            <source>Click to overwrite</source>
+            <translation>클릭해서 덮어쓰기</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10" />
+            <source>Restore to default</source>
+            <translation>기본값으로 복원</translation>
+        </message>
+    </context>
+    <context>
+        <name>YACReaderFlowConfigWidget</name>
+        <message>
+            <source>CoverFlow look</source>
+            <translation type="vanished">코버플로 스타일</translation>
+        </message>
+        <message>
+            <source>How to show covers:</source>
+            <translation type="vanished">표지 표시 방식:</translation>
+        </message>
+        <message>
+            <source>Stripe look</source>
+            <translation type="vanished">줄무늬 스타일</translation>
+        </message>
+        <message>
+            <source>Overlapped Stripe look</source>
+            <translation type="vanished">겹친 줄무늬 스타일</translation>
+        </message>
+    </context>
+    <context>
+        <name>YACReaderGLFlowConfigWidget</name>
+        <message>
+            <source>Stripe look</source>
+            <translation type="vanished">줄무늬 스타일</translation>
+        </message>
+        <message>
+            <source>Overlapped Stripe look</source>
+            <translation type="vanished">겹친 줄무늬 스타일</translation>
+        </message>
+    </context>
+    <context>
+        <name>YACReaderOptionsDialog</name>
+        <message>
+            <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="19" />
+            <source>Save</source>
+            <translation>저장</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="20" />
+            <source>Cancel</source>
+            <translation>취소</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="25" />
+            <source>Edit shortcuts</source>
+            <translation>단축키 편집</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28" />
+            <source>Shortcuts</source>
+            <translation>단축키</translation>
+        </message>
+    </context>
+    <context>
+        <name>YACReaderSearchLineEdit</name>
+        <message>
+            <location filename="../custom_widgets/yacreader_search_line_edit.cpp" line="31" />
+            <source>type to search</source>
+            <translation>검색어 입력</translation>
+        </message>
+    </context>
+    <context>
+        <name>YACReaderSlider</name>
+        <message>
+            <location filename="../YACReader/width_slider.cpp" line="49" />
+            <source>Reset</source>
+            <translation>초기화</translation>
+        </message>
+    </context>
+    <context>
+        <name>YACReaderTranslator</name>
+        <message>
+            <location filename="../YACReader/translator.cpp" line="42" />
+            <source>YACReader translator</source>
+            <translation>YACReader 번역기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/translator.cpp" line="82" />
+            <location filename="../YACReader/translator.cpp" line="188" />
+            <source>Translation</source>
+            <translation>번역</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/translator.cpp" line="102" />
+            <source>clear</source>
+            <translation>지우기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/translator.cpp" line="197" />
+            <source>Service not available</source>
+            <translation>서비스를 사용할 수 없습니다</translation>
+        </message>
+    </context>
+</TS>

--- a/YACReader/yacreader_ko.ts
+++ b/YACReader/yacreader_ko.ts
@@ -932,12 +932,12 @@
         <location filename="main_window_viewer.cpp" line="1130"/>
         <location filename="main_window_viewer.cpp" line="1148"/>
         <source>Extract page(s)</source>
-        <translation type="unfinished"></translation>
+        <translation type="페이지 추출"></translation>
     </message>
     <message>
         <location filename="main_window_viewer.cpp" line="375"/>
         <source>Extract page(s) from the original source</source>
-        <translation type="unfinished"></translation>
+        <translation type="페이지 추출"></translation>
     </message>
     <message>
         <location filename="main_window_viewer.cpp" line="380"/>
@@ -1226,32 +1226,32 @@
     <message>
         <location filename="main_window_viewer.cpp" line="1094"/>
         <source>Overwrite file?</source>
-        <translation type="unfinished"></translation>
+        <translation type="파일을 덮어쓰기 하시겠습니까?"></translation>
     </message>
     <message>
         <location filename="main_window_viewer.cpp" line="1094"/>
         <source>The file already exists. Do you want to overwrite it?</source>
-        <translation type="unfinished"></translation>
+        <translation type="파일이 이미 있습니다. 덮어쓰시겠습니까?"></translation>
     </message>
     <message>
         <location filename="main_window_viewer.cpp" line="1130"/>
         <source>The current page could not be extracted.</source>
-        <translation type="unfinished"></translation>
+        <translation type="현재 페이지를 추출할 수 없습니다."></translation>
     </message>
     <message>
         <location filename="main_window_viewer.cpp" line="1135"/>
         <source>Overwrite files?</source>
-        <translation type="unfinished"></translation>
+        <translation type="파일을 덮어쓰기 하시겠습니까?"></translation>
     </message>
     <message>
         <location filename="main_window_viewer.cpp" line="1135"/>
         <source>Some files already exist. Do you want to overwrite them?</source>
-        <translation type="unfinished"></translation>
+        <translation type="일부 파일이 이미 있습니다. 덮어쓰시겠습니까?"></translation>
     </message>
     <message>
         <location filename="main_window_viewer.cpp" line="1148"/>
         <source>Some pages could not be extracted.</source>
-        <translation type="unfinished"></translation>
+        <translation type="일부 페이지를 추출할 수 없습니다."></translation>
     </message>
     <message>
         <location filename="main_window_viewer.cpp" line="1293"/>
@@ -1419,12 +1419,12 @@
     <message>
         <location filename="../custom_widgets/whats_new_dialog.cpp" line="183"/>
         <source>Release notes are not available.</source>
-        <translation type="unfinished"></translation>
+        <translation type="릴리스 노트를 사용할 수 없습니다."></translation>
     </message>
     <message>
         <location filename="../custom_widgets/whats_new_dialog.cpp" line="239"/>
         <source>Previous versions</source>
-        <translation type="unfinished"></translation>
+        <translation type="이전 버전"></translation>
     </message>
 </context>
 <context>

--- a/YACReaderLibrary/CMakeLists.txt
+++ b/YACReaderLibrary/CMakeLists.txt
@@ -484,6 +484,7 @@ qt_add_translations(YACReaderLibrary
         yacreaderlibrary_zh_TW.ts
         yacreaderlibrary_zh_HK.ts
         yacreaderlibrary_it.ts
+        yacreaderlibrary_ko.ts
         yacreaderlibrary_source.ts
         yacreaderlibrary_en.ts
     SOURCES

--- a/YACReaderLibrary/yacreaderlibrary_ko.ts
+++ b/YACReaderLibrary/yacreaderlibrary_ko.ts
@@ -1,0 +1,3892 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+    <context>
+        <name>ActionsShortcutsModel</name>
+        <message>
+            <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="73" />
+            <source>None</source>
+            <translation>없음</translation>
+        </message>
+    </context>
+    <context>
+        <name>AddLabelDialog</name>
+        <message>
+            <location filename="add_label_dialog.cpp" line="25" />
+            <source>Label name:</source>
+            <translation>라벨 이름:</translation>
+        </message>
+        <message>
+            <location filename="add_label_dialog.cpp" line="28" />
+            <source>Choose a color:</source>
+            <translation>색상 선택:</translation>
+        </message>
+        <message>
+            <location filename="add_label_dialog.cpp" line="42" />
+            <source>accept</source>
+            <translation>확인</translation>
+        </message>
+        <message>
+            <location filename="add_label_dialog.cpp" line="43" />
+            <source>cancel</source>
+            <translation>취소</translation>
+        </message>
+    </context>
+    <context>
+        <name>AddLibraryDialog</name>
+        <message>
+            <location filename="add_library_dialog.cpp" line="26" />
+            <source>Add</source>
+            <translation>추가</translation>
+        </message>
+        <message>
+            <location filename="add_library_dialog.cpp" line="64" />
+            <source>Add an existing library</source>
+            <translation>기존 라이브러리 추가</translation>
+        </message>
+        <message>
+            <location filename="add_library_dialog.cpp" line="30" />
+            <source>Cancel</source>
+            <translation>취소</translation>
+        </message>
+        <message>
+            <location filename="add_library_dialog.cpp" line="16" />
+            <source>Comics folder : </source>
+            <translation>만화 폴더: </translation>
+        </message>
+        <message>
+            <location filename="add_library_dialog.cpp" line="21" />
+            <source>Library name : </source>
+            <translation>라이브러리 이름: </translation>
+        </message>
+    </context>
+    <context>
+        <name>ApiKeyDialog</name>
+        <message>
+            <location filename="comic_vine/api_key_dialog.cpp" line="32" />
+            <source>Cancel</source>
+            <translation>취소</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/api_key_dialog.cpp" line="21" />
+            <source>Before you can connect to Comic Vine, you need your own API key. Please, get one free &lt;a href="http://www.comicvine.com/api/"&gt;here&lt;/a&gt;</source>
+            <translation>Comic Vine에 연결하려면 본인의 API 키가 필요합니다. &lt;a href="http://www.comicvine.com/api/"&gt;여기&lt;/a&gt;에서 무료로 발급받으세요.</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/api_key_dialog.cpp" line="25" />
+            <source>Paste here your Comic Vine API key</source>
+            <translation>Comic Vine API 키를 여기 붙여넣으세요</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/api_key_dialog.cpp" line="28" />
+            <source>Accept</source>
+            <translation>확인</translation>
+        </message>
+    </context>
+    <context>
+        <name>AppearanceTabWidget</name>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="38" />
+            <source>Color scheme</source>
+            <translation>색 구성표</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="46" />
+            <source>System</source>
+            <translation>시스템</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="47" />
+            <source>Light</source>
+            <translation>밝은</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="48" />
+            <source>Dark</source>
+            <translation>어두운</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="49" />
+            <source>Custom</source>
+            <translation>사용자 지정</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="105" />
+            <source>Remove</source>
+            <translation>제거</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="107" />
+            <source>Remove this user-imported theme</source>
+            <translation>사용자 가져온 이 테마 제거</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="115" />
+            <source>Light:</source>
+            <translation>밝은:</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="116" />
+            <source>Dark:</source>
+            <translation>어두운:</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="117" />
+            <source>Custom:</source>
+            <translation>사용자 지정:</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="119" />
+            <source>Import theme...</source>
+            <translation>테마 가져오기...</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="121" />
+            <source>Theme</source>
+            <translation>테마</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="173" />
+            <source>Theme editor</source>
+            <translation>테마 편집기</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="175" />
+            <source>Open Theme Editor...</source>
+            <translation>테마 편집기 열기...</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="184" />
+            <source>Theme editor error</source>
+            <translation>테마 편집기 오류</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="185" />
+            <source>The current theme JSON could not be loaded.</source>
+            <translation>현재 테마 JSON을 불러올 수 없습니다.</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="279" />
+            <source>Import theme</source>
+            <translation>테마 가져오기</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="279" />
+            <source>JSON files (*.json);;All files (*)</source>
+            <translation>JSON 파일 (*.json);;모든 파일 (*)</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="287" />
+            <source>Could not import theme from:
+%1</source>
+            <translation>다음에서 테마를 가져올 수 없습니다:
+%1</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="288" />
+            <source>Could not import theme from:
+%1
+
+%2</source>
+            <translation>다음에서 테마를 가져올 수 없습니다:
+%1
+
+%2</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/appearance_tab_widget.cpp" line="289" />
+            <source>Import failed</source>
+            <translation>가져오기 실패</translation>
+        </message>
+    </context>
+    <context>
+        <name>BookmarksDialog</name>
+        <message>
+            <location filename="../YACReader/bookmarks_dialog.cpp" line="25" />
+            <source>Lastest Page</source>
+            <translation>마지막 페이지</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/bookmarks_dialog.cpp" line="75" />
+            <source>Close</source>
+            <translation>닫기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/bookmarks_dialog.cpp" line="85" />
+            <source>Click on any image to go to the bookmark</source>
+            <translation>이미지를 클릭하면 책갈피로 이동합니다</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/bookmarks_dialog.cpp" line="107" />
+            <location filename="../YACReader/bookmarks_dialog.cpp" line="124" />
+            <source>Loading...</source>
+            <translation>불러오는 중...</translation>
+        </message>
+    </context>
+    <context>
+        <name>ClassicComicsView</name>
+        <message>
+            <location filename="classic_comics_view.cpp" line="85" />
+            <source>Hide comic flow</source>
+            <translation>만화 흐름 숨기기</translation>
+        </message>
+    </context>
+    <context>
+        <name>ComicInfoView</name>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="302" />
+            <source>Characters</source>
+            <translation>등장인물</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="334" />
+            <source>Main character or team</source>
+            <translation>주요 등장인물 또는 팀</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="359" />
+            <source>Teams</source>
+            <translation>팀</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="393" />
+            <source>Locations</source>
+            <translation>장소</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="425" />
+            <source>Authors</source>
+            <translation>작가진</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="457" />
+            <source>writer</source>
+            <translation>글</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="479" />
+            <source>penciller</source>
+            <translation>밑그림</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="501" />
+            <source>inker</source>
+            <translation>펜선</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="523" />
+            <source>colorist</source>
+            <translation>채색</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="545" />
+            <source>letterer</source>
+            <translation>식자</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="567" />
+            <source>cover artist</source>
+            <translation>표지 그림</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="589" />
+            <source>editor</source>
+            <translation>편집</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="611" />
+            <source>imprint</source>
+            <translation>출판 브랜드</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="626" />
+            <source>Publisher</source>
+            <translation>출판사</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="678" />
+            <source>color</source>
+            <translation>컬러</translation>
+        </message>
+        <message>
+            <location filename="qml/ComicInfoView.qml" line="678" />
+            <source>b/w</source>
+            <translation>흑백</translation>
+        </message>
+    </context>
+    <context>
+        <name>ComicModel</name>
+        <message>
+            <location filename="db/comic_model.cpp" line="364" />
+            <source>yes</source>
+            <translation>예</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="364" />
+            <source>no</source>
+            <translation>아니오</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="395" />
+            <source>Title</source>
+            <translation>제목</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="397" />
+            <source>File Name</source>
+            <translation>파일 이름</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="399" />
+            <source>Pages</source>
+            <translation>페이지</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="401" />
+            <source>Size</source>
+            <translation>크기</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="403" />
+            <source>Read</source>
+            <translation>읽음</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="405" />
+            <source>Current Page</source>
+            <translation>현재 페이지</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="407" />
+            <source>Publication Date</source>
+            <translation>출판일</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="409" />
+            <source>Rating</source>
+            <translation>평점</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="411" />
+            <source>Series</source>
+            <translation>시리즈</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="413" />
+            <source>Volume</source>
+            <translation>볼륨</translation>
+        </message>
+        <message>
+            <location filename="db/comic_model.cpp" line="415" />
+            <source>Story Arc</source>
+            <translation>스토리 아크</translation>
+        </message>
+    </context>
+    <context>
+        <name>ComicVineDialog</name>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="54" />
+            <source>skip</source>
+            <translation>건너뛰기</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="55" />
+            <source>back</source>
+            <translation>뒤로</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="56" />
+            <source>next</source>
+            <translation>다음</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="57" />
+            <source>search</source>
+            <translation>검색</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="58" />
+            <source>close</source>
+            <translation>닫기</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="134" />
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="588" />
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="627" />
+            <source>Looking for volume...</source>
+            <translation>볼륨 검색 중...</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="132" />
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="546" />
+            <source>comic %1 of %2 - %3</source>
+            <translation>%1 / %2 만화 - %3</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="249" />
+            <source>%1 comics selected</source>
+            <translation>만화 %1개 선택됨</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="280" />
+            <source>Error connecting to ComicVine</source>
+            <translation>Comic Vine 연결 오류</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="460" />
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="486" />
+            <source>Retrieving tags for : %1</source>
+            <translation>태그 가져오는 중 : %1</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="607" />
+            <source>Retrieving volume info...</source>
+            <translation>볼륨 정보 가져오는 중...</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/comic_vine_dialog.cpp" line="639" />
+            <source>Looking for comic...</source>
+            <translation>만화 검색 중...</translation>
+        </message>
+    </context>
+    <context>
+        <name>ContinuousPageWidget</name>
+        <message>
+            <location filename="../YACReader/continuous_page_widget.cpp" line="156" />
+            <source>Loading page %1</source>
+            <translation>페이지 %1 불러오는 중</translation>
+        </message>
+    </context>
+    <context>
+        <name>CreateLibraryDialog</name>
+        <message>
+            <location filename="create_library_dialog.cpp" line="76" />
+            <source>Create new library</source>
+            <translation>새 라이브러리 만들기</translation>
+        </message>
+        <message>
+            <location filename="create_library_dialog.cpp" line="34" />
+            <source>Cancel</source>
+            <translation>취소</translation>
+        </message>
+        <message>
+            <location filename="create_library_dialog.cpp" line="30" />
+            <source>Create</source>
+            <translation>만들기</translation>
+        </message>
+        <message>
+            <location filename="create_library_dialog.cpp" line="20" />
+            <source>Comics folder : </source>
+            <translation>만화 폴더: </translation>
+        </message>
+        <message>
+            <location filename="create_library_dialog.cpp" line="25" />
+            <source>Library Name : </source>
+            <translation>라이브러리 이름: </translation>
+        </message>
+        <message>
+            <location filename="create_library_dialog.cpp" line="56" />
+            <source>Create a library could take several minutes. You can stop the process and update the library later for completing the task.</source>
+            <translation>라이브러리 생성은 몇 분 걸릴 수 있습니다. 작업을 중지하고 나중에 라이브러리를 업데이트하여 완료할 수 있습니다.</translation>
+        </message>
+        <message>
+            <location filename="create_library_dialog.cpp" line="104" />
+            <source>Path not found</source>
+            <translation>경로를 찾을 수 없음</translation>
+        </message>
+        <message>
+            <location filename="create_library_dialog.cpp" line="104" />
+            <source>The selected path does not exist or is not a valid path. Be sure that you have write access to this folder</source>
+            <translation>선택한 경로가 존재하지 않거나 올바르지 않습니다. 이 폴더에 쓰기 권한이 있는지 확인하세요</translation>
+        </message>
+    </context>
+    <context>
+        <name>EditShortcutsDialog</name>
+        <message>
+            <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="23" />
+            <source>Restore defaults</source>
+            <translation>기본값으로 복원</translation>
+        </message>
+        <message>
+            <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="24" />
+            <source>To change a shortcut, double click in the key combination and type the new keys.</source>
+            <translation>단축키를 바꾸려면 키 조합을 더블 클릭하고 새 키를 입력하세요.</translation>
+        </message>
+        <message>
+            <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="71" />
+            <source>Shortcuts settings</source>
+            <translation>단축키 설정</translation>
+        </message>
+        <message>
+            <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="122" />
+            <source>Shortcut in use</source>
+            <translation>사용 중인 단축키</translation>
+        </message>
+        <message>
+            <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="122" />
+            <source>The shortcut "%1" is already assigned to other function</source>
+            <translation>"%1" 단축키는 이미 다른 기능이 사용 중입니다</translation>
+        </message>
+    </context>
+    <context>
+        <name>EmptyFolderWidget</name>
+        <message>
+            <location filename="empty_folder_widget.cpp" line="8" />
+            <source>This folder doesn't contain comics yet</source>
+            <translation>이 폴더에는 아직 만화가 없습니다</translation>
+        </message>
+    </context>
+    <context>
+        <name>EmptyLabelWidget</name>
+        <message>
+            <location filename="empty_label_widget.cpp" line="7" />
+            <source>This label doesn't contain comics yet</source>
+            <translation>이 라벨에 아직 만화가 없습니다</translation>
+        </message>
+    </context>
+    <context>
+        <name>EmptyReadingListWidget</name>
+        <message>
+            <location filename="empty_reading_list_widget.cpp" line="8" />
+            <source>This reading list does not contain any comics yet</source>
+            <translation>이 읽기 목록에 아직 만화가 없습니다</translation>
+        </message>
+    </context>
+    <context>
+        <name>EmptySpecialListWidget</name>
+        <message>
+            <location filename="empty_special_list.cpp" line="13" />
+            <source>No favorites</source>
+            <translation>즐겨찾기 없음</translation>
+        </message>
+        <message>
+            <location filename="empty_special_list.cpp" line="20" />
+            <source>You are not reading anything yet, come on!!</source>
+            <translation>아직 읽고 있는 만화가 없습니다. 지금 시작해보세요!!</translation>
+        </message>
+        <message>
+            <location filename="empty_special_list.cpp" line="27" />
+            <source>There are no recent comics!</source>
+            <translation>최근 본 만화가 없습니다!</translation>
+        </message>
+    </context>
+    <context>
+        <name>ExportComicsInfoDialog</name>
+        <message>
+            <location filename="export_comics_info_dialog.cpp" line="22" />
+            <source>Cancel</source>
+            <translation>취소</translation>
+        </message>
+        <message>
+            <location filename="export_comics_info_dialog.cpp" line="18" />
+            <source>Create</source>
+            <translation>생성</translation>
+        </message>
+        <message>
+            <location filename="export_comics_info_dialog.cpp" line="14" />
+            <source>Output file : </source>
+            <translation>출력 파일: </translation>
+        </message>
+        <message>
+            <location filename="export_comics_info_dialog.cpp" line="55" />
+            <source>Export comics info</source>
+            <translation>만화 정보 내보내기</translation>
+        </message>
+        <message>
+            <location filename="export_comics_info_dialog.cpp" line="72" />
+            <source>Destination database name</source>
+            <translation>대상 데이터베이스 이름</translation>
+        </message>
+        <message>
+            <location filename="export_comics_info_dialog.cpp" line="87" />
+            <source>Problem found while writing</source>
+            <translation>쓰기 중 문제 발생</translation>
+        </message>
+        <message>
+            <location filename="export_comics_info_dialog.cpp" line="87" />
+            <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
+            <translation>출력 파일에 선택한 경로가 존재하지 않거나 올바르지 않습니다. 이 폴더에 쓰기 권한이 있는지 확인하세요</translation>
+        </message>
+    </context>
+    <context>
+        <name>ExportLibraryDialog</name>
+        <message>
+            <location filename="export_library_dialog.cpp" line="19" />
+            <source>Cancel</source>
+            <translation>취소</translation>
+        </message>
+        <message>
+            <location filename="export_library_dialog.cpp" line="15" />
+            <source>Create</source>
+            <translation>생성</translation>
+        </message>
+        <message>
+            <location filename="export_library_dialog.cpp" line="11" />
+            <source>Output folder : </source>
+            <translation>출력 폴더: </translation>
+        </message>
+        <message>
+            <location filename="export_library_dialog.cpp" line="58" />
+            <source>Create covers package</source>
+            <translation>표지 패키지 생성</translation>
+        </message>
+        <message>
+            <location filename="export_library_dialog.cpp" line="82" />
+            <source>Destination directory</source>
+            <translation>대상 폴더</translation>
+        </message>
+        <message>
+            <location filename="export_library_dialog.cpp" line="77" />
+            <source>Problem found while writing</source>
+            <translation>쓰기 중 문제 발생</translation>
+        </message>
+        <message>
+            <location filename="export_library_dialog.cpp" line="77" />
+            <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
+            <translation>출력 파일에 선택한 경로가 존재하지 않거나 올바르지 않습니다. 이 폴더에 쓰기 권한이 있는지 확인하세요</translation>
+        </message>
+    </context>
+    <context>
+        <name>FileComic</name>
+        <message>
+            <location filename="../common/comic.cpp" line="562" />
+            <source>7z not found</source>
+            <translation>7z를 찾을 수 없습니다</translation>
+        </message>
+        <message>
+            <location filename="../common/comic.cpp" line="454" />
+            <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
+            <translation>%1번 페이지에서 CRC 오류 발생: 일부 페이지가 올바르게 표시되지 않을 수 있습니다</translation>
+        </message>
+        <message>
+            <location filename="../common/comic.cpp" line="461" />
+            <source>Unknown error opening the file</source>
+            <translation>파일을 여는 중 알 수 없는 오류가 발생했습니다</translation>
+        </message>
+        <message>
+            <location filename="../common/comic.cpp" line="568" />
+            <source>Format not supported</source>
+            <translation>지원하지 않는 형식입니다</translation>
+        </message>
+    </context>
+    <context>
+        <name>FolderContentView</name>
+        <message>
+            <location filename="qml/FolderContentView.qml" line="223" />
+            <source>Continue Reading...</source>
+            <translation>이어 읽기...</translation>
+        </message>
+    </context>
+    <context>
+        <name>GoToDialog</name>
+        <message>
+            <location filename="../YACReader/goto_dialog.cpp" line="15" />
+            <source>Page : </source>
+            <translation>페이지: </translation>
+        </message>
+        <message>
+            <location filename="../YACReader/goto_dialog.cpp" line="23" />
+            <source>Go To</source>
+            <translation>이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/goto_dialog.cpp" line="25" />
+            <source>Cancel</source>
+            <translation>취소</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/goto_dialog.cpp" line="39" />
+            <location filename="../YACReader/goto_dialog.cpp" line="71" />
+            <source>Total pages : </source>
+            <translation>전체 페이지: </translation>
+        </message>
+        <message>
+            <location filename="../YACReader/goto_dialog.cpp" line="53" />
+            <source>Go to...</source>
+            <translation>이동...</translation>
+        </message>
+    </context>
+    <context>
+        <name>GoToFlowToolBar</name>
+        <message>
+            <location filename="../YACReader/goto_flow_toolbar.cpp" line="25" />
+            <source>Page : </source>
+            <translation>페이지: </translation>
+        </message>
+    </context>
+    <context>
+        <name>GridComicsView</name>
+        <message>
+            <location filename="grid_comics_view.cpp" line="77" />
+            <source>Show info</source>
+            <translation>정보 보기</translation>
+        </message>
+    </context>
+    <context>
+        <name>HelpAboutDialog</name>
+        <message>
+            <location filename="../custom_widgets/help_about_dialog.cpp" line="23" />
+            <source>About</source>
+            <translation>정보</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/help_about_dialog.cpp" line="26" />
+            <source>Help</source>
+            <translation>도움말</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/help_about_dialog.cpp" line="29" />
+            <source>System info</source>
+            <translation>시스템 정보</translation>
+        </message>
+    </context>
+    <context>
+        <name>ImportComicsInfoDialog</name>
+        <message>
+            <location filename="import_comics_info_dialog.cpp" line="24" />
+            <source>Cancel</source>
+            <translation>취소</translation>
+        </message>
+        <message>
+            <location filename="import_comics_info_dialog.cpp" line="14" />
+            <source>Import comics info</source>
+            <translation>만화 정보 가져오기</translation>
+        </message>
+        <message>
+            <location filename="import_comics_info_dialog.cpp" line="16" />
+            <source>Info database location : </source>
+            <translation>정보 데이터베이스 경로: </translation>
+        </message>
+        <message>
+            <location filename="import_comics_info_dialog.cpp" line="20" />
+            <source>Import</source>
+            <translation>가져오기</translation>
+        </message>
+        <message>
+            <location filename="import_comics_info_dialog.cpp" line="80" />
+            <source>Comics info file (*.ydb)</source>
+            <translation>만화 정보 파일 (*.ydb)</translation>
+        </message>
+    </context>
+    <context>
+        <name>ImportLibraryDialog</name>
+        <message>
+            <location filename="import_library_dialog.cpp" line="26" />
+            <source>Destination folder : </source>
+            <translation>대상 폴더: </translation>
+        </message>
+        <message>
+            <location filename="import_library_dialog.cpp" line="34" />
+            <source>Cancel</source>
+            <translation>취소</translation>
+        </message>
+        <message>
+            <location filename="import_library_dialog.cpp" line="30" />
+            <source>Unpack</source>
+            <translation>풀기</translation>
+        </message>
+        <message>
+            <location filename="import_library_dialog.cpp" line="115" />
+            <source>Compresed library covers (*.clc)</source>
+            <translation>압축된 라이브러리 표지 (*.clc)</translation>
+        </message>
+        <message>
+            <location filename="import_library_dialog.cpp" line="22" />
+            <source>Package location : </source>
+            <translation>패키지 경로: </translation>
+        </message>
+        <message>
+            <location filename="import_library_dialog.cpp" line="17" />
+            <source>Library Name : </source>
+            <translation>라이브러리 이름: </translation>
+        </message>
+        <message>
+            <location filename="import_library_dialog.cpp" line="85" />
+            <source>Extract a catalog</source>
+            <translation>카탈로그 추출</translation>
+        </message>
+    </context>
+    <context>
+        <name>ImportWidget</name>
+        <message>
+            <location filename="import_widget.cpp" line="131" />
+            <source>stop</source>
+            <translation>중지</translation>
+        </message>
+        <message>
+            <location filename="import_widget.cpp" line="171" />
+            <source>Some of the comics being added...</source>
+            <translation>일부 만화를 추가하는 중...</translation>
+        </message>
+        <message>
+            <location filename="import_widget.cpp" line="318" />
+            <source>Importing comics</source>
+            <translation>만화 가져오는 중</translation>
+        </message>
+        <message>
+            <location filename="import_widget.cpp" line="319" />
+            <source>&lt;p&gt;YACReaderLibrary is now creating a new library.&lt;/p&gt;&lt;p&gt;Create a library could take several minutes. You can stop the process and update the library later for completing the task.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;YACReaderLibrary가 새 라이브러리를 만들고 있습니다.&lt;/p&gt;&lt;p&gt;라이브러리 생성은 몇 분 걸릴 수 있습니다. 작업을 중지하고 나중에 라이브러리를 업데이트하여 작업을 완료할 수 있습니다.&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <location filename="import_widget.cpp" line="330" />
+            <source>Updating the library</source>
+            <translation>라이브러리 업데이트 중</translation>
+        </message>
+        <message>
+            <location filename="import_widget.cpp" line="331" />
+            <source>&lt;p&gt;The current library is being updated. For faster updates, please, update your libraries frequently.&lt;/p&gt;&lt;p&gt;You can stop the process and continue updating this library later.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;현재 라이브러리를 업데이트하고 있습니다. 더 빠른 업데이트를 위해 라이브러리를 자주 업데이트하세요.&lt;/p&gt;&lt;p&gt;작업을 중지하고 나중에 이 라이브러리 업데이트를 계속할 수 있습니다.&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <location filename="import_widget.cpp" line="342" />
+            <source>Upgrading the library</source>
+            <translation>라이브러리 업그레이드 중</translation>
+        </message>
+        <message>
+            <location filename="import_widget.cpp" line="343" />
+            <source>&lt;p&gt;The current library is being upgraded, please wait.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;현재 라이브러리를 업그레이드하고 있습니다. 잠시만 기다려주세요.&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <location filename="import_widget.cpp" line="354" />
+            <source>Scanning the library</source>
+            <translation>라이브러리 스캔 중</translation>
+        </message>
+        <message>
+            <location filename="import_widget.cpp" line="355" />
+            <source>&lt;p&gt;Current library is being scanned for legacy XML metadata information.&lt;/p&gt;&lt;p&gt;This is only needed once, and only if the library was crated with YACReaderLibrary 9.8.2 or earlier.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;현재 라이브러리에서 레거시 XML 메타데이터 정보를 스캔하고 있습니다.&lt;/p&gt;&lt;p&gt;이 작업은 한 번만 필요하며, 라이브러리가 YACReaderLibrary 9.8.2 또는 이전 버전으로 만들어진 경우에만 해당됩니다.&lt;/p&gt;</translation>
+        </message>
+    </context>
+    <context>
+        <name>LibraryWindow</name>
+        <message>
+            <source>Remove current library from your collection</source>
+            <translation type="vanished">내 컬렉션에서 현재 라이브러리 제거</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="626" />
+            <source>Library</source>
+            <translation>라이브러리</translation>
+        </message>
+        <message>
+            <source>Rename current library</source>
+            <translation type="vanished">현재 라이브러리 이름 변경</translation>
+        </message>
+        <message>
+            <source>Open current comic on YACReader</source>
+            <translation type="vanished">YACReader에서 현재 만화 열기</translation>
+        </message>
+        <message>
+            <source>Update current library</source>
+            <translation type="vanished">현재 라이브러리 업데이트</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1408" />
+            <source>Open folder...</source>
+            <translation>폴더 열기...</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="545" />
+            <location filename="library_window.cpp" line="1310" />
+            <location filename="library_window.cpp" line="1435" />
+            <source>western manga (left to right)</source>
+            <translation>서양 만화 (왼쪽 → 오른쪽)</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="551" />
+            <location filename="library_window.cpp" line="1316" />
+            <location filename="library_window.cpp" line="1441" />
+            <source>4koma (top to botom)</source>
+            <oldsource>4koma (top to botom</oldsource>
+            <translation>4컷 (위 → 아래)</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1861" />
+            <source>Do you want remove </source>
+            <translation>다음을 제거하시겠습니까: </translation>
+        </message>
+        <message>
+            <source>Expand all nodes</source>
+            <translation type="vanished">모든 노드 펼치기</translation>
+        </message>
+        <message>
+            <source>Show options dialog</source>
+            <translation type="vanished">환경설정 다이얼로그 표시</translation>
+        </message>
+        <message>
+            <source>Create a new library</source>
+            <translation type="vanished">새 라이브러리 만들기</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="223" />
+            <source>YACReader Library</source>
+            <translation>YACReader Library</translation>
+        </message>
+        <message>
+            <source>Open an existing library</source>
+            <translation type="vanished">기존 라이브러리 열기</translation>
+        </message>
+        <message>
+            <source>Pack the covers of the selected library</source>
+            <translation type="vanished">선택한 라이브러리의 표지 묶기</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="542" />
+            <location filename="library_window.cpp" line="1307" />
+            <location filename="library_window.cpp" line="1429" />
+            <source>manga</source>
+            <translation>망가</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="539" />
+            <location filename="library_window.cpp" line="1304" />
+            <location filename="library_window.cpp" line="1432" />
+            <source>comic</source>
+            <translation>만화</translation>
+        </message>
+        <message>
+            <source>Help, About YACReader</source>
+            <translation type="vanished">도움말, YACReader 정보</translation>
+        </message>
+        <message>
+            <source>Select root node</source>
+            <translation type="vanished">루트 노드 선택</translation>
+        </message>
+        <message>
+            <source>Unpack a catalog</source>
+            <translation type="vanished">카탈로그 풀기</translation>
+        </message>
+        <message>
+            <source>Open containing folder...</source>
+            <translation type="vanished">포함된 폴더 열기...</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1861" />
+            <source>Are you sure?</source>
+            <translation>확실합니까?</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1414" />
+            <source>Rescan library for XML info</source>
+            <translation>XML 정보로 라이브러리 재검색</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1423" />
+            <source>Set as read</source>
+            <translation>읽음으로 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1426" />
+            <location filename="library_window.cpp" line="1567" />
+            <source>Set as unread</source>
+            <translation>읽지 않음으로 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="548" />
+            <location filename="library_window.cpp" line="1313" />
+            <location filename="library_window.cpp" line="1438" />
+            <source>web comic</source>
+            <translation>웹 만화</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1150" />
+            <source>Add new folder</source>
+            <translation>새 폴더 추가</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1186" />
+            <source>Delete folder</source>
+            <translation>폴더 삭제</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1417" />
+            <source>Set as uncompleted</source>
+            <translation>미완료로 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1420" />
+            <source>Set as completed</source>
+            <translation>완료로 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1411" />
+            <source>Update folder</source>
+            <translation>폴더 업데이트</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="652" />
+            <source>Folder</source>
+            <translation>폴더</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="674" />
+            <source>Comic</source>
+            <translation>만화</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="802" />
+            <source>Upgrade failed</source>
+            <translation>업그레이드 실패</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="802" />
+            <source>There were errors during library upgrade in: </source>
+            <translation>라이브러리 업그레이드 중 오류 발생: </translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="831" />
+            <source>Update needed</source>
+            <translation>업데이트 필요</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="831" />
+            <source>This library was created with a previous version of YACReaderLibrary. It needs to be updated. Update now?</source>
+            <translation>이 라이브러리는 YACReaderLibrary의 이전 버전으로 만들어졌습니다. 업데이트가 필요합니다. 지금 업데이트하시겠습니까?</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="898" />
+            <source>Download new version</source>
+            <translation>새 버전 내려받기</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="898" />
+            <source>This library was created with a newer version of YACReaderLibrary. Download the new version now?</source>
+            <translation>이 라이브러리는 YACReaderLibrary의 최신 버전으로 만들어졌습니다. 지금 새 버전을 내려받으시겠습니까?</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="919" />
+            <source>Library not available</source>
+            <translation>라이브러리를 사용할 수 없습니다</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="919" />
+            <source>Library '%1' is no longer available. Do you want to remove it?</source>
+            <translation>'%1' 라이브러리를 더 이상 사용할 수 없습니다. 제거하시겠습니까?</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="938" />
+            <source>Old library</source>
+            <translation>오래된 라이브러리</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="938" />
+            <source>Library '%1' has been created with an older version of YACReaderLibrary. It must be created again. Do you want to create the library now?</source>
+            <translation>'%1' 라이브러리는 이전 버전의 YACReaderLibrary로 만들어졌습니다. 다시 만들어야 합니다. 지금 만드시겠습니까?</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="969" />
+            <location filename="library_window.cpp" line="1005" />
+            <source>Copying comics...</source>
+            <translation>만화 복사 중...</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="986" />
+            <location filename="library_window.cpp" line="1024" />
+            <source>Moving comics...</source>
+            <translation>만화 이동 중...</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1151" />
+            <source>Folder name:</source>
+            <translation>폴더 이름:</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1180" />
+            <source>No folder selected</source>
+            <translation>선택된 폴더 없음</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1180" />
+            <source>Please, select a folder first</source>
+            <translation>먼저 폴더를 선택하세요</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1184" />
+            <source>Error in path</source>
+            <translation>경로 오류</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1184" />
+            <source>There was an error accessing the folder's path</source>
+            <translation>폴더 경로에 접근하는 중 오류가 발생했습니다</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1186" />
+            <source>The selected folder and all its contents will be deleted from your disk. Are you sure?</source>
+            <translation>선택한 폴더와 그 안의 모든 내용이 디스크에서 삭제됩니다. 계속하시겠습니까?</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1212" />
+            <location filename="library_window.cpp" line="2174" />
+            <source>Unable to delete</source>
+            <translation>삭제할 수 없음</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1212" />
+            <source>There was an issue trying to delete the selected folders. Please, check for write permissions and be sure that any applications are using these folders or any of the contained files.</source>
+            <translation>선택한 폴더를 삭제하는 중 문제가 발생했습니다. 쓰기 권한을 확인하고, 다른 응용 프로그램이 이 폴더나 안의 파일을 사용 중인지 확인하세요.</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1224" />
+            <source>Add new reading lists</source>
+            <translation>새 읽기 목록 추가</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1225" />
+            <location filename="library_window.cpp" line="1274" />
+            <source>List name:</source>
+            <translation>목록 이름:</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1243" />
+            <source>Delete list/label</source>
+            <translation>목록/라벨 삭제</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1243" />
+            <source>The selected item will be deleted, your comics or folders will NOT be deleted from your disk. Are you sure?</source>
+            <translation>선택한 항목이 삭제됩니다. 디스크에서 만화나 폴더는 삭제되지 않습니다. 계속하시겠습니까?</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1273" />
+            <source>Rename list name</source>
+            <translation>목록 이름 변경</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="591" />
+            <location filename="library_window.cpp" line="1375" />
+            <location filename="library_window.cpp" line="1489" />
+            <location filename="library_window.cpp" line="2631" />
+            <source>Set type</source>
+            <translation>유형 설정</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1444" />
+            <source>Set custom cover</source>
+            <translation>사용자 지정 표지 설정</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1447" />
+            <source>Delete custom cover</source>
+            <translation>사용자 지정 표지 삭제</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1632" />
+            <source>Save covers</source>
+            <translation>표지 저장</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1651" />
+            <source>You are adding too many libraries.</source>
+            <translation>라이브러리를 너무 많이 추가하고 있습니다.</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1651" />
+            <source>You are adding too many libraries.
+
+You probably only need one library in your top level comics folder, you can browse any subfolders using the folders section in the left sidebar.
+
+YACReaderLibrary will not stop you from creating more libraries but you should keep the number of libraries low.</source>
+            <translation>라이브러리를 너무 많이 추가하고 있습니다.
+
+최상위 만화 폴더에 라이브러리 하나만 있으면 충분합니다. 좌측 사이드바의 폴더 섹션으로 하위 폴더를 탐색할 수 있습니다.
+
+YACReaderLibrary는 라이브러리를 더 만드는 것을 막지 않지만, 라이브러리 수는 적게 유지하는 것이 좋습니다.</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1711" />
+            <location filename="library_window.cpp" line="1713" />
+            <source>YACReader not found</source>
+            <translation>YACReader를 찾을 수 없음</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1711" />
+            <source>YACReader not found. YACReader should be installed in the same folder as YACReaderLibrary.</source>
+            <translation>YACReader를 찾을 수 없습니다. YACReader는 YACReaderLibrary와 같은 폴더에 설치되어야 합니다.</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1713" />
+            <source>YACReader not found. There might be a problem with your YACReader installation.</source>
+            <translation>YACReader를 찾을 수 없습니다. YACReader 설치에 문제가 있을 수 있습니다.</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1720" />
+            <source>Error</source>
+            <translation>오류</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1720" />
+            <source>Error opening comic with third party reader.</source>
+            <translation>타사 뷰어로 만화를 여는 중 오류가 발생했습니다.</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1807" />
+            <source>Library not found</source>
+            <translation>라이브러리를 찾을 수 없음</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1807" />
+            <source>The selected folder doesn't contain any library.</source>
+            <translation>선택한 폴더에 라이브러리가 없습니다.</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1861" />
+            <source> library?</source>
+            <translation>라이브러리?</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1862" />
+            <source>Remove and delete metadata</source>
+            <translation>제거 및 메타데이터 삭제</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="1932" />
+            <source>Library info</source>
+            <translation>라이브러리 정보</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2174" />
+            <source>There was an issue trying to delete the selected comics. Please, check for write permissions in the selected files or containing folder.</source>
+            <translation>선택한 만화를 삭제하는 중 문제가 발생했습니다. 선택한 파일이나 포함된 폴더의 쓰기 권한을 확인하세요.</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2205" />
+            <source>Assign comics numbers</source>
+            <translation>만화에 번호 부여</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2206" />
+            <source>Assign numbers starting in:</source>
+            <translation>다음 번호부터 부여:</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2306" />
+            <source>Invalid image</source>
+            <translation>잘못된 이미지</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2306" />
+            <source>The selected file is not a valid image.</source>
+            <translation>선택한 파일이 유효한 이미지가 아닙니다.</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2312" />
+            <source>Error saving cover</source>
+            <translation>표지 저장 오류</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2312" />
+            <source>There was an error saving the cover image.</source>
+            <translation>표지 이미지를 저장하는 중 오류가 발생했습니다.</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2451" />
+            <source>Error creating the library</source>
+            <translation>라이브러리 생성 오류</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2456" />
+            <source>Error updating the library</source>
+            <translation>라이브러리 업데이트 오류</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2461" />
+            <source>Error opening the library</source>
+            <translation>라이브러리 열기 오류</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2510" />
+            <source>Delete comics</source>
+            <translation>만화 삭제</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2510" />
+            <source>All the selected comics will be deleted from your disk. Are you sure?</source>
+            <translation>선택한 만화가 모두 디스크에서 삭제됩니다. 확실합니까?</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2547" />
+            <source>Remove comics</source>
+            <translation>만화 제거</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2547" />
+            <source>Comics will only be deleted from the current label/list. Are you sure?</source>
+            <translation>만화가 현재 라벨/목록에서만 삭제됩니다. 확실합니까?</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2649" />
+            <source>Library name already exists</source>
+            <translation>라이브러리 이름 중복</translation>
+        </message>
+        <message>
+            <location filename="library_window.cpp" line="2649" />
+            <source>There is another library with the name '%1'.</source>
+            <translation>'%1' 이름의 라이브러리가 이미 있습니다.</translation>
+        </message>
+    </context>
+    <context>
+        <name>LibraryWindowActions</name>
+        <message>
+            <location filename="library_window_actions.cpp" line="39" />
+            <source>Create a new library</source>
+            <translation>새 라이브러리 만들기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="44" />
+            <source>Open an existing library</source>
+            <translation>기존 라이브러리 열기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="48" />
+            <location filename="library_window_actions.cpp" line="49" />
+            <source>Export comics info</source>
+            <translation>만화 정보 내보내기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="53" />
+            <location filename="library_window_actions.cpp" line="54" />
+            <source>Import comics info</source>
+            <translation>만화 정보 가져오기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="58" />
+            <source>Pack covers</source>
+            <translation>표지 묶기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="59" />
+            <source>Pack the covers of the selected library</source>
+            <translation>선택한 라이브러리의 표지 묶기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="63" />
+            <source>Unpack covers</source>
+            <translation>표지 풀기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="64" />
+            <source>Unpack a catalog</source>
+            <translation>카탈로그 풀기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="68" />
+            <source>Update library</source>
+            <translation>라이브러리 업데이트</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="69" />
+            <source>Update current library</source>
+            <translation>현재 라이브러리 업데이트</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="73" />
+            <source>Rename library</source>
+            <translation>라이브러리 이름 변경</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="74" />
+            <source>Rename current library</source>
+            <translation>현재 라이브러리 이름 변경</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="78" />
+            <source>Remove library</source>
+            <translation>라이브러리 제거</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="79" />
+            <source>Remove current library from your collection</source>
+            <translation>내 컬렉션에서 현재 라이브러리 제거</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="83" />
+            <source>Rescan library for XML info</source>
+            <translation>XML 정보로 라이브러리 재검색</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="84" />
+            <source>Tries to find XML info embedded in comic files. You only need to do this if the library was created with 9.8.2 or earlier versions or if you are using third party software to embed XML info in the files.</source>
+            <translation>만화 파일에 포함된 XML 정보를 찾으려고 시도합니다. 9.8.2 이하 버전으로 만든 라이브러리이거나 타사 소프트웨어로 파일에 XML 정보를 포함한 경우에만 필요합니다.</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="88" />
+            <source>Show library info</source>
+            <translation>라이브러리 정보 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="89" />
+            <source>Show information about the current library</source>
+            <translation>현재 라이브러리에 대한 정보 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="93" />
+            <source>Open current comic</source>
+            <translation>현재 만화 열기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="94" />
+            <source>Open current comic on YACReader</source>
+            <translation>YACReader에서 현재 만화 열기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="98" />
+            <source>Save selected covers to...</source>
+            <translation>선택한 표지 저장...</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="99" />
+            <source>Save covers of the selected comics as JPG files</source>
+            <translation>선택한 만화의 표지를 JPG 파일로 저장</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="103" />
+            <location filename="library_window_actions.cpp" line="224" />
+            <source>Set as read</source>
+            <translation>읽음으로 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="104" />
+            <source>Set comic as read</source>
+            <translation>만화를 읽음으로 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="108" />
+            <location filename="library_window_actions.cpp" line="229" />
+            <source>Set as unread</source>
+            <translation>읽지 않음으로 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="109" />
+            <source>Set comic as unread</source>
+            <translation>만화를 읽지 않음으로 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="113" />
+            <location filename="library_window_actions.cpp" line="244" />
+            <source>manga</source>
+            <translation>망가</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="114" />
+            <source>Set issue as manga</source>
+            <translation>만화를 망가로 설정</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="118" />
+            <location filename="library_window_actions.cpp" line="249" />
+            <source>comic</source>
+            <translation>만화</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="119" />
+            <source>Set issue as normal</source>
+            <translation>만화를 일반으로 설정</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="123" />
+            <source>western manga</source>
+            <translation>서양 만화</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="124" />
+            <source>Set issue as western manga</source>
+            <translation>만화를 서양 만화로 설정</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="129" />
+            <location filename="library_window_actions.cpp" line="259" />
+            <source>web comic</source>
+            <translation>웹 만화</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="130" />
+            <source>Set issue as web comic</source>
+            <translation>만화를 웹 만화로 설정</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="135" />
+            <location filename="library_window_actions.cpp" line="264" />
+            <source>yonkoma</source>
+            <translation>4컷 만화</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="136" />
+            <source>Set issue as yonkoma</source>
+            <translation>만화를 4컷 만화로 설정</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="140" />
+            <source>Show/Hide marks</source>
+            <translation>읽음 마크 표시/숨김</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="141" />
+            <source>Show or hide read marks</source>
+            <translation>읽음 마크를 표시하거나 숨김</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="147" />
+            <source>Show/Hide recent indicator</source>
+            <translation>신규 표시 표시/숨김</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="148" />
+            <source>Show or hide recent indicator</source>
+            <translation>신규 표시를 표시하거나 숨김</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="155" />
+            <location filename="library_window_actions.cpp" line="156" />
+            <source>Fullscreen mode on/off</source>
+            <translation>전체화면 모드 켜기/끄기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="161" />
+            <source>Help, About YACReader</source>
+            <translation>도움말, YACReader 정보</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="165" />
+            <source>Add new folder</source>
+            <translation>새 폴더 추가</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="168" />
+            <source>Add new folder to the current library</source>
+            <translation>현재 라이브러리에 새 폴더 추가</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="170" />
+            <source>Delete folder</source>
+            <translation>폴더 삭제</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="173" />
+            <source>Delete current folder from disk</source>
+            <translation>현재 폴더를 디스크에서 삭제</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="178" />
+            <source>Select root node</source>
+            <translation>루트 노드 선택</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="181" />
+            <source>Expand all nodes</source>
+            <translation>모든 노드 펼치기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="186" />
+            <source>Collapse all nodes</source>
+            <translation>모든 노드 접기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="191" />
+            <source>Show options dialog</source>
+            <translation>환경설정 다이얼로그 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="196" />
+            <source>Show comics server options dialog</source>
+            <translation>만화 서버 환경설정 다이얼로그 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="200" />
+            <location filename="library_window_actions.cpp" line="201" />
+            <source>Change between comics views</source>
+            <translation>만화 보기 전환</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="209" />
+            <source>Open folder...</source>
+            <translation>폴더 열기...</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="214" />
+            <source>Set as uncompleted</source>
+            <translation>미완료로 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="219" />
+            <source>Set as completed</source>
+            <translation>완료로 표시</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="234" />
+            <source>Set custom cover</source>
+            <translation>사용자 지정 표지 설정</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="239" />
+            <source>Delete custom cover</source>
+            <translation>사용자 지정 표지 삭제</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="254" />
+            <source>western manga (left to right)</source>
+            <translation>서양 만화 (왼쪽 → 오른쪽)</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="271" />
+            <source>Open containing folder...</source>
+            <translation>포함된 폴더 열기...</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="276" />
+            <source>Reset comic rating</source>
+            <translation>만화 평점 초기화</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="282" />
+            <source>Select all comics</source>
+            <translation>모든 만화 선택</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="287" />
+            <source>Edit</source>
+            <translation>편집</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="292" />
+            <source>Assign current order to comics</source>
+            <translation>만화에 현재 순서 적용</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="297" />
+            <source>Update cover</source>
+            <translation>표지 업데이트</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="303" />
+            <source>Delete selected comics</source>
+            <translation>선택한 만화 삭제</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="308" />
+            <source>Delete metadata from selected comics</source>
+            <translation>선택한 만화에서 메타데이터 삭제</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="315" />
+            <source>Download tags from Comic Vine</source>
+            <translation>Comic Vine에서 태그 내려받기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="318" />
+            <source>Focus search line</source>
+            <translation>검색창으로 이동</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="324" />
+            <source>Focus comics view</source>
+            <translation>만화 보기로 이동</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="329" />
+            <source>Edit shortcuts</source>
+            <translation>단축키 편집</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="335" />
+            <source>&amp;Quit</source>
+            <translation>끝내기(&amp;Q)</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="342" />
+            <source>Update folder</source>
+            <translation>폴더 업데이트</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="344" />
+            <source>Update current folder</source>
+            <translation>현재 폴더 업데이트</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="348" />
+            <source>Scan legacy XML metadata</source>
+            <translation>레거시 XML 메타데이터 스캔</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="352" />
+            <source>Add new reading list</source>
+            <translation>새 읽기 목록 추가</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="355" />
+            <source>Add a new reading list to the current library</source>
+            <translation>현재 라이브러리에 새 읽기 목록 추가</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="357" />
+            <source>Remove reading list</source>
+            <translation>읽기 목록 제거</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="360" />
+            <source>Remove current reading list from the library</source>
+            <translation>라이브러리에서 현재 읽기 목록 제거</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="362" />
+            <source>Add new label</source>
+            <translation>새 라벨 추가</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="365" />
+            <source>Add a new label to this library</source>
+            <translation>이 라이브러리에 새 라벨 추가</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="367" />
+            <source>Rename selected list</source>
+            <translation>선택한 목록 이름 변경</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="370" />
+            <source>Rename any selected labels or lists</source>
+            <translation>선택한 라벨이나 목록 이름 변경</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="373" />
+            <source>Add to...</source>
+            <translation>추가...</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="375" />
+            <source>Favorites</source>
+            <translation>즐겨찾기</translation>
+        </message>
+        <message>
+            <location filename="library_window_actions.cpp" line="378" />
+            <source>Add selected comics to favorites list</source>
+            <translation>선택한 만화를 즐겨찾기 목록에 추가</translation>
+        </message>
+    </context>
+    <context>
+        <name>LocalComicListModel</name>
+        <message>
+            <location filename="comic_vine/model/local_comic_list_model.cpp" line="72" />
+            <source>file name</source>
+            <translation>파일 이름</translation>
+        </message>
+    </context>
+    <context>
+        <name>NoLibrariesWidget</name>
+        <message>
+            <location filename="no_libraries_widget.cpp" line="20" />
+            <source>You don't have any libraries yet</source>
+            <translation>아직 라이브러리가 없습니다</translation>
+        </message>
+        <message>
+            <location filename="no_libraries_widget.cpp" line="22" />
+            <source>&lt;p&gt;You can create a library in any folder, YACReaderLibrary will import all comics and folders from this folder. If you have created any library in the past you can open them.&lt;/p&gt;&lt;p&gt;Don't forget that you can use YACReader as a stand alone application for reading the comics on your computer.&lt;/p&gt;</source>
+            <translation>&lt;p&gt;아무 폴더에 라이브러리를 만들 수 있고, YACReaderLibrary가 그 폴더의 모든 만화와 하위 폴더를 가져옵니다. 이전에 만든 라이브러리가 있으면 열 수 있습니다.&lt;/p&gt;&lt;p&gt;YACReader는 단독 응용 프로그램으로 컴퓨터의 만화를 보는 데도 쓸 수 있습니다.&lt;/p&gt;</translation>
+        </message>
+        <message>
+            <location filename="no_libraries_widget.cpp" line="26" />
+            <source>create your first library</source>
+            <translation>첫 라이브러리 만들기</translation>
+        </message>
+        <message>
+            <location filename="no_libraries_widget.cpp" line="28" />
+            <source>add an existing one</source>
+            <translation>기존 라이브러리 추가</translation>
+        </message>
+    </context>
+    <context>
+        <name>NoSearchResultsWidget</name>
+        <message>
+            <location filename="no_search_results_widget.cpp" line="9" />
+            <source>No results</source>
+            <translation>결과 없음</translation>
+        </message>
+    </context>
+    <context>
+        <name>OptionsDialog</name>
+        <message>
+            <location filename="options_dialog.cpp" line="169" />
+            <location filename="../YACReader/options_dialog.cpp" line="44" />
+            <source>Language</source>
+            <translation>언어</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="171" />
+            <location filename="../YACReader/options_dialog.cpp" line="46" />
+            <source>Application language</source>
+            <translation>응용 프로그램 언어</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="173" />
+            <location filename="../YACReader/options_dialog.cpp" line="48" />
+            <source>System default</source>
+            <translation>시스템 기본값</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="183" />
+            <source>Tray icon settings (experimental)</source>
+            <translation>트레이 아이콘 설정 (실험적)</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="186" />
+            <source>Close to tray</source>
+            <translation>트레이로 최소화</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="187" />
+            <source>Start into the system tray</source>
+            <translation>시스템 트레이에서 시작</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="205" />
+            <source>Edit Comic Vine API key</source>
+            <translation>Comic Vine API 키 편집</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="208" />
+            <source>Comic Vine API key</source>
+            <translation>Comic Vine API 키</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="213" />
+            <source>ComicInfo.xml legacy support</source>
+            <translation>ComicInfo.xml 레거시 지원</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="215" />
+            <source>Import metadata from ComicInfo.xml when adding new comics</source>
+            <oldsource>Import metada from ComicInfo.xml when adding new comics</oldsource>
+            <translation>새 만화 추가 시 ComicInfo.xml에서 메타데이터 가져오기</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="225" />
+            <source>Consider 'recent' items added or updated since X days ago</source>
+            <translation>X일 전부터 추가되거나 업데이트된 항목을 '최근'으로 간주</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="237" />
+            <source>Third party reader</source>
+            <translation>타사 뷰어</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="239" />
+            <source>Write {comic_file_path} where the path should go in the command</source>
+            <translation>명령어에서 경로가 들어갈 자리에 {comic_file_path}를 입력하세요</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="240" />
+            <location filename="../YACReader/options_dialog.cpp" line="87" />
+            <source>Clear</source>
+            <translation>지우기</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="265" />
+            <source>Update libraries at startup</source>
+            <translation>시작 시 라이브러리 업데이트</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="270" />
+            <source>Try to detect changes automatically</source>
+            <translation>변경 사항 자동 감지 시도</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="275" />
+            <source>Update libraries periodically</source>
+            <translation>라이브러리 주기적으로 업데이트</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="281" />
+            <source>Interval:</source>
+            <translation>간격:</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="283" />
+            <source>30 minutes</source>
+            <translation>30분</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="284" />
+            <source>1 hour</source>
+            <translation>1시간</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="285" />
+            <source>2 hours</source>
+            <translation>2시간</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="286" />
+            <source>4 hours</source>
+            <translation>4시간</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="287" />
+            <source>8 hours</source>
+            <translation>8시간</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="288" />
+            <source>12 hours</source>
+            <translation>12시간</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="289" />
+            <source>daily</source>
+            <translation>매일</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="296" />
+            <source>Update libraries at certain time</source>
+            <translation>특정 시간에 라이브러리 업데이트</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="302" />
+            <source>Time:</source>
+            <translation>시간:</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="329" />
+            <source>WARNING! During library updates writes to the database are disabled!
+Don't schedule updates while you may be using the app actively.
+During automatic updates the app will block some of the actions until the update is finished.
+To stop an automatic update tap on the loading indicator next to the Libraries title.</source>
+            <oldsource>WARNING! During library updates writes to the database are disabled!
+Don't schedule updates while you may be using the app actively.
+To stop an automatic update tap on the loading indicator next to the Libraries title.</oldsource>
+            <translation>주의! 라이브러리를 업데이트하는 동안에는 데이터베이스에 기록할 수 없습니다.
+앱을 적극적으로 사용 중일 때는 업데이트를 예약하지 마세요.
+자동 업데이트가 진행되는 동안에는 일부 기능이 잠시 차단될 수 있습니다.
+자동 업데이트를 중단하려면 라이브러리 제목 옆에 표시되는 로딩 아이콘을 눌러주세요.</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="337" />
+            <source>Modifications detection</source>
+            <translation>수정 감지</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="339" />
+            <source>Compare the modified date of files when updating a library (not recommended)</source>
+            <translation>라이브러리 업데이트 시 파일 수정 날짜 비교 (권장하지 않음)</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="378" />
+            <source>Enable background image</source>
+            <translation>배경 이미지 사용</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="380" />
+            <source>Opacity level</source>
+            <translation>불투명도</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="385" />
+            <source>Blur level</source>
+            <translation>흐림 정도</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="390" />
+            <source>Use selected comic cover as background</source>
+            <translation>선택한 만화 표지를 배경으로 사용</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="392" />
+            <source>Restore defautls</source>
+            <translation>기본값으로 복원</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="403" />
+            <source>Background</source>
+            <translation>배경</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="406" />
+            <source>Display continue reading banner</source>
+            <translation>이어 읽기 배너 표시</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="407" />
+            <source>Display current comic banner</source>
+            <translation>현재 만화 배너 표시</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="413" />
+            <source>Continue reading</source>
+            <translation>이어 읽기</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="29" />
+            <source>Comic Flow</source>
+            <translation>코믹 플로우</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="28" />
+            <location filename="options_dialog.cpp" line="334" />
+            <source>Libraries</source>
+            <translation>라이브러리</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="30" />
+            <source>Grid view</source>
+            <translation>격자 보기</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="27" />
+            <location filename="../YACReader/options_dialog.cpp" line="253" />
+            <source>General</source>
+            <translation>일반</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="31" />
+            <location filename="../YACReader/options_dialog.cpp" line="256" />
+            <source>Appearance</source>
+            <translation>외관</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="44" />
+            <location filename="../YACReader/options_dialog.cpp" line="271" />
+            <source>Options</source>
+            <translation>환경설정</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="37" />
+            <source>My comics path</source>
+            <translation>내 만화 경로</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="57" />
+            <source>Display</source>
+            <translation>표시</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="59" />
+            <source>Show time in current page information label</source>
+            <translation>현재 페이지 정보 라벨에 시간 표시</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="65" />
+            <source>"Go to flow" size</source>
+            <translation>페이지 흐름 크기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="83" />
+            <source>Background color</source>
+            <translation>배경색</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="86" />
+            <source>Choose</source>
+            <translation>선택</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="95" />
+            <source>Scroll behaviour</source>
+            <translation>스크롤 동작</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="98" />
+            <source>Disable scroll animations and smooth scrolling</source>
+            <translation>스크롤 애니메이션과 부드러운 스크롤 끄기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="99" />
+            <source>Do not turn page using scroll</source>
+            <translation>스크롤로 페이지 넘기지 않기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="100" />
+            <source>Use single scroll step to turn page</source>
+            <translation>한 단계 스크롤로 페이지 넘기기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="108" />
+            <source>Mouse mode</source>
+            <translation>마우스 모드</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="111" />
+            <source>Only Back/Forward buttons can turn pages</source>
+            <translation>뒤로/앞으로 버튼만 페이지 넘김</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="112" />
+            <source>Use the Left/Right buttons to turn pages.</source>
+            <translation>왼쪽/오른쪽 버튼으로 페이지 넘김.</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="113" />
+            <source>Click left or right half of the screen to turn pages.</source>
+            <translation>화면 왼쪽 또는 오른쪽 절반을 클릭하여 페이지 넘김.</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="139" />
+            <source>Quick Navigation Mode</source>
+            <translation>빠른 탐색 모드</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="140" />
+            <source>Disable mouse over activation</source>
+            <translation>마우스 오버 활성화 끄기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="177" />
+            <source>Brightness</source>
+            <translation>밝기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="178" />
+            <source>Contrast</source>
+            <translation>대비</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="179" />
+            <source>Gamma</source>
+            <translation>감마</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="183" />
+            <source>Reset</source>
+            <translation>초기화</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="188" />
+            <source>Image options</source>
+            <translation>이미지 옵션</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="192" />
+            <source>Fit options</source>
+            <translation>맞춤 옵션</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="194" />
+            <source>Enlarge images to fit width/height</source>
+            <translation>작은 그림도 꽉차게 보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="205" />
+            <source>Double Page options</source>
+            <translation>두 페이지 옵션</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="207" />
+            <source>Show covers as single page</source>
+            <translation>표지를 한 장으로 표시</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="218" />
+            <source>Scaling</source>
+            <translation>스케일링</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="220" />
+            <source>Scaling method</source>
+            <translation>스케일링 방법</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="222" />
+            <source>Nearest (fast, low quality)</source>
+            <translation>빠른 모드 (빠름, 저화질)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="223" />
+            <source>Bilinear</source>
+            <translation>보통 모드 (중간 품질)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="224" />
+            <source>Lanczos (better quality)</source>
+            <translation>고화질 모드 (더 좋은 화질)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="254" />
+            <source>Page Flow</source>
+            <translation>페이지 플로우</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="255" />
+            <source>Image adjustment</source>
+            <translation>이미지 조정</translation>
+        </message>
+        <message>
+            <location filename="options_dialog.cpp" line="35" />
+            <location filename="../YACReader/options_dialog.cpp" line="262" />
+            <source>Restart is needed</source>
+            <translation>재시작이 필요합니다</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/options_dialog.cpp" line="285" />
+            <source>Comics directory</source>
+            <translation>만화 폴더</translation>
+        </message>
+    </context>
+    <context>
+        <name>PropertiesDialog</name>
+        <message>
+            <location filename="properties_dialog.cpp" line="88" />
+            <source>General info</source>
+            <translation>일반 정보</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="90" />
+            <source>Authors</source>
+            <translation>작가진</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="91" />
+            <source>Publishing</source>
+            <translation>출판</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="89" />
+            <source>Plot</source>
+            <translation>줄거리</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="92" />
+            <source>Notes</source>
+            <translation>메모</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="101" />
+            <source>Cover page</source>
+            <translation>표지 페이지</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="110" />
+            <source>Load previous page as cover</source>
+            <translation>이전 페이지를 표지로 불러오기</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="114" />
+            <source>Load next page as cover</source>
+            <translation>다음 페이지를 표지로 불러오기</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="119" />
+            <source>Reset cover to the default image</source>
+            <translation>표지를 기본 이미지로 초기화</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="124" />
+            <source>Load custom cover image</source>
+            <translation>사용자 지정 표지 이미지 불러오기</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="168" />
+            <source>Series:</source>
+            <translation>시리즈:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="169" />
+            <source>Title:</source>
+            <translation>제목:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="173" />
+            <location filename="properties_dialog.cpp" line="187" />
+            <location filename="properties_dialog.cpp" line="198" />
+            <source>of:</source>
+            <translation> / </translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="178" />
+            <source>Issue number:</source>
+            <translation>이슈 번호:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="180" />
+            <source>Volume:</source>
+            <translation>볼륨:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="185" />
+            <source>Arc number:</source>
+            <translation>아크 번호:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="191" />
+            <source>Story arc:</source>
+            <translation>스토리 아크:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="196" />
+            <source>alt. number:</source>
+            <translation>대체 번호:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="202" />
+            <source>Alternate series:</source>
+            <translation>대체 시리즈:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="204" />
+            <source>Series Group:</source>
+            <translation>시리즈 그룹:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="206" />
+            <source>Genre:</source>
+            <translation>장르:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="208" />
+            <source>Size:</source>
+            <translation>크기:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="228" />
+            <source>Writer(s):</source>
+            <translation>글:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="231" />
+            <source>Penciller(s):</source>
+            <translation>밑그림:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="238" />
+            <source>Inker(s):</source>
+            <translation>펜선:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="241" />
+            <source>Colorist(s):</source>
+            <translation>채색:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="248" />
+            <source>Letterer(s):</source>
+            <translation>식자:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="251" />
+            <source>Cover Artist(s):</source>
+            <translation>표지 그림:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="258" />
+            <source>Editor(s):</source>
+            <translation>편집:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="261" />
+            <source>Imprint:</source>
+            <translation>임프린트:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="282" />
+            <source>Day:</source>
+            <translation>일:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="286" />
+            <source>Month:</source>
+            <translation>월:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="290" />
+            <source>Year:</source>
+            <translation>연도:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="298" />
+            <source>Publisher:</source>
+            <translation>출판사:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="299" />
+            <source>Format:</source>
+            <translation>형식:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="300" />
+            <source>Color/BW:</source>
+            <translation>컬러/흑백:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="301" />
+            <source>Age rating:</source>
+            <translation>연령 등급:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="302" />
+            <source>Type:</source>
+            <translation>유형:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="303" />
+            <source>Language (ISO):</source>
+            <translation>언어 (ISO):</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="324" />
+            <source>Synopsis:</source>
+            <translation>줄거리:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="331" />
+            <source>Characters:</source>
+            <translation>등장인물:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="334" />
+            <source>Teams:</source>
+            <translation>팀:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="340" />
+            <source>Locations:</source>
+            <translation>장소:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="346" />
+            <source>Main character or team:</source>
+            <translation>주요 등장인물 또는 팀:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="368" />
+            <source>Review:</source>
+            <translation>리뷰:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="369" />
+            <source>Notes:</source>
+            <translation>메모:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="370" />
+            <source>Tags:</source>
+            <translation>태그:</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="468" />
+            <source>Comic Vine link: &lt;a style='color: #FFCB00; text-decoration:none; font-weight:bold;' href="http://www.comicvine.com/comic/4000-%1/"&gt; view &lt;/a&gt;</source>
+            <translation>Comic Vine 링크: &lt;a style='color: #FFCB00; text-decoration:none; font-weight:bold;' href="http://www.comicvine.com/comic/4000-%1/"&gt; 보기 &lt;/a&gt;</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="488" />
+            <source>Not found</source>
+            <translation>찾을 수 없음</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="488" />
+            <source>Comic not found. You should update your library.</source>
+            <translation>만화를 찾을 수 없습니다. 라이브러리를 업데이트하세요.</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="623" />
+            <source>Edit selected comics information</source>
+            <translation>선택한 만화 정보 편집</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="1241" />
+            <source>Invalid cover</source>
+            <translation>잘못된 표지</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="1241" />
+            <source>The image is invalid.</source>
+            <translation>이미지가 유효하지 않습니다.</translation>
+        </message>
+        <message>
+            <location filename="properties_dialog.cpp" line="585" />
+            <source>Edit comic information</source>
+            <translation>만화 정보 편집</translation>
+        </message>
+    </context>
+    <context>
+        <name>QCoreApplication</name>
+        <message>
+            <location filename="../YACReaderLibraryServer/main.cpp" line="82" />
+            <source>
+YACReaderLibraryServer is the headless (no gui) version of YACReaderLibrary.
+
+This appplication supports persistent settings, to set them up edit this file %1
+To learn about the available settings please check the documentation at https://raw.githubusercontent.com/YACReader/yacreader/develop/YACReaderLibraryServer/SETTINGS_README.md</source>
+            <translation>
+YACReaderLibraryServer는 YACReaderLibrary의 헤드리스(GUI 없는) 버전입니다.
+
+이 응용 프로그램은 영구 설정을 지원합니다. 설정을 변경하려면 다음 파일을 편집하세요: %1
+사용 가능한 설정 문서는 다음에서 확인할 수 있습니다: https://raw.githubusercontent.com/YACReader/yacreader/develop/YACReaderLibraryServer/SETTINGS_README.md</translation>
+        </message>
+    </context>
+    <context>
+        <name>QObject</name>
+        <message>
+            <location filename="../common/exit_check.cpp" line="13" />
+            <source>7z lib not found</source>
+            <translation>7z 라이브러리를 찾을 수 없습니다</translation>
+        </message>
+        <message>
+            <location filename="../common/exit_check.cpp" line="13" />
+            <source>unable to load 7z lib from ./utils</source>
+            <translation>./utils에서 7z 라이브러리를 불러올 수 없습니다</translation>
+        </message>
+        <message>
+            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41" />
+            <source>Trace</source>
+            <translation>추적</translation>
+        </message>
+        <message>
+            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43" />
+            <source>Debug</source>
+            <translation>디버그</translation>
+        </message>
+        <message>
+            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45" />
+            <source>Info</source>
+            <translation>정보</translation>
+        </message>
+        <message>
+            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47" />
+            <source>Warning</source>
+            <translation>경고</translation>
+        </message>
+        <message>
+            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49" />
+            <source>Error</source>
+            <translation>오류</translation>
+        </message>
+        <message>
+            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51" />
+            <source>Fatal</source>
+            <translation>치명적 오류</translation>
+        </message>
+        <message>
+            <location filename="../common/yacreader_global_gui.cpp" line="94" />
+            <source>Select custom cover</source>
+            <translation>사용자 지정 표지 선택</translation>
+        </message>
+        <message>
+            <location filename="../common/yacreader_global_gui.cpp" line="94" />
+            <source>Images (%1)</source>
+            <translation>이미지 (%1)</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_repository.cpp" line="113" />
+            <source>The file could not be read or is not valid JSON.</source>
+            <translation>파일을 읽을 수 없거나 유효한 JSON이 아닙니다.</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_repository.cpp" line="122" />
+            <source>This theme is for %1, not %2.</source>
+            <translation>이 테마는 %2가 아닌 %1용입니다.</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_sidebar.cpp" line="149" />
+            <source>Libraries</source>
+            <translation>라이브러리</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_sidebar.cpp" line="150" />
+            <source>Folders</source>
+            <translation>폴더</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_sidebar.cpp" line="151" />
+            <source>Reading Lists</source>
+            <translation>읽기 목록</translation>
+        </message>
+    </context>
+    <context>
+        <name>RenameLibraryDialog</name>
+        <message>
+            <location filename="rename_library_dialog.cpp" line="49" />
+            <source>Rename current library</source>
+            <translation>현재 라이브러리 이름 변경</translation>
+        </message>
+        <message>
+            <location filename="rename_library_dialog.cpp" line="24" />
+            <source>Cancel</source>
+            <translation>취소</translation>
+        </message>
+        <message>
+            <location filename="rename_library_dialog.cpp" line="20" />
+            <source>Rename</source>
+            <translation>이름 변경</translation>
+        </message>
+        <message>
+            <location filename="rename_library_dialog.cpp" line="15" />
+            <source>New Library Name : </source>
+            <translation>새 라이브러리 이름: </translation>
+        </message>
+    </context>
+    <context>
+        <name>ScraperResultsPaginator</name>
+        <message>
+            <location filename="comic_vine/scraper_results_paginator.cpp" line="19" />
+            <source>Number of volumes found : %1</source>
+            <translation>검색된 볼륨 수 : %1</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/scraper_results_paginator.cpp" line="20" />
+            <location filename="comic_vine/scraper_results_paginator.cpp" line="44" />
+            <source>page %1 of %2</source>
+            <translation>%1 / %2 페이지</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/scraper_results_paginator.cpp" line="43" />
+            <source>Number of %1 found : %2</source>
+            <translation>검색된 %1 수 : %2</translation>
+        </message>
+    </context>
+    <context>
+        <name>SearchSingleComic</name>
+        <message>
+            <location filename="comic_vine/search_single_comic.cpp" line="14" />
+            <source>Please provide some additional information for this comic.</source>
+            <oldsource>Please provide some additional information.</oldsource>
+            <translation>이 만화에 대한 추가 정보를 입력하세요.</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/search_single_comic.cpp" line="18" />
+            <source>Series:</source>
+            <translation>시리즈:</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/search_single_comic.cpp" line="21" />
+            <source>Use exact match search. Disable if you want to find volumes that match some of the words in the name.</source>
+            <translation>정확히 일치 검색을 사용합니다. 이름의 일부 단어와 일치하는 볼륨을 찾으려면 비활성화하세요.</translation>
+        </message>
+    </context>
+    <context>
+        <name>SearchVolume</name>
+        <message>
+            <location filename="comic_vine/search_volume.cpp" line="12" />
+            <source>Please provide some additional information.</source>
+            <translation>추가 정보를 입력하세요.</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/search_volume.cpp" line="14" />
+            <source>Series:</source>
+            <translation>시리즈:</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/search_volume.cpp" line="17" />
+            <source>Use exact match search. Disable if you want to find volumes that match some of the words in the name.</source>
+            <translation>정확히 일치 검색을 사용합니다. 이름의 일부 단어와 일치하는 볼륨을 찾으려면 비활성화하세요.</translation>
+        </message>
+    </context>
+    <context>
+        <name>SelectComic</name>
+        <message>
+            <location filename="comic_vine/select_comic.cpp" line="16" />
+            <source>Please, select the right comic info.</source>
+            <translation>맞는 만화 정보를 선택하세요.</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/select_comic.cpp" line="37" />
+            <source>comics</source>
+            <translation>만화</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/select_comic.cpp" line="106" />
+            <source>loading cover</source>
+            <translation>표지 불러오는 중</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/select_comic.cpp" line="107" />
+            <source>loading description</source>
+            <translation>설명 불러오는 중</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/select_comic.cpp" line="157" />
+            <source>comic description unavailable</source>
+            <translation>만화 설명을 사용할 수 없음</translation>
+        </message>
+    </context>
+    <context>
+        <name>SelectVolume</name>
+        <message>
+            <location filename="comic_vine/select_volume.cpp" line="35" />
+            <source>Please, select the right series for your comic.</source>
+            <translation>만화에 맞는 시리즈를 선택하세요.</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/select_volume.cpp" line="54" />
+            <source>Filter:</source>
+            <translation>필터:</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/select_volume.cpp" line="65" />
+            <source>volumes</source>
+            <translation>볼륨</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/select_volume.cpp" line="148" />
+            <source>Nothing found, clear the filter if any.</source>
+            <translation>검색 결과 없음. 필터가 있으면 초기화하세요.</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/select_volume.cpp" line="154" />
+            <source>loading cover</source>
+            <translation>표지 불러오는 중</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/select_volume.cpp" line="155" />
+            <source>loading description</source>
+            <translation>설명 불러오는 중</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/select_volume.cpp" line="207" />
+            <source>volume description unavailable</source>
+            <translation>볼륨 설명을 사용할 수 없음</translation>
+        </message>
+    </context>
+    <context>
+        <name>SeriesQuestion</name>
+        <message>
+            <location filename="comic_vine/series_question.cpp" line="12" />
+            <source>You are trying to get information for various comics at once, are they part of the same series?</source>
+            <translation>여러 만화의 정보를 한 번에 가져오려고 합니다. 같은 시리즈에 속하는 만화입니까?</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/series_question.cpp" line="13" />
+            <source>yes</source>
+            <translation>예</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/series_question.cpp" line="14" />
+            <source>no</source>
+            <translation>아니오</translation>
+        </message>
+    </context>
+    <context>
+        <name>ServerConfigDialog</name>
+        <message>
+            <location filename="server_config_dialog.cpp" line="27" />
+            <source>set port</source>
+            <translation>포트 설정</translation>
+        </message>
+        <message>
+            <location filename="server_config_dialog.cpp" line="34" />
+            <source>Server connectivity information</source>
+            <translation>서버 연결 정보</translation>
+        </message>
+        <message>
+            <location filename="server_config_dialog.cpp" line="37" />
+            <source>Scan it!</source>
+            <translation>스캔하세요!</translation>
+        </message>
+        <message>
+            <location filename="server_config_dialog.cpp" line="42" />
+            <source>YACReader is available for iOS and Android devices.&lt;br/&gt;Discover it for &lt;a href='https://ios.yacreader.com' style='color:rgb(193, 148, 65)'&gt;iOS&lt;/a&gt; or &lt;a href='https://android.yacreader.com' style='color:rgb(193, 148, 65)'&gt;Android&lt;/a&gt;.</source>
+            <translation>YACReader는 iOS와 Android 기기에서도 사용할 수 있습니다.&lt;br/&gt;&lt;a href='https://ios.yacreader.com' style='color:rgb(193, 148, 65)'&gt;iOS&lt;/a&gt; 또는 &lt;a href='https://android.yacreader.com' style='color:rgb(193, 148, 65)'&gt;Android&lt;/a&gt;에서 확인하세요.</translation>
+        </message>
+        <message>
+            <location filename="server_config_dialog.cpp" line="48" />
+            <source>Choose an IP address</source>
+            <translation>IP 주소 선택</translation>
+        </message>
+        <message>
+            <location filename="server_config_dialog.cpp" line="51" />
+            <source>Port</source>
+            <translation>포트</translation>
+        </message>
+        <message>
+            <location filename="server_config_dialog.cpp" line="83" />
+            <source>enable the server</source>
+            <translation>서버 사용</translation>
+        </message>
+    </context>
+    <context>
+        <name>SortVolumeComics</name>
+        <message>
+            <location filename="comic_vine/sort_volume_comics.cpp" line="59" />
+            <source>Please, sort the list of comics on the left until it matches the comics' information.</source>
+            <translation>왼쪽의 만화 목록을 만화 정보와 일치할 때까지 정렬하세요.</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/sort_volume_comics.cpp" line="61" />
+            <source>sort comics to match comic information</source>
+            <translation>만화 정보에 맞게 정렬</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/sort_volume_comics.cpp" line="98" />
+            <source>issues</source>
+            <translation>이슈</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/sort_volume_comics.cpp" line="126" />
+            <source>remove selected comics</source>
+            <translation>선택한 만화 제거</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/sort_volume_comics.cpp" line="127" />
+            <source>restore all removed comics</source>
+            <translation>제거한 만화 모두 복원</translation>
+        </message>
+    </context>
+    <context>
+        <name>ThemeEditorDialog</name>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="65" />
+            <source>Theme Editor</source>
+            <translation>테마 편집기</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="69" />
+            <source>+</source>
+            <translation>+</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="70" />
+            <source>-</source>
+            <translation>-</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="71" />
+            <source>i</source>
+            <translation>i</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="75" />
+            <source>Expand all</source>
+            <translation>모두 펼치기</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="76" />
+            <source>Collapse all</source>
+            <translation>모두 접기</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="77" />
+            <source>Hold to flash the selected value in the UI (magenta / toggled / 0↔10). Releases restore the original.</source>
+            <translation>누르고 있으면 UI에서 선택한 값이 깜박입니다 (마젠타 / 토글 / 0↔10). 놓으면 원래대로 돌아갑니다.</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="82" />
+            <source>Search…</source>
+            <translation>검색…</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="100" />
+            <source>Light</source>
+            <translation>밝은</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="101" />
+            <source>Dark</source>
+            <translation>어두운</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="104" />
+            <source>ID:</source>
+            <translation>ID:</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="105" />
+            <source>Display name:</source>
+            <translation>표시 이름:</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="106" />
+            <source>Variant:</source>
+            <translation>변형:</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="108" />
+            <source>Theme info</source>
+            <translation>테마 정보</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="129" />
+            <source>Parameter</source>
+            <translation>매개변수</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="129" />
+            <source>Value</source>
+            <translation>값</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="153" />
+            <source>Save and apply</source>
+            <translation>저장 후 적용</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="154" />
+            <source>Export to file...</source>
+            <translation>파일로 내보내기...</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="155" />
+            <source>Load from file...</source>
+            <translation>파일에서 불러오기...</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="156" />
+            <source>Close</source>
+            <translation>닫기</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="213" />
+            <source>Double-click to edit color</source>
+            <translation>두 번 클릭하여 색 편집</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="215" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="267" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="268" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="462" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="467" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="498" />
+            <source>true</source>
+            <translation>true</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="215" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="268" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="467" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="498" />
+            <source>false</source>
+            <translation>false</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="218" />
+            <source>Double-click to toggle</source>
+            <translation>두 번 클릭하여 전환</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="222" />
+            <source>Double-click to edit value</source>
+            <translation>두 번 클릭하여 값 편집</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="236" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="283" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="288" />
+            <source>Edit: %1</source>
+            <translation>편집: %1</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="402" />
+            <source>Save theme</source>
+            <translation>테마 저장</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="402" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="417" />
+            <source>JSON files (*.json);;All files (*)</source>
+            <translation>JSON 파일 (*.json);;모든 파일 (*)</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="408" />
+            <source>Save failed</source>
+            <translation>저장 실패</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="408" />
+            <source>Could not open file for writing:
+%1</source>
+            <translation>쓰기 위해 파일을 열 수 없습니다:
+%1</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="417" />
+            <source>Load theme</source>
+            <translation>테마 불러오기</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="423" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="430" />
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="434" />
+            <source>Load failed</source>
+            <translation>불러오기 실패</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="423" />
+            <source>Could not open file:
+%1</source>
+            <translation>파일을 열 수 없습니다:
+%1</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="430" />
+            <source>Invalid JSON:
+%1</source>
+            <translation>잘못된 JSON:
+%1</translation>
+        </message>
+        <message>
+            <location filename="../common/themes/theme_editor_dialog.cpp" line="434" />
+            <source>Expected a JSON object.</source>
+            <translation>JSON 객체가 필요합니다.</translation>
+        </message>
+    </context>
+    <context>
+        <name>TitleHeader</name>
+        <message>
+            <location filename="comic_vine/title_header.cpp" line="27" />
+            <source>SEARCH</source>
+            <translation>검색</translation>
+        </message>
+    </context>
+    <context>
+        <name>UpdateLibraryDialog</name>
+        <message>
+            <location filename="create_library_dialog.cpp" line="170" />
+            <source>Cancel</source>
+            <translation>취소</translation>
+        </message>
+        <message>
+            <location filename="create_library_dialog.cpp" line="164" />
+            <source>Updating....</source>
+            <translation>업데이트 중...</translation>
+        </message>
+        <message>
+            <location filename="create_library_dialog.cpp" line="189" />
+            <source>Update library</source>
+            <translation>라이브러리 업데이트</translation>
+        </message>
+    </context>
+    <context>
+        <name>Viewer</name>
+        <message>
+            <location filename="../YACReader/viewer.cpp" line="60" />
+            <location filename="../YACReader/viewer.cpp" line="1367" />
+            <source>Press 'O' to open comic.</source>
+            <translation>'O'를 눌러 만화를 열어보세요.</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/viewer.cpp" line="262" />
+            <source>Not found</source>
+            <translation>찾을 수 없음</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/viewer.cpp" line="262" />
+            <source>Comic not found</source>
+            <translation>만화를 찾을 수 없습니다</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/viewer.cpp" line="268" />
+            <source>Error opening comic</source>
+            <translation>만화를 여는 중 오류가 발생했습니다</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/viewer.cpp" line="274" />
+            <source>CRC Error</source>
+            <translation>CRC 오류</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/viewer.cpp" line="1383" />
+            <source>Loading...please wait!</source>
+            <translation>불러오는 중... 잠시 기다려주세요!</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/viewer.cpp" line="1394" />
+            <source>Page not available!</source>
+            <translation>페이지를 불러올 수 없습니다!</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/viewer.cpp" line="1602" />
+            <source>Cover!</source>
+            <translation>표지!</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/viewer.cpp" line="1616" />
+            <source>Last page!</source>
+            <translation>마지막 페이지!</translation>
+        </message>
+    </context>
+    <context>
+        <name>VolumeComicsModel</name>
+        <message>
+            <location filename="comic_vine/model/volume_comics_model.cpp" line="120" />
+            <source>title</source>
+            <translation>제목</translation>
+        </message>
+    </context>
+    <context>
+        <name>VolumesModel</name>
+        <message>
+            <location filename="comic_vine/model/volumes_model.cpp" line="118" />
+            <source>year</source>
+            <translation>연도</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/model/volumes_model.cpp" line="120" />
+            <source>issues</source>
+            <translation>이슈</translation>
+        </message>
+        <message>
+            <location filename="comic_vine/model/volumes_model.cpp" line="122" />
+            <source>publisher</source>
+            <translation>출판사</translation>
+        </message>
+    </context>
+    <context>
+        <name>YACReader3DFlowConfigWidget</name>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="19" />
+            <source>Presets:</source>
+            <translation>프리셋:</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="21" />
+            <source>Classic look</source>
+            <translation>클래식 스타일</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="24" />
+            <source>Stripe look</source>
+            <translation>줄무늬 스타일</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="27" />
+            <source>Overlapped Stripe look</source>
+            <translation>겹친 줄무늬 스타일</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="30" />
+            <source>Modern look</source>
+            <translation>모던 스타일</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="33" />
+            <source>Roulette look</source>
+            <translation>룰렛 스타일</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="77" />
+            <source>Show advanced settings</source>
+            <translation>고급 설정 보기</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="86" />
+            <source>Custom:</source>
+            <translation>사용자 지정:</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="89" />
+            <source>View angle</source>
+            <translation>시야각</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="95" />
+            <source>Position</source>
+            <translation>위치</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="101" />
+            <source>Cover gap</source>
+            <translation>표지 간격</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="107" />
+            <source>Central gap</source>
+            <translation>중앙 간격</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="113" />
+            <source>Zoom</source>
+            <translation>확대/축소</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="119" />
+            <source>Y offset</source>
+            <translation>Y축 오프셋</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="125" />
+            <source>Z offset</source>
+            <translation>Z축 오프셋</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="131" />
+            <source>Cover Angle</source>
+            <translation>표지 각도</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="137" />
+            <source>Visibility</source>
+            <translation>가시성</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="143" />
+            <source>Light</source>
+            <translation>조명</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="149" />
+            <source>Max angle</source>
+            <translation>최대 각도</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="181" />
+            <source>Low Performance</source>
+            <translation>저성능</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="183" />
+            <source>High Performance</source>
+            <translation>고성능</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="194" />
+            <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
+            <translation>수직 동기화 사용 (전체화면 결의 이미지 품질 향상, 성능 저하)</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="202" />
+            <source>Performance:</source>
+            <translation>성능:</translation>
+        </message>
+    </context>
+    <context>
+        <name>YACReader::MainWindowViewer</name>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="190" />
+            <source>&amp;Open</source>
+            <translation>열기(&amp;O)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="191" />
+            <source>Open a comic</source>
+            <translation>만화 열기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="197" />
+            <source>New instance</source>
+            <translation>새 창</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="216" />
+            <source>Open Folder</source>
+            <translation>폴더 열기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="217" />
+            <source>Open image folder</source>
+            <translation>이미지 폴더 열기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="222" />
+            <source>Open latest comic</source>
+            <translation>마지막 만화 열기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="223" />
+            <source>Open the latest comic opened in the previous reading session</source>
+            <translation>이전 작업에서 마지막으로 열었던 만화 열기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="235" />
+            <source>Clear</source>
+            <translation>지우기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="236" />
+            <source>Clear open recent list</source>
+            <translation>최근 목록 지우기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="239" />
+            <source>Save</source>
+            <translation>저장</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="240" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="945" />
+            <source>Save current page</source>
+            <translation>현재 페이지 저장</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="245" />
+            <source>Previous Comic</source>
+            <translation>이전 만화</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="246" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1733" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1737" />
+            <source>Open previous comic</source>
+            <translation>이전 만화 열기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="251" />
+            <source>Next Comic</source>
+            <translation>다음 만화</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="252" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1732" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1738" />
+            <source>Open next comic</source>
+            <translation>다음 만화 열기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="257" />
+            <source>&amp;Previous</source>
+            <translation>이전(&amp;P)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="259" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1735" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1739" />
+            <source>Go to previous page</source>
+            <translation>이전 페이지로 이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="264" />
+            <source>&amp;Next</source>
+            <translation>다음(&amp;N)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="266" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1734" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1740" />
+            <source>Go to next page</source>
+            <translation>다음 페이지로 이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="271" />
+            <source>Fit Height</source>
+            <translation>꽉차게 보기 (높이 맞춤)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="272" />
+            <source>Fit image to height</source>
+            <translation>이미지를 높이에 맞춤</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="278" />
+            <source>Fit Width</source>
+            <translation>꽉차게 보기 (폭 맞춤)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="279" />
+            <source>Fit image to width</source>
+            <translation>이미지를 폭에 맞춤</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="285" />
+            <source>Show full size</source>
+            <translation>원본 크기 (100%)로 보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="292" />
+            <source>Fit to page</source>
+            <translation>꽉차게 보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="298" />
+            <source>Continuous scroll</source>
+            <translation>연속 스크롤</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="299" />
+            <source>Switch to continuous scroll mode</source>
+            <translation>연속 스크롤 모드로 전환</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="331" />
+            <source>Reset zoom</source>
+            <translation>확대/축소 초기화</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="336" />
+            <source>Show zoom slider</source>
+            <translation>확대/축소 슬라이더 보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="338" />
+            <source>Zoom+</source>
+            <translation>확대+</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="343" />
+            <source>Zoom-</source>
+            <translation>축소-</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="348" />
+            <source>Rotate image to the left</source>
+            <translation>이미지 왼쪽으로 회전</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="353" />
+            <source>Rotate image to the right</source>
+            <translation>이미지 오른쪽으로 회전</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="358" />
+            <source>Double page mode</source>
+            <translation>두 페이지씩 보기 (왼쪽 → 오른쪽)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="359" />
+            <source>Switch to double page mode</source>
+            <translation>두 페이지씩 보기로 전환</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="367" />
+            <source>Double page manga mode</source>
+            <translation>두 페이지씩 보기 (왼쪽 ← 오른쪽)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="368" />
+            <source>Reverse reading order in double page mode</source>
+            <translation>두 페이지씩 보기에서 읽기 순서 뒤집기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="376" />
+            <source>Go To</source>
+            <translation>이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="377" />
+            <source>Go to page ...</source>
+            <translation>페이지로 이동...</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="382" />
+            <source>Options</source>
+            <translation>환경설정</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="383" />
+            <source>YACReader options</source>
+            <translation>YACReader 환경설정</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="389" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="684" />
+            <source>Help</source>
+            <translation>도움말</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="390" />
+            <source>Help, About YACReader</source>
+            <translation>도움말, YACReader 정보</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="395" />
+            <source>Magnifying glass</source>
+            <translation>돋보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="396" />
+            <source>Switch Magnifying glass</source>
+            <translation>돋보기 전환</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="402" />
+            <source>Set bookmark</source>
+            <translation>책갈피 설정</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="403" />
+            <source>Set a bookmark on the current page</source>
+            <translation>현재 페이지에 책갈피 설정</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="411" />
+            <source>Show bookmarks</source>
+            <translation>책갈피 보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="412" />
+            <source>Show the bookmarks of the current comic</source>
+            <translation>현재 만화의 책갈피 보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="417" />
+            <source>Show keyboard shortcuts</source>
+            <translation>키보드 단축키 보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="422" />
+            <source>Show Info</source>
+            <translation>정보 보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="427" />
+            <source>Close</source>
+            <translation>닫기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="432" />
+            <source>Show Dictionary</source>
+            <translation>사전 보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="438" />
+            <source>Show go to flow</source>
+            <translation>페이지 흐름 보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="443" />
+            <source>Edit shortcuts</source>
+            <translation>단축키 편집</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="464" />
+            <source>&amp;File</source>
+            <translation>파일(&amp;F)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="479" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="638" />
+            <source>Open recent</source>
+            <translation>최근 항목 열기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="627" />
+            <source>File</source>
+            <translation>파일</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="648" />
+            <source>Edit</source>
+            <translation>편집</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="652" />
+            <source>View</source>
+            <translation>보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="669" />
+            <source>Go</source>
+            <translation>이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="677" />
+            <source>Window</source>
+            <translation>창</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="794" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="796" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="798" />
+            <source>Open Comic</source>
+            <translation>만화 열기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="794" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="796" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="798" />
+            <source>Comic files</source>
+            <translation>만화 파일</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="889" />
+            <source>Open folder</source>
+            <translation>폴더 열기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="945" />
+            <source>page_%1.jpg</source>
+            <translation>page_%1.jpg</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="945" />
+            <source>Image files (*.jpg)</source>
+            <translation>이미지 파일 (*.jpg)</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1151" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1164" />
+            <source>Comics</source>
+            <translation>만화</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1152" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1180" />
+            <source>General</source>
+            <translation>일반</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1153" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1218" />
+            <source>Magnifiying glass</source>
+            <translation>돋보기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1154" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1229" />
+            <source>Page adjustement</source>
+            <translation>페이지 조정</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1155" />
+            <location filename="../YACReader/main_window_viewer.cpp" line="1307" />
+            <source>Reading</source>
+            <translation>읽기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1174" />
+            <source>Toggle fullscreen mode</source>
+            <translation>전체화면 전환</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1177" />
+            <source>Hide/show toolbar</source>
+            <translation>도구 모음 표시/숨김</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1199" />
+            <source>Size up magnifying glass</source>
+            <translation>돋보기 크게</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1202" />
+            <source>Size down magnifying glass</source>
+            <translation>돋보기 작게</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1205" />
+            <source>Zoom in magnifying glass</source>
+            <translation>돋보기 확대</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1208" />
+            <source>Zoom out magnifying glass</source>
+            <translation>돋보기 축소</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1211" />
+            <source>Reset magnifying glass</source>
+            <translation>돋보기 초기화</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1225" />
+            <source>Toggle between fit to width and fit to height</source>
+            <translation>폭 맞춤 / 높이 맞춤 전환</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1247" />
+            <source>Autoscroll down</source>
+            <translation>아래로 자동 스크롤</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1250" />
+            <source>Autoscroll up</source>
+            <translation>위로 자동 스크롤</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1253" />
+            <source>Autoscroll forward, horizontal first</source>
+            <translation>세로 우선으로 정방향 자동 스크롤</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1257" />
+            <source>Autoscroll backward, horizontal first</source>
+            <translation>가로 우선으로 정방향 자동 스크롤</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1261" />
+            <source>Autoscroll forward, vertical first</source>
+            <translation>세로 우선으로 역방향 자동 스크롤</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1265" />
+            <source>Autoscroll backward, vertical first</source>
+            <translation>가로 우선으로 역방향 자동 스크롤</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1269" />
+            <source>Move down</source>
+            <translation>아래로 이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1272" />
+            <source>Move up</source>
+            <translation>위로 이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1275" />
+            <source>Move left</source>
+            <translation>왼쪽으로 이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1278" />
+            <source>Move right</source>
+            <translation>오른쪽으로 이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1281" />
+            <source>Go to the first page</source>
+            <translation>첫 페이지로 이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1284" />
+            <source>Go to the last page</source>
+            <translation>마지막 페이지로 이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1287" />
+            <source>Offset double page to the left</source>
+            <translation>두 페이지 왼쪽으로 이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1289" />
+            <source>Offset double page to the right</source>
+            <translation>두 페이지 오른쪽으로 이동</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1356" />
+            <source>There is a new version available</source>
+            <translation>새 버전을 내려받으시겠습니까?</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1357" />
+            <source>Do you want to download the new version?</source>
+            <translation>새 버전을 내려받으시겠습니까?</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1360" />
+            <source>Remind me in 14 days</source>
+            <translation>14일 후에 다시 알림</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/main_window_viewer.cpp" line="1361" />
+            <source>Not now</source>
+            <translation>나중에</translation>
+        </message>
+    </context>
+    <context>
+        <name>YACReader::TrayIconController</name>
+        <message>
+            <location filename="trayicon_controller.cpp" line="52" />
+            <source>&amp;Restore</source>
+            <translation>복원(&amp;R)</translation>
+        </message>
+        <message>
+            <location filename="trayicon_controller.cpp" line="79" />
+            <source>Systray</source>
+            <translation>시스템 트레이</translation>
+        </message>
+        <message>
+            <location filename="trayicon_controller.cpp" line="80" />
+            <source>YACReaderLibrary will keep running in the system tray. To terminate the program, choose &lt;b&gt;Quit&lt;/b&gt; in the context menu of the system tray icon.</source>
+            <translation>YACReaderLibrary는 시스템 트레이에서 계속 실행됩니다. 프로그램을 종료하려면 시스템 트레이 아이콘의 컨텍스트 메뉴에서 &lt;b&gt;끝내기&lt;/b&gt;를 선택하세요.</translation>
+        </message>
+    </context>
+    <context>
+        <name>YACReaderFieldEdit</name>
+        <message>
+            <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9" />
+            <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28" />
+            <source>Click to overwrite</source>
+            <translation>클릭해서 덮어쓰기</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11" />
+            <source>Restore to default</source>
+            <translation>기본값으로 복원</translation>
+        </message>
+    </context>
+    <context>
+        <name>YACReaderFieldPlainTextEdit</name>
+        <message>
+            <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9" />
+            <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19" />
+            <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44" />
+            <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50" />
+            <source>Click to overwrite</source>
+            <translation>클릭해서 덮어쓰기</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10" />
+            <source>Restore to default</source>
+            <translation>기본값으로 복원</translation>
+        </message>
+    </context>
+    <context>
+        <name>YACReaderFlowConfigWidget</name>
+        <message>
+            <source>CoverFlow look</source>
+            <translation type="vanished">코버플로 스타일</translation>
+        </message>
+        <message>
+            <source>How to show covers:</source>
+            <translation type="vanished">표지 표시 방식:</translation>
+        </message>
+        <message>
+            <source>Stripe look</source>
+            <translation type="vanished">줄무늬 스타일</translation>
+        </message>
+        <message>
+            <source>Overlapped Stripe look</source>
+            <translation type="vanished">겹친 줄무늬 스타일</translation>
+        </message>
+    </context>
+    <context>
+        <name>YACReaderGLFlowConfigWidget</name>
+        <message>
+            <source>Stripe look</source>
+            <translation type="vanished">줄무늬 스타일</translation>
+        </message>
+        <message>
+            <source>Overlapped Stripe look</source>
+            <translation type="vanished">겹친 줄무늬 스타일</translation>
+        </message>
+    </context>
+    <context>
+        <name>YACReaderOptionsDialog</name>
+        <message>
+            <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="19" />
+            <source>Save</source>
+            <translation>저장</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="20" />
+            <source>Cancel</source>
+            <translation>취소</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="25" />
+            <source>Edit shortcuts</source>
+            <translation>단축키 편집</translation>
+        </message>
+        <message>
+            <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28" />
+            <source>Shortcuts</source>
+            <translation>단축키</translation>
+        </message>
+    </context>
+    <context>
+        <name>YACReaderSearchLineEdit</name>
+        <message>
+            <location filename="../custom_widgets/yacreader_search_line_edit.cpp" line="31" />
+            <source>type to search</source>
+            <translation>검색어 입력</translation>
+        </message>
+    </context>
+    <context>
+        <name>YACReaderSlider</name>
+        <message>
+            <location filename="../YACReader/width_slider.cpp" line="49" />
+            <source>Reset</source>
+            <translation>초기화</translation>
+        </message>
+    </context>
+    <context>
+        <name>YACReaderTranslator</name>
+        <message>
+            <location filename="../YACReader/translator.cpp" line="42" />
+            <source>YACReader translator</source>
+            <translation>YACReader 번역기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/translator.cpp" line="82" />
+            <location filename="../YACReader/translator.cpp" line="188" />
+            <source>Translation</source>
+            <translation>번역</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/translator.cpp" line="102" />
+            <source>clear</source>
+            <translation>지우기</translation>
+        </message>
+        <message>
+            <location filename="../YACReader/translator.cpp" line="197" />
+            <source>Service not available</source>
+            <translation>서비스를 사용할 수 없습니다</translation>
+        </message>
+    </context>
+</TS>

--- a/YACReaderLibrary/yacreaderlibrary_ko.ts
+++ b/YACReaderLibrary/yacreaderlibrary_ko.ts
@@ -1,3892 +1,2941 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
-    <context>
-        <name>ActionsShortcutsModel</name>
-        <message>
-            <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="73" />
-            <source>None</source>
-            <translation>없음</translation>
-        </message>
-    </context>
-    <context>
-        <name>AddLabelDialog</name>
-        <message>
-            <location filename="add_label_dialog.cpp" line="25" />
-            <source>Label name:</source>
-            <translation>라벨 이름:</translation>
-        </message>
-        <message>
-            <location filename="add_label_dialog.cpp" line="28" />
-            <source>Choose a color:</source>
-            <translation>색상 선택:</translation>
-        </message>
-        <message>
-            <location filename="add_label_dialog.cpp" line="42" />
-            <source>accept</source>
-            <translation>확인</translation>
-        </message>
-        <message>
-            <location filename="add_label_dialog.cpp" line="43" />
-            <source>cancel</source>
-            <translation>취소</translation>
-        </message>
-    </context>
-    <context>
-        <name>AddLibraryDialog</name>
-        <message>
-            <location filename="add_library_dialog.cpp" line="26" />
-            <source>Add</source>
-            <translation>추가</translation>
-        </message>
-        <message>
-            <location filename="add_library_dialog.cpp" line="64" />
-            <source>Add an existing library</source>
-            <translation>기존 라이브러리 추가</translation>
-        </message>
-        <message>
-            <location filename="add_library_dialog.cpp" line="30" />
-            <source>Cancel</source>
-            <translation>취소</translation>
-        </message>
-        <message>
-            <location filename="add_library_dialog.cpp" line="16" />
-            <source>Comics folder : </source>
-            <translation>만화 폴더: </translation>
-        </message>
-        <message>
-            <location filename="add_library_dialog.cpp" line="21" />
-            <source>Library name : </source>
-            <translation>라이브러리 이름: </translation>
-        </message>
-    </context>
-    <context>
-        <name>ApiKeyDialog</name>
-        <message>
-            <location filename="comic_vine/api_key_dialog.cpp" line="32" />
-            <source>Cancel</source>
-            <translation>취소</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/api_key_dialog.cpp" line="21" />
-            <source>Before you can connect to Comic Vine, you need your own API key. Please, get one free &lt;a href="http://www.comicvine.com/api/"&gt;here&lt;/a&gt;</source>
-            <translation>Comic Vine에 연결하려면 본인의 API 키가 필요합니다. &lt;a href="http://www.comicvine.com/api/"&gt;여기&lt;/a&gt;에서 무료로 발급받으세요.</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/api_key_dialog.cpp" line="25" />
-            <source>Paste here your Comic Vine API key</source>
-            <translation>Comic Vine API 키를 여기 붙여넣으세요</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/api_key_dialog.cpp" line="28" />
-            <source>Accept</source>
-            <translation>확인</translation>
-        </message>
-    </context>
-    <context>
-        <name>AppearanceTabWidget</name>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="38" />
-            <source>Color scheme</source>
-            <translation>색 구성표</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="46" />
-            <source>System</source>
-            <translation>시스템</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="47" />
-            <source>Light</source>
-            <translation>밝은</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="48" />
-            <source>Dark</source>
-            <translation>어두운</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="49" />
-            <source>Custom</source>
-            <translation>사용자 지정</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="105" />
-            <source>Remove</source>
-            <translation>제거</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="107" />
-            <source>Remove this user-imported theme</source>
-            <translation>사용자 가져온 이 테마 제거</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="115" />
-            <source>Light:</source>
-            <translation>밝은:</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="116" />
-            <source>Dark:</source>
-            <translation>어두운:</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="117" />
-            <source>Custom:</source>
-            <translation>사용자 지정:</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="119" />
-            <source>Import theme...</source>
-            <translation>테마 가져오기...</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="121" />
-            <source>Theme</source>
-            <translation>테마</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="173" />
-            <source>Theme editor</source>
-            <translation>테마 편집기</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="175" />
-            <source>Open Theme Editor...</source>
-            <translation>테마 편집기 열기...</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="184" />
-            <source>Theme editor error</source>
-            <translation>테마 편집기 오류</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="185" />
-            <source>The current theme JSON could not be loaded.</source>
-            <translation>현재 테마 JSON을 불러올 수 없습니다.</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="279" />
-            <source>Import theme</source>
-            <translation>테마 가져오기</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="279" />
-            <source>JSON files (*.json);;All files (*)</source>
-            <translation>JSON 파일 (*.json);;모든 파일 (*)</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="287" />
-            <source>Could not import theme from:
+<TS version="2.1" language="ko">
+<context>
+    <name>ActionsShortcutsModel</name>
+    <message>
+        <location filename="../shortcuts_management/actions_shortcuts_model.cpp" line="74"/>
+        <source>None</source>
+        <translation>없음</translation>
+    </message>
+</context>
+<context>
+    <name>AddLabelDialog</name>
+    <message>
+        <location filename="add_label_dialog.cpp" line="28"/>
+        <source>Label name:</source>
+        <translation>라벨 이름:</translation>
+    </message>
+    <message>
+        <location filename="add_label_dialog.cpp" line="31"/>
+        <source>Choose a color:</source>
+        <translation>색상 선택:</translation>
+    </message>
+    <message>
+        <location filename="add_label_dialog.cpp" line="45"/>
+        <source>accept</source>
+        <translation>확인</translation>
+    </message>
+    <message>
+        <location filename="add_label_dialog.cpp" line="46"/>
+        <source>cancel</source>
+        <translation>취소</translation>
+    </message>
+</context>
+<context>
+    <name>AddLibraryDialog</name>
+    <message>
+        <location filename="add_library_dialog.cpp" line="26"/>
+        <source>Add</source>
+        <translation>추가</translation>
+    </message>
+    <message>
+        <location filename="add_library_dialog.cpp" line="64"/>
+        <source>Add an existing library</source>
+        <translation>기존 라이브러리 추가</translation>
+    </message>
+    <message>
+        <location filename="add_library_dialog.cpp" line="30"/>
+        <source>Cancel</source>
+        <translation>취소</translation>
+    </message>
+    <message>
+        <location filename="add_library_dialog.cpp" line="16"/>
+        <source>Comics folder : </source>
+        <translation>만화 폴더: </translation>
+    </message>
+    <message>
+        <location filename="add_library_dialog.cpp" line="21"/>
+        <source>Library name : </source>
+        <translation>라이브러리 이름: </translation>
+    </message>
+</context>
+<context>
+    <name>ApiKeyDialog</name>
+    <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="32"/>
+        <source>Cancel</source>
+        <translation>취소</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="21"/>
+        <source>Before you can connect to Comic Vine, you need your own API key. Please, get one free &lt;a href=&quot;http://www.comicvine.com/api/&quot;&gt;here&lt;/a&gt;</source>
+        <translation>Comic Vine에 연결하려면 본인의 API 키가 필요합니다. &lt;a href=&quot;http://www.comicvine.com/api/&quot;&gt;여기&lt;/a&gt;에서 무료로 발급받으세요.</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="25"/>
+        <source>Paste here your Comic Vine API key</source>
+        <translation>Comic Vine API 키를 여기 붙여넣으세요</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/api_key_dialog.cpp" line="28"/>
+        <source>Accept</source>
+        <translation>확인</translation>
+    </message>
+</context>
+<context>
+    <name>AppearanceTabWidget</name>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="38"/>
+        <source>Color scheme</source>
+        <translation>색 구성표</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="46"/>
+        <source>System</source>
+        <translation>시스템</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="47"/>
+        <source>Light</source>
+        <translation>밝은</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="48"/>
+        <source>Dark</source>
+        <translation>어두운</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="49"/>
+        <source>Custom</source>
+        <translation>사용자 지정</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="105"/>
+        <source>Remove</source>
+        <translation>제거</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="107"/>
+        <source>Remove this user-imported theme</source>
+        <translation>사용자 가져온 이 테마 제거</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="115"/>
+        <source>Light:</source>
+        <translation>밝은:</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="116"/>
+        <source>Dark:</source>
+        <translation>어두운:</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="117"/>
+        <source>Custom:</source>
+        <translation>사용자 지정:</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="119"/>
+        <source>Import theme...</source>
+        <translation>테마 가져오기...</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="121"/>
+        <source>Theme</source>
+        <translation>테마</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="173"/>
+        <source>Theme editor</source>
+        <translation>테마 편집기</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="175"/>
+        <source>Open Theme Editor...</source>
+        <translation>테마 편집기 열기...</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="184"/>
+        <source>Theme editor error</source>
+        <translation>테마 편집기 오류</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="185"/>
+        <source>The current theme JSON could not be loaded.</source>
+        <translation>현재 테마 JSON을 불러올 수 없습니다.</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="279"/>
+        <source>Import theme</source>
+        <translation>테마 가져오기</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="279"/>
+        <source>JSON files (*.json);;All files (*)</source>
+        <translation>JSON 파일 (*.json);;모든 파일 (*)</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="287"/>
+        <source>Could not import theme from:
 %1</source>
-            <translation>다음에서 테마를 가져올 수 없습니다:
+        <translation>다음에서 테마를 가져올 수 없습니다:
 %1</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="288" />
-            <source>Could not import theme from:
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="288"/>
+        <source>Could not import theme from:
 %1
 
 %2</source>
-            <translation>다음에서 테마를 가져올 수 없습니다:
+        <translation>다음에서 테마를 가져올 수 없습니다:
 %1
 
 %2</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/appearance_tab_widget.cpp" line="289" />
-            <source>Import failed</source>
-            <translation>가져오기 실패</translation>
-        </message>
-    </context>
-    <context>
-        <name>BookmarksDialog</name>
-        <message>
-            <location filename="../YACReader/bookmarks_dialog.cpp" line="25" />
-            <source>Lastest Page</source>
-            <translation>마지막 페이지</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/bookmarks_dialog.cpp" line="75" />
-            <source>Close</source>
-            <translation>닫기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/bookmarks_dialog.cpp" line="85" />
-            <source>Click on any image to go to the bookmark</source>
-            <translation>이미지를 클릭하면 책갈피로 이동합니다</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/bookmarks_dialog.cpp" line="107" />
-            <location filename="../YACReader/bookmarks_dialog.cpp" line="124" />
-            <source>Loading...</source>
-            <translation>불러오는 중...</translation>
-        </message>
-    </context>
-    <context>
-        <name>ClassicComicsView</name>
-        <message>
-            <location filename="classic_comics_view.cpp" line="85" />
-            <source>Hide comic flow</source>
-            <translation>만화 흐름 숨기기</translation>
-        </message>
-    </context>
-    <context>
-        <name>ComicInfoView</name>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="302" />
-            <source>Characters</source>
-            <translation>등장인물</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="334" />
-            <source>Main character or team</source>
-            <translation>주요 등장인물 또는 팀</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="359" />
-            <source>Teams</source>
-            <translation>팀</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="393" />
-            <source>Locations</source>
-            <translation>장소</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="425" />
-            <source>Authors</source>
-            <translation>작가진</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="457" />
-            <source>writer</source>
-            <translation>글</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="479" />
-            <source>penciller</source>
-            <translation>밑그림</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="501" />
-            <source>inker</source>
-            <translation>펜선</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="523" />
-            <source>colorist</source>
-            <translation>채색</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="545" />
-            <source>letterer</source>
-            <translation>식자</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="567" />
-            <source>cover artist</source>
-            <translation>표지 그림</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="589" />
-            <source>editor</source>
-            <translation>편집</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="611" />
-            <source>imprint</source>
-            <translation>출판 브랜드</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="626" />
-            <source>Publisher</source>
-            <translation>출판사</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="678" />
-            <source>color</source>
-            <translation>컬러</translation>
-        </message>
-        <message>
-            <location filename="qml/ComicInfoView.qml" line="678" />
-            <source>b/w</source>
-            <translation>흑백</translation>
-        </message>
-    </context>
-    <context>
-        <name>ComicModel</name>
-        <message>
-            <location filename="db/comic_model.cpp" line="364" />
-            <source>yes</source>
-            <translation>예</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="364" />
-            <source>no</source>
-            <translation>아니오</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="395" />
-            <source>Title</source>
-            <translation>제목</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="397" />
-            <source>File Name</source>
-            <translation>파일 이름</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="399" />
-            <source>Pages</source>
-            <translation>페이지</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="401" />
-            <source>Size</source>
-            <translation>크기</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="403" />
-            <source>Read</source>
-            <translation>읽음</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="405" />
-            <source>Current Page</source>
-            <translation>현재 페이지</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="407" />
-            <source>Publication Date</source>
-            <translation>출판일</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="409" />
-            <source>Rating</source>
-            <translation>평점</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="411" />
-            <source>Series</source>
-            <translation>시리즈</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="413" />
-            <source>Volume</source>
-            <translation>볼륨</translation>
-        </message>
-        <message>
-            <location filename="db/comic_model.cpp" line="415" />
-            <source>Story Arc</source>
-            <translation>스토리 아크</translation>
-        </message>
-    </context>
-    <context>
-        <name>ComicVineDialog</name>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="54" />
-            <source>skip</source>
-            <translation>건너뛰기</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="55" />
-            <source>back</source>
-            <translation>뒤로</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="56" />
-            <source>next</source>
-            <translation>다음</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="57" />
-            <source>search</source>
-            <translation>검색</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="58" />
-            <source>close</source>
-            <translation>닫기</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="134" />
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="588" />
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="627" />
-            <source>Looking for volume...</source>
-            <translation>볼륨 검색 중...</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="132" />
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="546" />
-            <source>comic %1 of %2 - %3</source>
-            <translation>%1 / %2 만화 - %3</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="249" />
-            <source>%1 comics selected</source>
-            <translation>만화 %1개 선택됨</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="280" />
-            <source>Error connecting to ComicVine</source>
-            <translation>Comic Vine 연결 오류</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="460" />
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="486" />
-            <source>Retrieving tags for : %1</source>
-            <translation>태그 가져오는 중 : %1</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="607" />
-            <source>Retrieving volume info...</source>
-            <translation>볼륨 정보 가져오는 중...</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/comic_vine_dialog.cpp" line="639" />
-            <source>Looking for comic...</source>
-            <translation>만화 검색 중...</translation>
-        </message>
-    </context>
-    <context>
-        <name>ContinuousPageWidget</name>
-        <message>
-            <location filename="../YACReader/continuous_page_widget.cpp" line="156" />
-            <source>Loading page %1</source>
-            <translation>페이지 %1 불러오는 중</translation>
-        </message>
-    </context>
-    <context>
-        <name>CreateLibraryDialog</name>
-        <message>
-            <location filename="create_library_dialog.cpp" line="76" />
-            <source>Create new library</source>
-            <translation>새 라이브러리 만들기</translation>
-        </message>
-        <message>
-            <location filename="create_library_dialog.cpp" line="34" />
-            <source>Cancel</source>
-            <translation>취소</translation>
-        </message>
-        <message>
-            <location filename="create_library_dialog.cpp" line="30" />
-            <source>Create</source>
-            <translation>만들기</translation>
-        </message>
-        <message>
-            <location filename="create_library_dialog.cpp" line="20" />
-            <source>Comics folder : </source>
-            <translation>만화 폴더: </translation>
-        </message>
-        <message>
-            <location filename="create_library_dialog.cpp" line="25" />
-            <source>Library Name : </source>
-            <translation>라이브러리 이름: </translation>
-        </message>
-        <message>
-            <location filename="create_library_dialog.cpp" line="56" />
-            <source>Create a library could take several minutes. You can stop the process and update the library later for completing the task.</source>
-            <translation>라이브러리 생성은 몇 분 걸릴 수 있습니다. 작업을 중지하고 나중에 라이브러리를 업데이트하여 완료할 수 있습니다.</translation>
-        </message>
-        <message>
-            <location filename="create_library_dialog.cpp" line="104" />
-            <source>Path not found</source>
-            <translation>경로를 찾을 수 없음</translation>
-        </message>
-        <message>
-            <location filename="create_library_dialog.cpp" line="104" />
-            <source>The selected path does not exist or is not a valid path. Be sure that you have write access to this folder</source>
-            <translation>선택한 경로가 존재하지 않거나 올바르지 않습니다. 이 폴더에 쓰기 권한이 있는지 확인하세요</translation>
-        </message>
-    </context>
-    <context>
-        <name>EditShortcutsDialog</name>
-        <message>
-            <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="23" />
-            <source>Restore defaults</source>
-            <translation>기본값으로 복원</translation>
-        </message>
-        <message>
-            <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="24" />
-            <source>To change a shortcut, double click in the key combination and type the new keys.</source>
-            <translation>단축키를 바꾸려면 키 조합을 더블 클릭하고 새 키를 입력하세요.</translation>
-        </message>
-        <message>
-            <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="71" />
-            <source>Shortcuts settings</source>
-            <translation>단축키 설정</translation>
-        </message>
-        <message>
-            <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="122" />
-            <source>Shortcut in use</source>
-            <translation>사용 중인 단축키</translation>
-        </message>
-        <message>
-            <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="122" />
-            <source>The shortcut "%1" is already assigned to other function</source>
-            <translation>"%1" 단축키는 이미 다른 기능이 사용 중입니다</translation>
-        </message>
-    </context>
-    <context>
-        <name>EmptyFolderWidget</name>
-        <message>
-            <location filename="empty_folder_widget.cpp" line="8" />
-            <source>This folder doesn't contain comics yet</source>
-            <translation>이 폴더에는 아직 만화가 없습니다</translation>
-        </message>
-    </context>
-    <context>
-        <name>EmptyLabelWidget</name>
-        <message>
-            <location filename="empty_label_widget.cpp" line="7" />
-            <source>This label doesn't contain comics yet</source>
-            <translation>이 라벨에 아직 만화가 없습니다</translation>
-        </message>
-    </context>
-    <context>
-        <name>EmptyReadingListWidget</name>
-        <message>
-            <location filename="empty_reading_list_widget.cpp" line="8" />
-            <source>This reading list does not contain any comics yet</source>
-            <translation>이 읽기 목록에 아직 만화가 없습니다</translation>
-        </message>
-    </context>
-    <context>
-        <name>EmptySpecialListWidget</name>
-        <message>
-            <location filename="empty_special_list.cpp" line="13" />
-            <source>No favorites</source>
-            <translation>즐겨찾기 없음</translation>
-        </message>
-        <message>
-            <location filename="empty_special_list.cpp" line="20" />
-            <source>You are not reading anything yet, come on!!</source>
-            <translation>아직 읽고 있는 만화가 없습니다. 지금 시작해보세요!!</translation>
-        </message>
-        <message>
-            <location filename="empty_special_list.cpp" line="27" />
-            <source>There are no recent comics!</source>
-            <translation>최근 본 만화가 없습니다!</translation>
-        </message>
-    </context>
-    <context>
-        <name>ExportComicsInfoDialog</name>
-        <message>
-            <location filename="export_comics_info_dialog.cpp" line="22" />
-            <source>Cancel</source>
-            <translation>취소</translation>
-        </message>
-        <message>
-            <location filename="export_comics_info_dialog.cpp" line="18" />
-            <source>Create</source>
-            <translation>생성</translation>
-        </message>
-        <message>
-            <location filename="export_comics_info_dialog.cpp" line="14" />
-            <source>Output file : </source>
-            <translation>출력 파일: </translation>
-        </message>
-        <message>
-            <location filename="export_comics_info_dialog.cpp" line="55" />
-            <source>Export comics info</source>
-            <translation>만화 정보 내보내기</translation>
-        </message>
-        <message>
-            <location filename="export_comics_info_dialog.cpp" line="72" />
-            <source>Destination database name</source>
-            <translation>대상 데이터베이스 이름</translation>
-        </message>
-        <message>
-            <location filename="export_comics_info_dialog.cpp" line="87" />
-            <source>Problem found while writing</source>
-            <translation>쓰기 중 문제 발생</translation>
-        </message>
-        <message>
-            <location filename="export_comics_info_dialog.cpp" line="87" />
-            <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
-            <translation>출력 파일에 선택한 경로가 존재하지 않거나 올바르지 않습니다. 이 폴더에 쓰기 권한이 있는지 확인하세요</translation>
-        </message>
-    </context>
-    <context>
-        <name>ExportLibraryDialog</name>
-        <message>
-            <location filename="export_library_dialog.cpp" line="19" />
-            <source>Cancel</source>
-            <translation>취소</translation>
-        </message>
-        <message>
-            <location filename="export_library_dialog.cpp" line="15" />
-            <source>Create</source>
-            <translation>생성</translation>
-        </message>
-        <message>
-            <location filename="export_library_dialog.cpp" line="11" />
-            <source>Output folder : </source>
-            <translation>출력 폴더: </translation>
-        </message>
-        <message>
-            <location filename="export_library_dialog.cpp" line="58" />
-            <source>Create covers package</source>
-            <translation>표지 패키지 생성</translation>
-        </message>
-        <message>
-            <location filename="export_library_dialog.cpp" line="82" />
-            <source>Destination directory</source>
-            <translation>대상 폴더</translation>
-        </message>
-        <message>
-            <location filename="export_library_dialog.cpp" line="77" />
-            <source>Problem found while writing</source>
-            <translation>쓰기 중 문제 발생</translation>
-        </message>
-        <message>
-            <location filename="export_library_dialog.cpp" line="77" />
-            <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
-            <translation>출력 파일에 선택한 경로가 존재하지 않거나 올바르지 않습니다. 이 폴더에 쓰기 권한이 있는지 확인하세요</translation>
-        </message>
-    </context>
-    <context>
-        <name>FileComic</name>
-        <message>
-            <location filename="../common/comic.cpp" line="562" />
-            <source>7z not found</source>
-            <translation>7z를 찾을 수 없습니다</translation>
-        </message>
-        <message>
-            <location filename="../common/comic.cpp" line="454" />
-            <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
-            <translation>%1번 페이지에서 CRC 오류 발생: 일부 페이지가 올바르게 표시되지 않을 수 있습니다</translation>
-        </message>
-        <message>
-            <location filename="../common/comic.cpp" line="461" />
-            <source>Unknown error opening the file</source>
-            <translation>파일을 여는 중 알 수 없는 오류가 발생했습니다</translation>
-        </message>
-        <message>
-            <location filename="../common/comic.cpp" line="568" />
-            <source>Format not supported</source>
-            <translation>지원하지 않는 형식입니다</translation>
-        </message>
-    </context>
-    <context>
-        <name>FolderContentView</name>
-        <message>
-            <location filename="qml/FolderContentView.qml" line="223" />
-            <source>Continue Reading...</source>
-            <translation>이어 읽기...</translation>
-        </message>
-    </context>
-    <context>
-        <name>GoToDialog</name>
-        <message>
-            <location filename="../YACReader/goto_dialog.cpp" line="15" />
-            <source>Page : </source>
-            <translation>페이지: </translation>
-        </message>
-        <message>
-            <location filename="../YACReader/goto_dialog.cpp" line="23" />
-            <source>Go To</source>
-            <translation>이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/goto_dialog.cpp" line="25" />
-            <source>Cancel</source>
-            <translation>취소</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/goto_dialog.cpp" line="39" />
-            <location filename="../YACReader/goto_dialog.cpp" line="71" />
-            <source>Total pages : </source>
-            <translation>전체 페이지: </translation>
-        </message>
-        <message>
-            <location filename="../YACReader/goto_dialog.cpp" line="53" />
-            <source>Go to...</source>
-            <translation>이동...</translation>
-        </message>
-    </context>
-    <context>
-        <name>GoToFlowToolBar</name>
-        <message>
-            <location filename="../YACReader/goto_flow_toolbar.cpp" line="25" />
-            <source>Page : </source>
-            <translation>페이지: </translation>
-        </message>
-    </context>
-    <context>
-        <name>GridComicsView</name>
-        <message>
-            <location filename="grid_comics_view.cpp" line="77" />
-            <source>Show info</source>
-            <translation>정보 보기</translation>
-        </message>
-    </context>
-    <context>
-        <name>HelpAboutDialog</name>
-        <message>
-            <location filename="../custom_widgets/help_about_dialog.cpp" line="23" />
-            <source>About</source>
-            <translation>정보</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/help_about_dialog.cpp" line="26" />
-            <source>Help</source>
-            <translation>도움말</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/help_about_dialog.cpp" line="29" />
-            <source>System info</source>
-            <translation>시스템 정보</translation>
-        </message>
-    </context>
-    <context>
-        <name>ImportComicsInfoDialog</name>
-        <message>
-            <location filename="import_comics_info_dialog.cpp" line="24" />
-            <source>Cancel</source>
-            <translation>취소</translation>
-        </message>
-        <message>
-            <location filename="import_comics_info_dialog.cpp" line="14" />
-            <source>Import comics info</source>
-            <translation>만화 정보 가져오기</translation>
-        </message>
-        <message>
-            <location filename="import_comics_info_dialog.cpp" line="16" />
-            <source>Info database location : </source>
-            <translation>정보 데이터베이스 경로: </translation>
-        </message>
-        <message>
-            <location filename="import_comics_info_dialog.cpp" line="20" />
-            <source>Import</source>
-            <translation>가져오기</translation>
-        </message>
-        <message>
-            <location filename="import_comics_info_dialog.cpp" line="80" />
-            <source>Comics info file (*.ydb)</source>
-            <translation>만화 정보 파일 (*.ydb)</translation>
-        </message>
-    </context>
-    <context>
-        <name>ImportLibraryDialog</name>
-        <message>
-            <location filename="import_library_dialog.cpp" line="26" />
-            <source>Destination folder : </source>
-            <translation>대상 폴더: </translation>
-        </message>
-        <message>
-            <location filename="import_library_dialog.cpp" line="34" />
-            <source>Cancel</source>
-            <translation>취소</translation>
-        </message>
-        <message>
-            <location filename="import_library_dialog.cpp" line="30" />
-            <source>Unpack</source>
-            <translation>풀기</translation>
-        </message>
-        <message>
-            <location filename="import_library_dialog.cpp" line="115" />
-            <source>Compresed library covers (*.clc)</source>
-            <translation>압축된 라이브러리 표지 (*.clc)</translation>
-        </message>
-        <message>
-            <location filename="import_library_dialog.cpp" line="22" />
-            <source>Package location : </source>
-            <translation>패키지 경로: </translation>
-        </message>
-        <message>
-            <location filename="import_library_dialog.cpp" line="17" />
-            <source>Library Name : </source>
-            <translation>라이브러리 이름: </translation>
-        </message>
-        <message>
-            <location filename="import_library_dialog.cpp" line="85" />
-            <source>Extract a catalog</source>
-            <translation>카탈로그 추출</translation>
-        </message>
-    </context>
-    <context>
-        <name>ImportWidget</name>
-        <message>
-            <location filename="import_widget.cpp" line="131" />
-            <source>stop</source>
-            <translation>중지</translation>
-        </message>
-        <message>
-            <location filename="import_widget.cpp" line="171" />
-            <source>Some of the comics being added...</source>
-            <translation>일부 만화를 추가하는 중...</translation>
-        </message>
-        <message>
-            <location filename="import_widget.cpp" line="318" />
-            <source>Importing comics</source>
-            <translation>만화 가져오는 중</translation>
-        </message>
-        <message>
-            <location filename="import_widget.cpp" line="319" />
-            <source>&lt;p&gt;YACReaderLibrary is now creating a new library.&lt;/p&gt;&lt;p&gt;Create a library could take several minutes. You can stop the process and update the library later for completing the task.&lt;/p&gt;</source>
-            <translation>&lt;p&gt;YACReaderLibrary가 새 라이브러리를 만들고 있습니다.&lt;/p&gt;&lt;p&gt;라이브러리 생성은 몇 분 걸릴 수 있습니다. 작업을 중지하고 나중에 라이브러리를 업데이트하여 작업을 완료할 수 있습니다.&lt;/p&gt;</translation>
-        </message>
-        <message>
-            <location filename="import_widget.cpp" line="330" />
-            <source>Updating the library</source>
-            <translation>라이브러리 업데이트 중</translation>
-        </message>
-        <message>
-            <location filename="import_widget.cpp" line="331" />
-            <source>&lt;p&gt;The current library is being updated. For faster updates, please, update your libraries frequently.&lt;/p&gt;&lt;p&gt;You can stop the process and continue updating this library later.&lt;/p&gt;</source>
-            <translation>&lt;p&gt;현재 라이브러리를 업데이트하고 있습니다. 더 빠른 업데이트를 위해 라이브러리를 자주 업데이트하세요.&lt;/p&gt;&lt;p&gt;작업을 중지하고 나중에 이 라이브러리 업데이트를 계속할 수 있습니다.&lt;/p&gt;</translation>
-        </message>
-        <message>
-            <location filename="import_widget.cpp" line="342" />
-            <source>Upgrading the library</source>
-            <translation>라이브러리 업그레이드 중</translation>
-        </message>
-        <message>
-            <location filename="import_widget.cpp" line="343" />
-            <source>&lt;p&gt;The current library is being upgraded, please wait.&lt;/p&gt;</source>
-            <translation>&lt;p&gt;현재 라이브러리를 업그레이드하고 있습니다. 잠시만 기다려주세요.&lt;/p&gt;</translation>
-        </message>
-        <message>
-            <location filename="import_widget.cpp" line="354" />
-            <source>Scanning the library</source>
-            <translation>라이브러리 스캔 중</translation>
-        </message>
-        <message>
-            <location filename="import_widget.cpp" line="355" />
-            <source>&lt;p&gt;Current library is being scanned for legacy XML metadata information.&lt;/p&gt;&lt;p&gt;This is only needed once, and only if the library was crated with YACReaderLibrary 9.8.2 or earlier.&lt;/p&gt;</source>
-            <translation>&lt;p&gt;현재 라이브러리에서 레거시 XML 메타데이터 정보를 스캔하고 있습니다.&lt;/p&gt;&lt;p&gt;이 작업은 한 번만 필요하며, 라이브러리가 YACReaderLibrary 9.8.2 또는 이전 버전으로 만들어진 경우에만 해당됩니다.&lt;/p&gt;</translation>
-        </message>
-    </context>
-    <context>
-        <name>LibraryWindow</name>
-        <message>
-            <source>Remove current library from your collection</source>
-            <translation type="vanished">내 컬렉션에서 현재 라이브러리 제거</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="626" />
-            <source>Library</source>
-            <translation>라이브러리</translation>
-        </message>
-        <message>
-            <source>Rename current library</source>
-            <translation type="vanished">현재 라이브러리 이름 변경</translation>
-        </message>
-        <message>
-            <source>Open current comic on YACReader</source>
-            <translation type="vanished">YACReader에서 현재 만화 열기</translation>
-        </message>
-        <message>
-            <source>Update current library</source>
-            <translation type="vanished">현재 라이브러리 업데이트</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1408" />
-            <source>Open folder...</source>
-            <translation>폴더 열기...</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="545" />
-            <location filename="library_window.cpp" line="1310" />
-            <location filename="library_window.cpp" line="1435" />
-            <source>western manga (left to right)</source>
-            <translation>서양 만화 (왼쪽 → 오른쪽)</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="551" />
-            <location filename="library_window.cpp" line="1316" />
-            <location filename="library_window.cpp" line="1441" />
-            <source>4koma (top to botom)</source>
-            <oldsource>4koma (top to botom</oldsource>
-            <translation>4컷 (위 → 아래)</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1861" />
-            <source>Do you want remove </source>
-            <translation>다음을 제거하시겠습니까: </translation>
-        </message>
-        <message>
-            <source>Expand all nodes</source>
-            <translation type="vanished">모든 노드 펼치기</translation>
-        </message>
-        <message>
-            <source>Show options dialog</source>
-            <translation type="vanished">환경설정 다이얼로그 표시</translation>
-        </message>
-        <message>
-            <source>Create a new library</source>
-            <translation type="vanished">새 라이브러리 만들기</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="223" />
-            <source>YACReader Library</source>
-            <translation>YACReader Library</translation>
-        </message>
-        <message>
-            <source>Open an existing library</source>
-            <translation type="vanished">기존 라이브러리 열기</translation>
-        </message>
-        <message>
-            <source>Pack the covers of the selected library</source>
-            <translation type="vanished">선택한 라이브러리의 표지 묶기</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="542" />
-            <location filename="library_window.cpp" line="1307" />
-            <location filename="library_window.cpp" line="1429" />
-            <source>manga</source>
-            <translation>망가</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="539" />
-            <location filename="library_window.cpp" line="1304" />
-            <location filename="library_window.cpp" line="1432" />
-            <source>comic</source>
-            <translation>만화</translation>
-        </message>
-        <message>
-            <source>Help, About YACReader</source>
-            <translation type="vanished">도움말, YACReader 정보</translation>
-        </message>
-        <message>
-            <source>Select root node</source>
-            <translation type="vanished">루트 노드 선택</translation>
-        </message>
-        <message>
-            <source>Unpack a catalog</source>
-            <translation type="vanished">카탈로그 풀기</translation>
-        </message>
-        <message>
-            <source>Open containing folder...</source>
-            <translation type="vanished">포함된 폴더 열기...</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1861" />
-            <source>Are you sure?</source>
-            <translation>확실합니까?</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1414" />
-            <source>Rescan library for XML info</source>
-            <translation>XML 정보로 라이브러리 재검색</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1423" />
-            <source>Set as read</source>
-            <translation>읽음으로 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1426" />
-            <location filename="library_window.cpp" line="1567" />
-            <source>Set as unread</source>
-            <translation>읽지 않음으로 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="548" />
-            <location filename="library_window.cpp" line="1313" />
-            <location filename="library_window.cpp" line="1438" />
-            <source>web comic</source>
-            <translation>웹 만화</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1150" />
-            <source>Add new folder</source>
-            <translation>새 폴더 추가</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1186" />
-            <source>Delete folder</source>
-            <translation>폴더 삭제</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1417" />
-            <source>Set as uncompleted</source>
-            <translation>미완료로 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1420" />
-            <source>Set as completed</source>
-            <translation>완료로 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1411" />
-            <source>Update folder</source>
-            <translation>폴더 업데이트</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="652" />
-            <source>Folder</source>
-            <translation>폴더</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="674" />
-            <source>Comic</source>
-            <translation>만화</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="802" />
-            <source>Upgrade failed</source>
-            <translation>업그레이드 실패</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="802" />
-            <source>There were errors during library upgrade in: </source>
-            <translation>라이브러리 업그레이드 중 오류 발생: </translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="831" />
-            <source>Update needed</source>
-            <translation>업데이트 필요</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="831" />
-            <source>This library was created with a previous version of YACReaderLibrary. It needs to be updated. Update now?</source>
-            <translation>이 라이브러리는 YACReaderLibrary의 이전 버전으로 만들어졌습니다. 업데이트가 필요합니다. 지금 업데이트하시겠습니까?</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="898" />
-            <source>Download new version</source>
-            <translation>새 버전 내려받기</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="898" />
-            <source>This library was created with a newer version of YACReaderLibrary. Download the new version now?</source>
-            <translation>이 라이브러리는 YACReaderLibrary의 최신 버전으로 만들어졌습니다. 지금 새 버전을 내려받으시겠습니까?</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="919" />
-            <source>Library not available</source>
-            <translation>라이브러리를 사용할 수 없습니다</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="919" />
-            <source>Library '%1' is no longer available. Do you want to remove it?</source>
-            <translation>'%1' 라이브러리를 더 이상 사용할 수 없습니다. 제거하시겠습니까?</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="938" />
-            <source>Old library</source>
-            <translation>오래된 라이브러리</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="938" />
-            <source>Library '%1' has been created with an older version of YACReaderLibrary. It must be created again. Do you want to create the library now?</source>
-            <translation>'%1' 라이브러리는 이전 버전의 YACReaderLibrary로 만들어졌습니다. 다시 만들어야 합니다. 지금 만드시겠습니까?</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="969" />
-            <location filename="library_window.cpp" line="1005" />
-            <source>Copying comics...</source>
-            <translation>만화 복사 중...</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="986" />
-            <location filename="library_window.cpp" line="1024" />
-            <source>Moving comics...</source>
-            <translation>만화 이동 중...</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1151" />
-            <source>Folder name:</source>
-            <translation>폴더 이름:</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1180" />
-            <source>No folder selected</source>
-            <translation>선택된 폴더 없음</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1180" />
-            <source>Please, select a folder first</source>
-            <translation>먼저 폴더를 선택하세요</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1184" />
-            <source>Error in path</source>
-            <translation>경로 오류</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1184" />
-            <source>There was an error accessing the folder's path</source>
-            <translation>폴더 경로에 접근하는 중 오류가 발생했습니다</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1186" />
-            <source>The selected folder and all its contents will be deleted from your disk. Are you sure?</source>
-            <translation>선택한 폴더와 그 안의 모든 내용이 디스크에서 삭제됩니다. 계속하시겠습니까?</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1212" />
-            <location filename="library_window.cpp" line="2174" />
-            <source>Unable to delete</source>
-            <translation>삭제할 수 없음</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1212" />
-            <source>There was an issue trying to delete the selected folders. Please, check for write permissions and be sure that any applications are using these folders or any of the contained files.</source>
-            <translation>선택한 폴더를 삭제하는 중 문제가 발생했습니다. 쓰기 권한을 확인하고, 다른 응용 프로그램이 이 폴더나 안의 파일을 사용 중인지 확인하세요.</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1224" />
-            <source>Add new reading lists</source>
-            <translation>새 읽기 목록 추가</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1225" />
-            <location filename="library_window.cpp" line="1274" />
-            <source>List name:</source>
-            <translation>목록 이름:</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1243" />
-            <source>Delete list/label</source>
-            <translation>목록/라벨 삭제</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1243" />
-            <source>The selected item will be deleted, your comics or folders will NOT be deleted from your disk. Are you sure?</source>
-            <translation>선택한 항목이 삭제됩니다. 디스크에서 만화나 폴더는 삭제되지 않습니다. 계속하시겠습니까?</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1273" />
-            <source>Rename list name</source>
-            <translation>목록 이름 변경</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="591" />
-            <location filename="library_window.cpp" line="1375" />
-            <location filename="library_window.cpp" line="1489" />
-            <location filename="library_window.cpp" line="2631" />
-            <source>Set type</source>
-            <translation>유형 설정</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1444" />
-            <source>Set custom cover</source>
-            <translation>사용자 지정 표지 설정</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1447" />
-            <source>Delete custom cover</source>
-            <translation>사용자 지정 표지 삭제</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1632" />
-            <source>Save covers</source>
-            <translation>표지 저장</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1651" />
-            <source>You are adding too many libraries.</source>
-            <translation>라이브러리를 너무 많이 추가하고 있습니다.</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1651" />
-            <source>You are adding too many libraries.
+    </message>
+    <message>
+        <location filename="../common/themes/appearance_tab_widget.cpp" line="289"/>
+        <source>Import failed</source>
+        <translation>가져오기 실패</translation>
+    </message>
+</context>
+<context>
+    <name>ClassicComicsView</name>
+    <message>
+        <location filename="classic_comics_view.cpp" line="92"/>
+        <source>Hide comic flow</source>
+        <translation>만화 흐름 숨기기</translation>
+    </message>
+</context>
+<context>
+    <name>ComicInfoView</name>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="302"/>
+        <source>Characters</source>
+        <translation>등장인물</translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="334"/>
+        <source>Main character or team</source>
+        <translation>주요 등장인물 또는 팀</translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="359"/>
+        <source>Teams</source>
+        <translation>팀</translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="393"/>
+        <source>Locations</source>
+        <translation>장소</translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="425"/>
+        <source>Authors</source>
+        <translation>작가진</translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="457"/>
+        <source>writer</source>
+        <translation>글</translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="479"/>
+        <source>penciller</source>
+        <translation>밑그림</translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="501"/>
+        <source>inker</source>
+        <translation>펜선</translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="523"/>
+        <source>colorist</source>
+        <translation>채색</translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="545"/>
+        <source>letterer</source>
+        <translation>식자</translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="567"/>
+        <source>cover artist</source>
+        <translation>표지 그림</translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="589"/>
+        <source>editor</source>
+        <translation>편집</translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="611"/>
+        <source>imprint</source>
+        <translation>출판 브랜드</translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="626"/>
+        <source>Publisher</source>
+        <translation>출판사</translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="678"/>
+        <source>color</source>
+        <translation>컬러</translation>
+    </message>
+    <message>
+        <location filename="qml/ComicInfoView.qml" line="678"/>
+        <source>b/w</source>
+        <translation>흑백</translation>
+    </message>
+</context>
+<context>
+    <name>ComicModel</name>
+    <message>
+        <location filename="db/comic_model.cpp" line="375"/>
+        <source>yes</source>
+        <translation>예</translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="375"/>
+        <source>no</source>
+        <translation>아니오</translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="406"/>
+        <source>Title</source>
+        <translation>제목</translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="408"/>
+        <source>File Name</source>
+        <translation>파일 이름</translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="410"/>
+        <source>Pages</source>
+        <translation>페이지</translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="412"/>
+        <source>Size</source>
+        <translation>크기</translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="414"/>
+        <source>Read</source>
+        <translation>읽음</translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="416"/>
+        <source>Current Page</source>
+        <translation>현재 페이지</translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="418"/>
+        <source>Publication Date</source>
+        <translation>출판일</translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="420"/>
+        <source>Rating</source>
+        <translation>평점</translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="422"/>
+        <source>Series</source>
+        <translation>시리즈</translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="424"/>
+        <source>Volume</source>
+        <translation>볼륨</translation>
+    </message>
+    <message>
+        <location filename="db/comic_model.cpp" line="426"/>
+        <source>Story Arc</source>
+        <translation>스토리 아크</translation>
+    </message>
+</context>
+<context>
+    <name>ComicVineDialog</name>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="55"/>
+        <source>skip</source>
+        <translation>건너뛰기</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="56"/>
+        <source>back</source>
+        <translation>뒤로</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="57"/>
+        <source>next</source>
+        <translation>다음</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="58"/>
+        <source>search</source>
+        <translation>검색</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="59"/>
+        <source>close</source>
+        <translation>닫기</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="135"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="589"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="628"/>
+        <source>Looking for volume...</source>
+        <translation>볼륨 검색 중...</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="133"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="547"/>
+        <source>comic %1 of %2 - %3</source>
+        <translation>%1 / %2 만화 - %3</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="250"/>
+        <source>%1 comics selected</source>
+        <translation>만화 %1개 선택됨</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="281"/>
+        <source>Error connecting to ComicVine</source>
+        <translation>Comic Vine 연결 오류</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="461"/>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="487"/>
+        <source>Retrieving tags for : %1</source>
+        <translation>태그 가져오는 중 : %1</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="608"/>
+        <source>Retrieving volume info...</source>
+        <translation>볼륨 정보 가져오는 중...</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/comic_vine_dialog.cpp" line="640"/>
+        <source>Looking for comic...</source>
+        <translation>만화 검색 중...</translation>
+    </message>
+</context>
+<context>
+    <name>CreateLibraryDialog</name>
+    <message>
+        <location filename="create_library_dialog.cpp" line="77"/>
+        <source>Create new library</source>
+        <translation>새 라이브러리 만들기</translation>
+    </message>
+    <message>
+        <location filename="create_library_dialog.cpp" line="35"/>
+        <source>Cancel</source>
+        <translation>취소</translation>
+    </message>
+    <message>
+        <location filename="create_library_dialog.cpp" line="31"/>
+        <source>Create</source>
+        <translation>만들기</translation>
+    </message>
+    <message>
+        <location filename="create_library_dialog.cpp" line="21"/>
+        <source>Comics folder : </source>
+        <translation>만화 폴더: </translation>
+    </message>
+    <message>
+        <location filename="create_library_dialog.cpp" line="26"/>
+        <source>Library Name : </source>
+        <translation>라이브러리 이름: </translation>
+    </message>
+    <message>
+        <location filename="create_library_dialog.cpp" line="57"/>
+        <source>Create a library could take several minutes. You can stop the process and update the library later for completing the task.</source>
+        <translation>라이브러리 생성은 몇 분 걸릴 수 있습니다. 작업을 중지하고 나중에 라이브러리를 업데이트하여 완료할 수 있습니다.</translation>
+    </message>
+    <message>
+        <location filename="create_library_dialog.cpp" line="105"/>
+        <source>Path not found</source>
+        <translation>경로를 찾을 수 없음</translation>
+    </message>
+    <message>
+        <location filename="create_library_dialog.cpp" line="105"/>
+        <source>The selected path does not exist or is not a valid path. Be sure that you have write access to this folder</source>
+        <translation>선택한 경로가 존재하지 않거나 올바르지 않습니다. 이 폴더에 쓰기 권한이 있는지 확인하세요</translation>
+    </message>
+</context>
+<context>
+    <name>EditShortcutsDialog</name>
+    <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="19"/>
+        <source>Restore defaults</source>
+        <translation>기본값으로 복원</translation>
+    </message>
+    <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="20"/>
+        <source>To change a shortcut, double click in the key combination and type the new keys.</source>
+        <translation>단축키를 바꾸려면 키 조합을 더블 클릭하고 새 키를 입력하세요.</translation>
+    </message>
+    <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="67"/>
+        <source>Shortcuts settings</source>
+        <translation>단축키 설정</translation>
+    </message>
+    <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="118"/>
+        <source>Shortcut in use</source>
+        <translation>사용 중인 단축키</translation>
+    </message>
+    <message>
+        <location filename="../shortcuts_management/edit_shortcuts_dialog.cpp" line="118"/>
+        <source>The shortcut &quot;%1&quot; is already assigned to other function</source>
+        <translation>&quot;%1&quot; 단축키는 이미 다른 기능이 사용 중입니다</translation>
+    </message>
+</context>
+<context>
+    <name>EmptyFolderWidget</name>
+    <message>
+        <location filename="empty_folder_widget.cpp" line="8"/>
+        <source>This folder doesn&apos;t contain comics yet</source>
+        <translation>이 폴더에는 아직 만화가 없습니다</translation>
+    </message>
+</context>
+<context>
+    <name>EmptyLabelWidget</name>
+    <message>
+        <location filename="empty_label_widget.cpp" line="7"/>
+        <source>This label doesn&apos;t contain comics yet</source>
+        <translation>이 라벨에 아직 만화가 없습니다</translation>
+    </message>
+</context>
+<context>
+    <name>EmptyReadingListWidget</name>
+    <message>
+        <location filename="empty_reading_list_widget.cpp" line="8"/>
+        <source>This reading list does not contain any comics yet</source>
+        <translation>이 읽기 목록에 아직 만화가 없습니다</translation>
+    </message>
+</context>
+<context>
+    <name>EmptySpecialListWidget</name>
+    <message>
+        <location filename="empty_special_list.cpp" line="13"/>
+        <source>No favorites</source>
+        <translation>즐겨찾기 없음</translation>
+    </message>
+    <message>
+        <location filename="empty_special_list.cpp" line="20"/>
+        <source>You are not reading anything yet, come on!!</source>
+        <translation>아직 읽고 있는 만화가 없습니다. 지금 시작해보세요!!</translation>
+    </message>
+    <message>
+        <location filename="empty_special_list.cpp" line="27"/>
+        <source>There are no recent comics!</source>
+        <translation>최근 본 만화가 없습니다!</translation>
+    </message>
+</context>
+<context>
+    <name>ExportComicsInfoDialog</name>
+    <message>
+        <location filename="export_comics_info_dialog.cpp" line="22"/>
+        <source>Cancel</source>
+        <translation>취소</translation>
+    </message>
+    <message>
+        <location filename="export_comics_info_dialog.cpp" line="18"/>
+        <source>Create</source>
+        <translation>생성</translation>
+    </message>
+    <message>
+        <location filename="export_comics_info_dialog.cpp" line="14"/>
+        <source>Output file : </source>
+        <translation>출력 파일: </translation>
+    </message>
+    <message>
+        <location filename="export_comics_info_dialog.cpp" line="55"/>
+        <source>Export comics info</source>
+        <translation>만화 정보 내보내기</translation>
+    </message>
+    <message>
+        <location filename="export_comics_info_dialog.cpp" line="72"/>
+        <source>Destination database name</source>
+        <translation>대상 데이터베이스 이름</translation>
+    </message>
+    <message>
+        <location filename="export_comics_info_dialog.cpp" line="87"/>
+        <source>Problem found while writing</source>
+        <translation>쓰기 중 문제 발생</translation>
+    </message>
+    <message>
+        <location filename="export_comics_info_dialog.cpp" line="87"/>
+        <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
+        <translation>출력 파일에 선택한 경로가 존재하지 않거나 올바르지 않습니다. 이 폴더에 쓰기 권한이 있는지 확인하세요</translation>
+    </message>
+</context>
+<context>
+    <name>ExportLibraryDialog</name>
+    <message>
+        <location filename="export_library_dialog.cpp" line="20"/>
+        <source>Cancel</source>
+        <translation>취소</translation>
+    </message>
+    <message>
+        <location filename="export_library_dialog.cpp" line="16"/>
+        <source>Create</source>
+        <translation>생성</translation>
+    </message>
+    <message>
+        <location filename="export_library_dialog.cpp" line="12"/>
+        <source>Output folder : </source>
+        <translation>출력 폴더: </translation>
+    </message>
+    <message>
+        <location filename="export_library_dialog.cpp" line="59"/>
+        <source>Create covers package</source>
+        <translation>표지 패키지 생성</translation>
+    </message>
+    <message>
+        <location filename="export_library_dialog.cpp" line="83"/>
+        <source>Destination directory</source>
+        <translation>대상 폴더</translation>
+    </message>
+    <message>
+        <location filename="export_library_dialog.cpp" line="78"/>
+        <source>Problem found while writing</source>
+        <translation>쓰기 중 문제 발생</translation>
+    </message>
+    <message>
+        <location filename="export_library_dialog.cpp" line="78"/>
+        <source>The selected path for the output file does not exist or is not a valid path. Be sure that you have write access to this folder</source>
+        <translation>출력 파일에 선택한 경로가 존재하지 않거나 올바르지 않습니다. 이 폴더에 쓰기 권한이 있는지 확인하세요</translation>
+    </message>
+</context>
+<context>
+    <name>FileComic</name>
+    <message>
+        <location filename="../common/comic.cpp" line="564"/>
+        <source>7z not found</source>
+        <translation>7z를 찾을 수 없습니다</translation>
+    </message>
+    <message>
+        <location filename="../common/comic.cpp" line="456"/>
+        <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
+        <translation>%1번 페이지에서 CRC 오류 발생: 일부 페이지가 올바르게 표시되지 않을 수 있습니다</translation>
+    </message>
+    <message>
+        <location filename="../common/comic.cpp" line="463"/>
+        <source>Unknown error opening the file</source>
+        <translation>파일을 여는 중 알 수 없는 오류가 발생했습니다</translation>
+    </message>
+    <message>
+        <location filename="../common/comic.cpp" line="570"/>
+        <source>Format not supported</source>
+        <translation>지원하지 않는 형식입니다</translation>
+    </message>
+</context>
+<context>
+    <name>FolderContentView</name>
+    <message>
+        <location filename="qml/FolderContentView.qml" line="223"/>
+        <source>Continue Reading...</source>
+        <translation>이어 읽기...</translation>
+    </message>
+</context>
+<context>
+    <name>GridComicsView</name>
+    <message>
+        <location filename="grid_comics_view.cpp" line="72"/>
+        <source>Show info</source>
+        <translation>정보 보기</translation>
+    </message>
+</context>
+<context>
+    <name>HelpAboutDialog</name>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="22"/>
+        <source>About</source>
+        <translation>정보</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="25"/>
+        <source>Help</source>
+        <translation>도움말</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/help_about_dialog.cpp" line="28"/>
+        <source>System info</source>
+        <translation>시스템 정보</translation>
+    </message>
+</context>
+<context>
+    <name>ImportComicsInfoDialog</name>
+    <message>
+        <location filename="import_comics_info_dialog.cpp" line="24"/>
+        <source>Cancel</source>
+        <translation>취소</translation>
+    </message>
+    <message>
+        <location filename="import_comics_info_dialog.cpp" line="14"/>
+        <source>Import comics info</source>
+        <translation>만화 정보 가져오기</translation>
+    </message>
+    <message>
+        <location filename="import_comics_info_dialog.cpp" line="16"/>
+        <source>Info database location : </source>
+        <translation>정보 데이터베이스 경로: </translation>
+    </message>
+    <message>
+        <location filename="import_comics_info_dialog.cpp" line="20"/>
+        <source>Import</source>
+        <translation>가져오기</translation>
+    </message>
+    <message>
+        <location filename="import_comics_info_dialog.cpp" line="80"/>
+        <source>Comics info file (*.ydb)</source>
+        <translation>만화 정보 파일 (*.ydb)</translation>
+    </message>
+</context>
+<context>
+    <name>ImportLibraryDialog</name>
+    <message>
+        <location filename="import_library_dialog.cpp" line="26"/>
+        <source>Destination folder : </source>
+        <translation>대상 폴더: </translation>
+    </message>
+    <message>
+        <location filename="import_library_dialog.cpp" line="34"/>
+        <source>Cancel</source>
+        <translation>취소</translation>
+    </message>
+    <message>
+        <location filename="import_library_dialog.cpp" line="30"/>
+        <source>Unpack</source>
+        <translation>풀기</translation>
+    </message>
+    <message>
+        <location filename="import_library_dialog.cpp" line="115"/>
+        <source>Compresed library covers (*.clc)</source>
+        <translation>압축된 라이브러리 표지 (*.clc)</translation>
+    </message>
+    <message>
+        <location filename="import_library_dialog.cpp" line="22"/>
+        <source>Package location : </source>
+        <translation>패키지 경로: </translation>
+    </message>
+    <message>
+        <location filename="import_library_dialog.cpp" line="17"/>
+        <source>Library Name : </source>
+        <translation>라이브러리 이름: </translation>
+    </message>
+    <message>
+        <location filename="import_library_dialog.cpp" line="85"/>
+        <source>Extract a catalog</source>
+        <translation>카탈로그 추출</translation>
+    </message>
+</context>
+<context>
+    <name>ImportWidget</name>
+    <message>
+        <location filename="import_widget.cpp" line="129"/>
+        <source>stop</source>
+        <translation>중지</translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="169"/>
+        <source>Some of the comics being added...</source>
+        <translation>일부 만화를 추가하는 중...</translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="316"/>
+        <source>Importing comics</source>
+        <translation>만화 가져오는 중</translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="317"/>
+        <source>&lt;p&gt;YACReaderLibrary is now creating a new library.&lt;/p&gt;&lt;p&gt;Create a library could take several minutes. You can stop the process and update the library later for completing the task.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;YACReaderLibrary가 새 라이브러리를 만들고 있습니다.&lt;/p&gt;&lt;p&gt;라이브러리 생성은 몇 분 걸릴 수 있습니다. 작업을 중지하고 나중에 라이브러리를 업데이트하여 작업을 완료할 수 있습니다.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="328"/>
+        <source>Updating the library</source>
+        <translation>라이브러리 업데이트 중</translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="329"/>
+        <source>&lt;p&gt;The current library is being updated. For faster updates, please, update your libraries frequently.&lt;/p&gt;&lt;p&gt;You can stop the process and continue updating this library later.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;현재 라이브러리를 업데이트하고 있습니다. 더 빠른 업데이트를 위해 라이브러리를 자주 업데이트하세요.&lt;/p&gt;&lt;p&gt;작업을 중지하고 나중에 이 라이브러리 업데이트를 계속할 수 있습니다.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="340"/>
+        <source>Upgrading the library</source>
+        <translation>라이브러리 업그레이드 중</translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="341"/>
+        <source>&lt;p&gt;The current library is being upgraded, please wait.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;현재 라이브러리를 업그레이드하고 있습니다. 잠시만 기다려주세요.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="352"/>
+        <source>Scanning the library</source>
+        <translation>라이브러리 스캔 중</translation>
+    </message>
+    <message>
+        <location filename="import_widget.cpp" line="353"/>
+        <source>&lt;p&gt;Current library is being scanned for legacy XML metadata information.&lt;/p&gt;&lt;p&gt;This is only needed once, and only if the library was crated with YACReaderLibrary 9.8.2 or earlier.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;현재 라이브러리에서 레거시 XML 메타데이터 정보를 스캔하고 있습니다.&lt;/p&gt;&lt;p&gt;이 작업은 한 번만 필요하며, 라이브러리가 YACReaderLibrary 9.8.2 또는 이전 버전으로 만들어진 경우에만 해당됩니다.&lt;/p&gt;</translation>
+    </message>
+</context>
+<context>
+    <name>LibraryWindow</name>
+    <message>
+        <location filename="library_window.cpp" line="629"/>
+        <source>Library</source>
+        <translation>라이브러리</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1411"/>
+        <source>Open folder...</source>
+        <translation>폴더 열기...</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="548"/>
+        <location filename="library_window.cpp" line="1313"/>
+        <location filename="library_window.cpp" line="1438"/>
+        <source>western manga (left to right)</source>
+        <translation>서양 만화 (왼쪽 → 오른쪽)</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="554"/>
+        <location filename="library_window.cpp" line="1319"/>
+        <location filename="library_window.cpp" line="1444"/>
+        <source>4koma (top to botom)</source>
+        <oldsource>4koma (top to botom</oldsource>
+        <translation>4컷 (위 → 아래)</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1867"/>
+        <source>Do you want remove </source>
+        <translation>다음을 제거하시겠습니까: </translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="212"/>
+        <source>YACReader Library</source>
+        <translation>YACReader Library</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="545"/>
+        <location filename="library_window.cpp" line="1310"/>
+        <location filename="library_window.cpp" line="1432"/>
+        <source>manga</source>
+        <translation>망가</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="542"/>
+        <location filename="library_window.cpp" line="1307"/>
+        <location filename="library_window.cpp" line="1435"/>
+        <source>comic</source>
+        <translation>만화</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1866"/>
+        <source>Are you sure?</source>
+        <translation>확실합니까?</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1417"/>
+        <source>Rescan library for XML info</source>
+        <translation>XML 정보로 라이브러리 재검색</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1426"/>
+        <source>Set as read</source>
+        <translation>읽음으로 표시</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1429"/>
+        <location filename="library_window.cpp" line="1570"/>
+        <source>Set as unread</source>
+        <translation>읽지 않음으로 표시</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="551"/>
+        <location filename="library_window.cpp" line="1316"/>
+        <location filename="library_window.cpp" line="1441"/>
+        <source>web comic</source>
+        <translation>웹 만화</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1153"/>
+        <source>Add new folder</source>
+        <translation>새 폴더 추가</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1189"/>
+        <source>Delete folder</source>
+        <translation>폴더 삭제</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1420"/>
+        <source>Set as uncompleted</source>
+        <translation>미완료로 표시</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1423"/>
+        <source>Set as completed</source>
+        <translation>완료로 표시</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1414"/>
+        <source>Update folder</source>
+        <translation>폴더 업데이트</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="655"/>
+        <source>Folder</source>
+        <translation>폴더</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="677"/>
+        <source>Comic</source>
+        <translation>만화</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="805"/>
+        <source>Upgrade failed</source>
+        <translation>업그레이드 실패</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="805"/>
+        <source>There were errors during library upgrade in: </source>
+        <translation>라이브러리 업그레이드 중 오류 발생: </translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="834"/>
+        <source>Update needed</source>
+        <translation>업데이트 필요</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="834"/>
+        <source>This library was created with a previous version of YACReaderLibrary. It needs to be updated. Update now?</source>
+        <translation>이 라이브러리는 YACReaderLibrary의 이전 버전으로 만들어졌습니다. 업데이트가 필요합니다. 지금 업데이트하시겠습니까?</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="901"/>
+        <source>Download new version</source>
+        <translation>새 버전 내려받기</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="901"/>
+        <source>This library was created with a newer version of YACReaderLibrary. Download the new version now?</source>
+        <translation>이 라이브러리는 YACReaderLibrary의 최신 버전으로 만들어졌습니다. 지금 새 버전을 내려받으시겠습니까?</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="922"/>
+        <source>Library not available</source>
+        <translation>라이브러리를 사용할 수 없습니다</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="922"/>
+        <source>Library &apos;%1&apos; is no longer available. Do you want to remove it?</source>
+        <translation>&apos;%1&apos; 라이브러리를 더 이상 사용할 수 없습니다. 제거하시겠습니까?</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="941"/>
+        <source>Old library</source>
+        <translation>오래된 라이브러리</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="941"/>
+        <source>Library &apos;%1&apos; has been created with an older version of YACReaderLibrary. It must be created again. Do you want to create the library now?</source>
+        <translation>&apos;%1&apos; 라이브러리는 이전 버전의 YACReaderLibrary로 만들어졌습니다. 다시 만들어야 합니다. 지금 만드시겠습니까?</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="972"/>
+        <location filename="library_window.cpp" line="1008"/>
+        <source>Copying comics...</source>
+        <translation>만화 복사 중...</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="989"/>
+        <location filename="library_window.cpp" line="1027"/>
+        <source>Moving comics...</source>
+        <translation>만화 이동 중...</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1154"/>
+        <source>Folder name:</source>
+        <translation>폴더 이름:</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1183"/>
+        <source>No folder selected</source>
+        <translation>선택된 폴더 없음</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1183"/>
+        <source>Please, select a folder first</source>
+        <translation>먼저 폴더를 선택하세요</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1187"/>
+        <source>Error in path</source>
+        <translation>경로 오류</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1187"/>
+        <source>There was an error accessing the folder&apos;s path</source>
+        <translation>폴더 경로에 접근하는 중 오류가 발생했습니다</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1189"/>
+        <source>The selected folder and all its contents will be deleted from your disk. Are you sure?</source>
+        <translation>선택한 폴더와 그 안의 모든 내용이 디스크에서 삭제됩니다. 계속하시겠습니까?</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1215"/>
+        <location filename="library_window.cpp" line="2136"/>
+        <source>Unable to delete</source>
+        <translation>삭제할 수 없음</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1215"/>
+        <source>There was an issue trying to delete the selected folders. Please, check for write permissions and be sure that any applications are using these folders or any of the contained files.</source>
+        <translation>선택한 폴더를 삭제하는 중 문제가 발생했습니다. 쓰기 권한을 확인하고, 다른 응용 프로그램이 이 폴더나 안의 파일을 사용 중인지 확인하세요.</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1227"/>
+        <source>Add new reading lists</source>
+        <translation>새 읽기 목록 추가</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1228"/>
+        <location filename="library_window.cpp" line="1277"/>
+        <source>List name:</source>
+        <translation>목록 이름:</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1246"/>
+        <source>Delete list/label</source>
+        <translation>목록/라벨 삭제</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1246"/>
+        <source>The selected item will be deleted, your comics or folders will NOT be deleted from your disk. Are you sure?</source>
+        <translation>선택한 항목이 삭제됩니다. 디스크에서 만화나 폴더는 삭제되지 않습니다. 계속하시겠습니까?</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1276"/>
+        <source>Rename list name</source>
+        <translation>목록 이름 변경</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="594"/>
+        <location filename="library_window.cpp" line="1378"/>
+        <location filename="library_window.cpp" line="1492"/>
+        <location filename="library_window.cpp" line="2594"/>
+        <source>Set type</source>
+        <translation>유형 설정</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1447"/>
+        <source>Set custom cover</source>
+        <translation>사용자 지정 표지 설정</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1450"/>
+        <source>Delete custom cover</source>
+        <translation>사용자 지정 표지 삭제</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1635"/>
+        <source>Save covers</source>
+        <translation>표지 저장</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1654"/>
+        <source>You are adding too many libraries.</source>
+        <translation>라이브러리를 너무 많이 추가하고 있습니다.</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1654"/>
+        <source>You are adding too many libraries.
 
 You probably only need one library in your top level comics folder, you can browse any subfolders using the folders section in the left sidebar.
 
 YACReaderLibrary will not stop you from creating more libraries but you should keep the number of libraries low.</source>
-            <translation>라이브러리를 너무 많이 추가하고 있습니다.
+        <translation>라이브러리를 너무 많이 추가하고 있습니다.
 
 최상위 만화 폴더에 라이브러리 하나만 있으면 충분합니다. 좌측 사이드바의 폴더 섹션으로 하위 폴더를 탐색할 수 있습니다.
 
 YACReaderLibrary는 라이브러리를 더 만드는 것을 막지 않지만, 라이브러리 수는 적게 유지하는 것이 좋습니다.</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1711" />
-            <location filename="library_window.cpp" line="1713" />
-            <source>YACReader not found</source>
-            <translation>YACReader를 찾을 수 없음</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1711" />
-            <source>YACReader not found. YACReader should be installed in the same folder as YACReaderLibrary.</source>
-            <translation>YACReader를 찾을 수 없습니다. YACReader는 YACReaderLibrary와 같은 폴더에 설치되어야 합니다.</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1713" />
-            <source>YACReader not found. There might be a problem with your YACReader installation.</source>
-            <translation>YACReader를 찾을 수 없습니다. YACReader 설치에 문제가 있을 수 있습니다.</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1720" />
-            <source>Error</source>
-            <translation>오류</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1720" />
-            <source>Error opening comic with third party reader.</source>
-            <translation>타사 뷰어로 만화를 여는 중 오류가 발생했습니다.</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1807" />
-            <source>Library not found</source>
-            <translation>라이브러리를 찾을 수 없음</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1807" />
-            <source>The selected folder doesn't contain any library.</source>
-            <translation>선택한 폴더에 라이브러리가 없습니다.</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1861" />
-            <source> library?</source>
-            <translation>라이브러리?</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1862" />
-            <source>Remove and delete metadata</source>
-            <translation>제거 및 메타데이터 삭제</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="1932" />
-            <source>Library info</source>
-            <translation>라이브러리 정보</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2174" />
-            <source>There was an issue trying to delete the selected comics. Please, check for write permissions in the selected files or containing folder.</source>
-            <translation>선택한 만화를 삭제하는 중 문제가 발생했습니다. 선택한 파일이나 포함된 폴더의 쓰기 권한을 확인하세요.</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2205" />
-            <source>Assign comics numbers</source>
-            <translation>만화에 번호 부여</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2206" />
-            <source>Assign numbers starting in:</source>
-            <translation>다음 번호부터 부여:</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2306" />
-            <source>Invalid image</source>
-            <translation>잘못된 이미지</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2306" />
-            <source>The selected file is not a valid image.</source>
-            <translation>선택한 파일이 유효한 이미지가 아닙니다.</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2312" />
-            <source>Error saving cover</source>
-            <translation>표지 저장 오류</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2312" />
-            <source>There was an error saving the cover image.</source>
-            <translation>표지 이미지를 저장하는 중 오류가 발생했습니다.</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2451" />
-            <source>Error creating the library</source>
-            <translation>라이브러리 생성 오류</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2456" />
-            <source>Error updating the library</source>
-            <translation>라이브러리 업데이트 오류</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2461" />
-            <source>Error opening the library</source>
-            <translation>라이브러리 열기 오류</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2510" />
-            <source>Delete comics</source>
-            <translation>만화 삭제</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2510" />
-            <source>All the selected comics will be deleted from your disk. Are you sure?</source>
-            <translation>선택한 만화가 모두 디스크에서 삭제됩니다. 확실합니까?</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2547" />
-            <source>Remove comics</source>
-            <translation>만화 제거</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2547" />
-            <source>Comics will only be deleted from the current label/list. Are you sure?</source>
-            <translation>만화가 현재 라벨/목록에서만 삭제됩니다. 확실합니까?</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2649" />
-            <source>Library name already exists</source>
-            <translation>라이브러리 이름 중복</translation>
-        </message>
-        <message>
-            <location filename="library_window.cpp" line="2649" />
-            <source>There is another library with the name '%1'.</source>
-            <translation>'%1' 이름의 라이브러리가 이미 있습니다.</translation>
-        </message>
-    </context>
-    <context>
-        <name>LibraryWindowActions</name>
-        <message>
-            <location filename="library_window_actions.cpp" line="39" />
-            <source>Create a new library</source>
-            <translation>새 라이브러리 만들기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="44" />
-            <source>Open an existing library</source>
-            <translation>기존 라이브러리 열기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="48" />
-            <location filename="library_window_actions.cpp" line="49" />
-            <source>Export comics info</source>
-            <translation>만화 정보 내보내기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="53" />
-            <location filename="library_window_actions.cpp" line="54" />
-            <source>Import comics info</source>
-            <translation>만화 정보 가져오기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="58" />
-            <source>Pack covers</source>
-            <translation>표지 묶기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="59" />
-            <source>Pack the covers of the selected library</source>
-            <translation>선택한 라이브러리의 표지 묶기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="63" />
-            <source>Unpack covers</source>
-            <translation>표지 풀기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="64" />
-            <source>Unpack a catalog</source>
-            <translation>카탈로그 풀기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="68" />
-            <source>Update library</source>
-            <translation>라이브러리 업데이트</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="69" />
-            <source>Update current library</source>
-            <translation>현재 라이브러리 업데이트</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="73" />
-            <source>Rename library</source>
-            <translation>라이브러리 이름 변경</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="74" />
-            <source>Rename current library</source>
-            <translation>현재 라이브러리 이름 변경</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="78" />
-            <source>Remove library</source>
-            <translation>라이브러리 제거</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="79" />
-            <source>Remove current library from your collection</source>
-            <translation>내 컬렉션에서 현재 라이브러리 제거</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="83" />
-            <source>Rescan library for XML info</source>
-            <translation>XML 정보로 라이브러리 재검색</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="84" />
-            <source>Tries to find XML info embedded in comic files. You only need to do this if the library was created with 9.8.2 or earlier versions or if you are using third party software to embed XML info in the files.</source>
-            <translation>만화 파일에 포함된 XML 정보를 찾으려고 시도합니다. 9.8.2 이하 버전으로 만든 라이브러리이거나 타사 소프트웨어로 파일에 XML 정보를 포함한 경우에만 필요합니다.</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="88" />
-            <source>Show library info</source>
-            <translation>라이브러리 정보 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="89" />
-            <source>Show information about the current library</source>
-            <translation>현재 라이브러리에 대한 정보 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="93" />
-            <source>Open current comic</source>
-            <translation>현재 만화 열기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="94" />
-            <source>Open current comic on YACReader</source>
-            <translation>YACReader에서 현재 만화 열기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="98" />
-            <source>Save selected covers to...</source>
-            <translation>선택한 표지 저장...</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="99" />
-            <source>Save covers of the selected comics as JPG files</source>
-            <translation>선택한 만화의 표지를 JPG 파일로 저장</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="103" />
-            <location filename="library_window_actions.cpp" line="224" />
-            <source>Set as read</source>
-            <translation>읽음으로 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="104" />
-            <source>Set comic as read</source>
-            <translation>만화를 읽음으로 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="108" />
-            <location filename="library_window_actions.cpp" line="229" />
-            <source>Set as unread</source>
-            <translation>읽지 않음으로 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="109" />
-            <source>Set comic as unread</source>
-            <translation>만화를 읽지 않음으로 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="113" />
-            <location filename="library_window_actions.cpp" line="244" />
-            <source>manga</source>
-            <translation>망가</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="114" />
-            <source>Set issue as manga</source>
-            <translation>만화를 망가로 설정</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="118" />
-            <location filename="library_window_actions.cpp" line="249" />
-            <source>comic</source>
-            <translation>만화</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="119" />
-            <source>Set issue as normal</source>
-            <translation>만화를 일반으로 설정</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="123" />
-            <source>western manga</source>
-            <translation>서양 만화</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="124" />
-            <source>Set issue as western manga</source>
-            <translation>만화를 서양 만화로 설정</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="129" />
-            <location filename="library_window_actions.cpp" line="259" />
-            <source>web comic</source>
-            <translation>웹 만화</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="130" />
-            <source>Set issue as web comic</source>
-            <translation>만화를 웹 만화로 설정</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="135" />
-            <location filename="library_window_actions.cpp" line="264" />
-            <source>yonkoma</source>
-            <translation>4컷 만화</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="136" />
-            <source>Set issue as yonkoma</source>
-            <translation>만화를 4컷 만화로 설정</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="140" />
-            <source>Show/Hide marks</source>
-            <translation>읽음 마크 표시/숨김</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="141" />
-            <source>Show or hide read marks</source>
-            <translation>읽음 마크를 표시하거나 숨김</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="147" />
-            <source>Show/Hide recent indicator</source>
-            <translation>신규 표시 표시/숨김</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="148" />
-            <source>Show or hide recent indicator</source>
-            <translation>신규 표시를 표시하거나 숨김</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="155" />
-            <location filename="library_window_actions.cpp" line="156" />
-            <source>Fullscreen mode on/off</source>
-            <translation>전체화면 모드 켜기/끄기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="161" />
-            <source>Help, About YACReader</source>
-            <translation>도움말, YACReader 정보</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="165" />
-            <source>Add new folder</source>
-            <translation>새 폴더 추가</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="168" />
-            <source>Add new folder to the current library</source>
-            <translation>현재 라이브러리에 새 폴더 추가</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="170" />
-            <source>Delete folder</source>
-            <translation>폴더 삭제</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="173" />
-            <source>Delete current folder from disk</source>
-            <translation>현재 폴더를 디스크에서 삭제</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="178" />
-            <source>Select root node</source>
-            <translation>루트 노드 선택</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="181" />
-            <source>Expand all nodes</source>
-            <translation>모든 노드 펼치기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="186" />
-            <source>Collapse all nodes</source>
-            <translation>모든 노드 접기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="191" />
-            <source>Show options dialog</source>
-            <translation>환경설정 다이얼로그 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="196" />
-            <source>Show comics server options dialog</source>
-            <translation>만화 서버 환경설정 다이얼로그 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="200" />
-            <location filename="library_window_actions.cpp" line="201" />
-            <source>Change between comics views</source>
-            <translation>만화 보기 전환</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="209" />
-            <source>Open folder...</source>
-            <translation>폴더 열기...</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="214" />
-            <source>Set as uncompleted</source>
-            <translation>미완료로 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="219" />
-            <source>Set as completed</source>
-            <translation>완료로 표시</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="234" />
-            <source>Set custom cover</source>
-            <translation>사용자 지정 표지 설정</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="239" />
-            <source>Delete custom cover</source>
-            <translation>사용자 지정 표지 삭제</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="254" />
-            <source>western manga (left to right)</source>
-            <translation>서양 만화 (왼쪽 → 오른쪽)</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="271" />
-            <source>Open containing folder...</source>
-            <translation>포함된 폴더 열기...</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="276" />
-            <source>Reset comic rating</source>
-            <translation>만화 평점 초기화</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="282" />
-            <source>Select all comics</source>
-            <translation>모든 만화 선택</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="287" />
-            <source>Edit</source>
-            <translation>편집</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="292" />
-            <source>Assign current order to comics</source>
-            <translation>만화에 현재 순서 적용</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="297" />
-            <source>Update cover</source>
-            <translation>표지 업데이트</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="303" />
-            <source>Delete selected comics</source>
-            <translation>선택한 만화 삭제</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="308" />
-            <source>Delete metadata from selected comics</source>
-            <translation>선택한 만화에서 메타데이터 삭제</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="315" />
-            <source>Download tags from Comic Vine</source>
-            <translation>Comic Vine에서 태그 내려받기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="318" />
-            <source>Focus search line</source>
-            <translation>검색창으로 이동</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="324" />
-            <source>Focus comics view</source>
-            <translation>만화 보기로 이동</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="329" />
-            <source>Edit shortcuts</source>
-            <translation>단축키 편집</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="335" />
-            <source>&amp;Quit</source>
-            <translation>끝내기(&amp;Q)</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="342" />
-            <source>Update folder</source>
-            <translation>폴더 업데이트</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="344" />
-            <source>Update current folder</source>
-            <translation>현재 폴더 업데이트</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="348" />
-            <source>Scan legacy XML metadata</source>
-            <translation>레거시 XML 메타데이터 스캔</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="352" />
-            <source>Add new reading list</source>
-            <translation>새 읽기 목록 추가</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="355" />
-            <source>Add a new reading list to the current library</source>
-            <translation>현재 라이브러리에 새 읽기 목록 추가</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="357" />
-            <source>Remove reading list</source>
-            <translation>읽기 목록 제거</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="360" />
-            <source>Remove current reading list from the library</source>
-            <translation>라이브러리에서 현재 읽기 목록 제거</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="362" />
-            <source>Add new label</source>
-            <translation>새 라벨 추가</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="365" />
-            <source>Add a new label to this library</source>
-            <translation>이 라이브러리에 새 라벨 추가</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="367" />
-            <source>Rename selected list</source>
-            <translation>선택한 목록 이름 변경</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="370" />
-            <source>Rename any selected labels or lists</source>
-            <translation>선택한 라벨이나 목록 이름 변경</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="373" />
-            <source>Add to...</source>
-            <translation>추가...</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="375" />
-            <source>Favorites</source>
-            <translation>즐겨찾기</translation>
-        </message>
-        <message>
-            <location filename="library_window_actions.cpp" line="378" />
-            <source>Add selected comics to favorites list</source>
-            <translation>선택한 만화를 즐겨찾기 목록에 추가</translation>
-        </message>
-    </context>
-    <context>
-        <name>LocalComicListModel</name>
-        <message>
-            <location filename="comic_vine/model/local_comic_list_model.cpp" line="72" />
-            <source>file name</source>
-            <translation>파일 이름</translation>
-        </message>
-    </context>
-    <context>
-        <name>NoLibrariesWidget</name>
-        <message>
-            <location filename="no_libraries_widget.cpp" line="20" />
-            <source>You don't have any libraries yet</source>
-            <translation>아직 라이브러리가 없습니다</translation>
-        </message>
-        <message>
-            <location filename="no_libraries_widget.cpp" line="22" />
-            <source>&lt;p&gt;You can create a library in any folder, YACReaderLibrary will import all comics and folders from this folder. If you have created any library in the past you can open them.&lt;/p&gt;&lt;p&gt;Don't forget that you can use YACReader as a stand alone application for reading the comics on your computer.&lt;/p&gt;</source>
-            <translation>&lt;p&gt;아무 폴더에 라이브러리를 만들 수 있고, YACReaderLibrary가 그 폴더의 모든 만화와 하위 폴더를 가져옵니다. 이전에 만든 라이브러리가 있으면 열 수 있습니다.&lt;/p&gt;&lt;p&gt;YACReader는 단독 응용 프로그램으로 컴퓨터의 만화를 보는 데도 쓸 수 있습니다.&lt;/p&gt;</translation>
-        </message>
-        <message>
-            <location filename="no_libraries_widget.cpp" line="26" />
-            <source>create your first library</source>
-            <translation>첫 라이브러리 만들기</translation>
-        </message>
-        <message>
-            <location filename="no_libraries_widget.cpp" line="28" />
-            <source>add an existing one</source>
-            <translation>기존 라이브러리 추가</translation>
-        </message>
-    </context>
-    <context>
-        <name>NoSearchResultsWidget</name>
-        <message>
-            <location filename="no_search_results_widget.cpp" line="9" />
-            <source>No results</source>
-            <translation>결과 없음</translation>
-        </message>
-    </context>
-    <context>
-        <name>OptionsDialog</name>
-        <message>
-            <location filename="options_dialog.cpp" line="169" />
-            <location filename="../YACReader/options_dialog.cpp" line="44" />
-            <source>Language</source>
-            <translation>언어</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="171" />
-            <location filename="../YACReader/options_dialog.cpp" line="46" />
-            <source>Application language</source>
-            <translation>응용 프로그램 언어</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="173" />
-            <location filename="../YACReader/options_dialog.cpp" line="48" />
-            <source>System default</source>
-            <translation>시스템 기본값</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="183" />
-            <source>Tray icon settings (experimental)</source>
-            <translation>트레이 아이콘 설정 (실험적)</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="186" />
-            <source>Close to tray</source>
-            <translation>트레이로 최소화</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="187" />
-            <source>Start into the system tray</source>
-            <translation>시스템 트레이에서 시작</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="205" />
-            <source>Edit Comic Vine API key</source>
-            <translation>Comic Vine API 키 편집</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="208" />
-            <source>Comic Vine API key</source>
-            <translation>Comic Vine API 키</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="213" />
-            <source>ComicInfo.xml legacy support</source>
-            <translation>ComicInfo.xml 레거시 지원</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="215" />
-            <source>Import metadata from ComicInfo.xml when adding new comics</source>
-            <oldsource>Import metada from ComicInfo.xml when adding new comics</oldsource>
-            <translation>새 만화 추가 시 ComicInfo.xml에서 메타데이터 가져오기</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="225" />
-            <source>Consider 'recent' items added or updated since X days ago</source>
-            <translation>X일 전부터 추가되거나 업데이트된 항목을 '최근'으로 간주</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="237" />
-            <source>Third party reader</source>
-            <translation>타사 뷰어</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="239" />
-            <source>Write {comic_file_path} where the path should go in the command</source>
-            <translation>명령어에서 경로가 들어갈 자리에 {comic_file_path}를 입력하세요</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="240" />
-            <location filename="../YACReader/options_dialog.cpp" line="87" />
-            <source>Clear</source>
-            <translation>지우기</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="265" />
-            <source>Update libraries at startup</source>
-            <translation>시작 시 라이브러리 업데이트</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="270" />
-            <source>Try to detect changes automatically</source>
-            <translation>변경 사항 자동 감지 시도</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="275" />
-            <source>Update libraries periodically</source>
-            <translation>라이브러리 주기적으로 업데이트</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="281" />
-            <source>Interval:</source>
-            <translation>간격:</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="283" />
-            <source>30 minutes</source>
-            <translation>30분</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="284" />
-            <source>1 hour</source>
-            <translation>1시간</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="285" />
-            <source>2 hours</source>
-            <translation>2시간</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="286" />
-            <source>4 hours</source>
-            <translation>4시간</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="287" />
-            <source>8 hours</source>
-            <translation>8시간</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="288" />
-            <source>12 hours</source>
-            <translation>12시간</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="289" />
-            <source>daily</source>
-            <translation>매일</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="296" />
-            <source>Update libraries at certain time</source>
-            <translation>특정 시간에 라이브러리 업데이트</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="302" />
-            <source>Time:</source>
-            <translation>시간:</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="329" />
-            <source>WARNING! During library updates writes to the database are disabled!
-Don't schedule updates while you may be using the app actively.
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1714"/>
+        <location filename="library_window.cpp" line="1716"/>
+        <source>YACReader not found</source>
+        <translation>YACReader를 찾을 수 없음</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1714"/>
+        <source>YACReader not found. YACReader should be installed in the same folder as YACReaderLibrary.</source>
+        <translation>YACReader를 찾을 수 없습니다. YACReader는 YACReaderLibrary와 같은 폴더에 설치되어야 합니다.</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1716"/>
+        <source>YACReader not found. There might be a problem with your YACReader installation.</source>
+        <translation>YACReader를 찾을 수 없습니다. YACReader 설치에 문제가 있을 수 있습니다.</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1723"/>
+        <source>Error</source>
+        <translation>오류</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1723"/>
+        <source>Error opening comic with third party reader.</source>
+        <translation>타사 뷰어로 만화를 여는 중 오류가 발생했습니다.</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1810"/>
+        <source>Library not found</source>
+        <translation>라이브러리를 찾을 수 없음</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1810"/>
+        <source>The selected folder doesn&apos;t contain any library.</source>
+        <translation>선택한 폴더에 라이브러리가 없습니다.</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1867"/>
+        <source> library?</source>
+        <translation>라이브러리?</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1870"/>
+        <source>Remove and delete metadata</source>
+        <translation>제거 및 메타데이터 삭제</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="1939"/>
+        <source>Library info</source>
+        <translation>라이브러리 정보</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2136"/>
+        <source>There was an issue trying to delete the selected comics. Please, check for write permissions in the selected files or containing folder.</source>
+        <translation>선택한 만화를 삭제하는 중 문제가 발생했습니다. 선택한 파일이나 포함된 폴더의 쓰기 권한을 확인하세요.</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2167"/>
+        <source>Assign comics numbers</source>
+        <translation>만화에 번호 부여</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2168"/>
+        <source>Assign numbers starting in:</source>
+        <translation>다음 번호부터 부여:</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2268"/>
+        <source>Invalid image</source>
+        <translation>잘못된 이미지</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2268"/>
+        <source>The selected file is not a valid image.</source>
+        <translation>선택한 파일이 유효한 이미지가 아닙니다.</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2274"/>
+        <source>Error saving cover</source>
+        <translation>표지 저장 오류</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2274"/>
+        <source>There was an error saving the cover image.</source>
+        <translation>표지 이미지를 저장하는 중 오류가 발생했습니다.</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2414"/>
+        <source>Error creating the library</source>
+        <translation>라이브러리 생성 오류</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2419"/>
+        <source>Error updating the library</source>
+        <translation>라이브러리 업데이트 오류</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2424"/>
+        <source>Error opening the library</source>
+        <translation>라이브러리 열기 오류</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2473"/>
+        <source>Delete comics</source>
+        <translation>만화 삭제</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2473"/>
+        <source>All the selected comics will be deleted from your disk. Are you sure?</source>
+        <translation>선택한 만화가 모두 디스크에서 삭제됩니다. 확실합니까?</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2510"/>
+        <source>Remove comics</source>
+        <translation>만화 제거</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2510"/>
+        <source>Comics will only be deleted from the current label/list. Are you sure?</source>
+        <translation>만화가 현재 라벨/목록에서만 삭제됩니다. 확실합니까?</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2612"/>
+        <source>Library name already exists</source>
+        <translation>라이브러리 이름 중복</translation>
+    </message>
+    <message>
+        <location filename="library_window.cpp" line="2612"/>
+        <source>There is another library with the name &apos;%1&apos;.</source>
+        <translation>&apos;%1&apos; 이름의 라이브러리가 이미 있습니다.</translation>
+    </message>
+</context>
+<context>
+    <name>LibraryWindowActions</name>
+    <message>
+        <location filename="library_window_actions.cpp" line="37"/>
+        <source>Create a new library</source>
+        <translation>새 라이브러리 만들기</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="42"/>
+        <source>Open an existing library</source>
+        <translation>기존 라이브러리 열기</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="46"/>
+        <location filename="library_window_actions.cpp" line="47"/>
+        <source>Export comics info</source>
+        <translation>만화 정보 내보내기</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="51"/>
+        <location filename="library_window_actions.cpp" line="52"/>
+        <source>Import comics info</source>
+        <translation>만화 정보 가져오기</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="56"/>
+        <source>Pack covers</source>
+        <translation>표지 묶기</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="57"/>
+        <source>Pack the covers of the selected library</source>
+        <translation>선택한 라이브러리의 표지 묶기</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="61"/>
+        <source>Unpack covers</source>
+        <translation>표지 풀기</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="62"/>
+        <source>Unpack a catalog</source>
+        <translation>카탈로그 풀기</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="66"/>
+        <source>Update library</source>
+        <translation>라이브러리 업데이트</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="67"/>
+        <source>Update current library</source>
+        <translation>현재 라이브러리 업데이트</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="71"/>
+        <source>Rename library</source>
+        <translation>라이브러리 이름 변경</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="72"/>
+        <source>Rename current library</source>
+        <translation>현재 라이브러리 이름 변경</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="76"/>
+        <source>Remove library</source>
+        <translation>라이브러리 제거</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="77"/>
+        <source>Remove current library from your collection</source>
+        <translation>내 컬렉션에서 현재 라이브러리 제거</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="81"/>
+        <source>Rescan library for XML info</source>
+        <translation>XML 정보로 라이브러리 재검색</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="82"/>
+        <source>Tries to find XML info embedded in comic files. You only need to do this if the library was created with 9.8.2 or earlier versions or if you are using third party software to embed XML info in the files.</source>
+        <translation>만화 파일에 포함된 XML 정보를 찾으려고 시도합니다. 9.8.2 이하 버전으로 만든 라이브러리이거나 타사 소프트웨어로 파일에 XML 정보를 포함한 경우에만 필요합니다.</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="86"/>
+        <source>Show library info</source>
+        <translation>라이브러리 정보 표시</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="87"/>
+        <source>Show information about the current library</source>
+        <translation>현재 라이브러리에 대한 정보 표시</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="91"/>
+        <source>Open current comic</source>
+        <translation>현재 만화 열기</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="92"/>
+        <source>Open current comic on YACReader</source>
+        <translation>YACReader에서 현재 만화 열기</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="96"/>
+        <source>Save selected covers to...</source>
+        <translation>선택한 표지 저장...</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="97"/>
+        <source>Save covers of the selected comics as JPG files</source>
+        <translation>선택한 만화의 표지를 JPG 파일로 저장</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="101"/>
+        <location filename="library_window_actions.cpp" line="222"/>
+        <source>Set as read</source>
+        <translation>읽음으로 표시</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="102"/>
+        <source>Set comic as read</source>
+        <translation>만화를 읽음으로 표시</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="106"/>
+        <location filename="library_window_actions.cpp" line="227"/>
+        <source>Set as unread</source>
+        <translation>읽지 않음으로 표시</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="107"/>
+        <source>Set comic as unread</source>
+        <translation>만화를 읽지 않음으로 표시</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="111"/>
+        <location filename="library_window_actions.cpp" line="242"/>
+        <source>manga</source>
+        <translation>망가</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="112"/>
+        <source>Set issue as manga</source>
+        <translation>만화를 망가로 설정</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="116"/>
+        <location filename="library_window_actions.cpp" line="247"/>
+        <source>comic</source>
+        <translation>만화</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="117"/>
+        <source>Set issue as normal</source>
+        <translation>만화를 일반으로 설정</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="121"/>
+        <source>western manga</source>
+        <translation>서양 만화</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="122"/>
+        <source>Set issue as western manga</source>
+        <translation>만화를 서양 만화로 설정</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="127"/>
+        <location filename="library_window_actions.cpp" line="257"/>
+        <source>web comic</source>
+        <translation>웹 만화</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="128"/>
+        <source>Set issue as web comic</source>
+        <translation>만화를 웹 만화로 설정</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="133"/>
+        <location filename="library_window_actions.cpp" line="262"/>
+        <source>yonkoma</source>
+        <translation>4컷 만화</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="134"/>
+        <source>Set issue as yonkoma</source>
+        <translation>만화를 4컷 만화로 설정</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="138"/>
+        <source>Show/Hide marks</source>
+        <translation>읽음 마크 표시/숨김</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="139"/>
+        <source>Show or hide read marks</source>
+        <translation>읽음 마크를 표시하거나 숨김</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="145"/>
+        <source>Show/Hide recent indicator</source>
+        <translation>신규 표시 표시/숨김</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="146"/>
+        <source>Show or hide recent indicator</source>
+        <translation>신규 표시를 표시하거나 숨김</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="153"/>
+        <location filename="library_window_actions.cpp" line="154"/>
+        <source>Fullscreen mode on/off</source>
+        <translation>전체화면 모드 켜기/끄기</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="159"/>
+        <source>Help, About YACReader</source>
+        <translation>도움말, YACReader 정보</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="163"/>
+        <source>Add new folder</source>
+        <translation>새 폴더 추가</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="166"/>
+        <source>Add new folder to the current library</source>
+        <translation>현재 라이브러리에 새 폴더 추가</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="168"/>
+        <source>Delete folder</source>
+        <translation>폴더 삭제</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="171"/>
+        <source>Delete current folder from disk</source>
+        <translation>현재 폴더를 디스크에서 삭제</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="176"/>
+        <source>Select root node</source>
+        <translation>루트 노드 선택</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="179"/>
+        <source>Expand all nodes</source>
+        <translation>모든 노드 펼치기</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="184"/>
+        <source>Collapse all nodes</source>
+        <translation>모든 노드 접기</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="189"/>
+        <source>Show options dialog</source>
+        <translation>환경설정 다이얼로그 표시</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="194"/>
+        <source>Show comics server options dialog</source>
+        <translation>만화 서버 환경설정 다이얼로그 표시</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="198"/>
+        <location filename="library_window_actions.cpp" line="199"/>
+        <source>Change between comics views</source>
+        <translation>만화 보기 전환</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="207"/>
+        <source>Open folder...</source>
+        <translation>폴더 열기...</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="212"/>
+        <source>Set as uncompleted</source>
+        <translation>미완료로 표시</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="217"/>
+        <source>Set as completed</source>
+        <translation>완료로 표시</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="232"/>
+        <source>Set custom cover</source>
+        <translation>사용자 지정 표지 설정</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="237"/>
+        <source>Delete custom cover</source>
+        <translation>사용자 지정 표지 삭제</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="252"/>
+        <source>western manga (left to right)</source>
+        <translation>서양 만화 (왼쪽 → 오른쪽)</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="269"/>
+        <source>Open containing folder...</source>
+        <translation>포함된 폴더 열기...</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="274"/>
+        <source>Reset comic rating</source>
+        <translation>만화 평점 초기화</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="280"/>
+        <source>Select all comics</source>
+        <translation>모든 만화 선택</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="285"/>
+        <source>Edit</source>
+        <translation>편집</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="290"/>
+        <source>Assign current order to comics</source>
+        <translation>만화에 현재 순서 적용</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="295"/>
+        <source>Update cover</source>
+        <translation>표지 업데이트</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="301"/>
+        <source>Delete selected comics</source>
+        <translation>선택한 만화 삭제</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="306"/>
+        <source>Delete metadata from selected comics</source>
+        <translation>선택한 만화에서 메타데이터 삭제</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="313"/>
+        <source>Download tags from Comic Vine</source>
+        <translation>Comic Vine에서 태그 내려받기</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="316"/>
+        <source>Focus search line</source>
+        <translation>검색창으로 이동</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="322"/>
+        <source>Focus comics view</source>
+        <translation>만화 보기로 이동</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="327"/>
+        <source>Edit shortcuts</source>
+        <translation>단축키 편집</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="333"/>
+        <source>&amp;Quit</source>
+        <translation>끝내기(&amp;Q)</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="340"/>
+        <source>Update folder</source>
+        <translation>폴더 업데이트</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="342"/>
+        <source>Update current folder</source>
+        <translation>현재 폴더 업데이트</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="346"/>
+        <source>Scan legacy XML metadata</source>
+        <translation>레거시 XML 메타데이터 스캔</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="350"/>
+        <source>Add new reading list</source>
+        <translation>새 읽기 목록 추가</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="353"/>
+        <source>Add a new reading list to the current library</source>
+        <translation>현재 라이브러리에 새 읽기 목록 추가</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="355"/>
+        <source>Remove reading list</source>
+        <translation>읽기 목록 제거</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="358"/>
+        <source>Remove current reading list from the library</source>
+        <translation>라이브러리에서 현재 읽기 목록 제거</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="360"/>
+        <source>Add new label</source>
+        <translation>새 라벨 추가</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="363"/>
+        <source>Add a new label to this library</source>
+        <translation>이 라이브러리에 새 라벨 추가</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="365"/>
+        <source>Rename selected list</source>
+        <translation>선택한 목록 이름 변경</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="368"/>
+        <source>Rename any selected labels or lists</source>
+        <translation>선택한 라벨이나 목록 이름 변경</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="371"/>
+        <source>Add to...</source>
+        <translation>추가...</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="373"/>
+        <source>Favorites</source>
+        <translation>즐겨찾기</translation>
+    </message>
+    <message>
+        <location filename="library_window_actions.cpp" line="376"/>
+        <source>Add selected comics to favorites list</source>
+        <translation>선택한 만화를 즐겨찾기 목록에 추가</translation>
+    </message>
+</context>
+<context>
+    <name>LocalComicListModel</name>
+    <message>
+        <location filename="comic_vine/model/local_comic_list_model.cpp" line="72"/>
+        <source>file name</source>
+        <translation>파일 이름</translation>
+    </message>
+</context>
+<context>
+    <name>NoLibrariesWidget</name>
+    <message>
+        <location filename="no_libraries_widget.cpp" line="18"/>
+        <source>You don&apos;t have any libraries yet</source>
+        <translation>아직 라이브러리가 없습니다</translation>
+    </message>
+    <message>
+        <location filename="no_libraries_widget.cpp" line="20"/>
+        <source>&lt;p&gt;You can create a library in any folder, YACReaderLibrary will import all comics and folders from this folder. If you have created any library in the past you can open them.&lt;/p&gt;&lt;p&gt;Don&apos;t forget that you can use YACReader as a stand alone application for reading the comics on your computer.&lt;/p&gt;</source>
+        <translation>&lt;p&gt;아무 폴더에 라이브러리를 만들 수 있고, YACReaderLibrary가 그 폴더의 모든 만화와 하위 폴더를 가져옵니다. 이전에 만든 라이브러리가 있으면 열 수 있습니다.&lt;/p&gt;&lt;p&gt;YACReader는 단독 응용 프로그램으로 컴퓨터의 만화를 보는 데도 쓸 수 있습니다.&lt;/p&gt;</translation>
+    </message>
+    <message>
+        <location filename="no_libraries_widget.cpp" line="24"/>
+        <source>create your first library</source>
+        <translation>첫 라이브러리 만들기</translation>
+    </message>
+    <message>
+        <location filename="no_libraries_widget.cpp" line="26"/>
+        <source>add an existing one</source>
+        <translation>기존 라이브러리 추가</translation>
+    </message>
+</context>
+<context>
+    <name>NoSearchResultsWidget</name>
+    <message>
+        <location filename="no_search_results_widget.cpp" line="9"/>
+        <source>No results</source>
+        <translation>결과 없음</translation>
+    </message>
+</context>
+<context>
+    <name>OptionsDialog</name>
+    <message>
+        <location filename="options_dialog.cpp" line="175"/>
+        <source>Language</source>
+        <translation>언어</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="177"/>
+        <source>Application language</source>
+        <translation>응용 프로그램 언어</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="179"/>
+        <source>System default</source>
+        <translation>시스템 기본값</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="189"/>
+        <source>Tray icon settings (experimental)</source>
+        <translation>트레이 아이콘 설정 (실험적)</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="192"/>
+        <source>Close to tray</source>
+        <translation>트레이로 최소화</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="193"/>
+        <source>Start into the system tray</source>
+        <translation>시스템 트레이에서 시작</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="211"/>
+        <source>Edit Comic Vine API key</source>
+        <translation>Comic Vine API 키 편집</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="214"/>
+        <source>Comic Vine API key</source>
+        <translation>Comic Vine API 키</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="219"/>
+        <source>ComicInfo.xml legacy support</source>
+        <translation>ComicInfo.xml 레거시 지원</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="221"/>
+        <source>Import metadata from ComicInfo.xml when adding new comics</source>
+        <oldsource>Import metada from ComicInfo.xml when adding new comics</oldsource>
+        <translation>새 만화 추가 시 ComicInfo.xml에서 메타데이터 가져오기</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="231"/>
+        <source>Consider &apos;recent&apos; items added or updated since X days ago</source>
+        <translation>X일 전부터 추가되거나 업데이트된 항목을 &apos;최근&apos;으로 간주</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="243"/>
+        <source>Third party reader</source>
+        <translation>타사 뷰어</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="245"/>
+        <source>Write {comic_file_path} where the path should go in the command</source>
+        <translation>명령어에서 경로가 들어갈 자리에 {comic_file_path}를 입력하세요</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="246"/>
+        <source>Clear</source>
+        <translation>지우기</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="271"/>
+        <source>Update libraries at startup</source>
+        <translation>시작 시 라이브러리 업데이트</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="276"/>
+        <source>Try to detect changes automatically</source>
+        <translation>변경 사항 자동 감지 시도</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="281"/>
+        <source>Update libraries periodically</source>
+        <translation>라이브러리 주기적으로 업데이트</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="287"/>
+        <source>Interval:</source>
+        <translation>간격:</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="289"/>
+        <source>30 minutes</source>
+        <translation>30분</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="290"/>
+        <source>1 hour</source>
+        <translation>1시간</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="291"/>
+        <source>2 hours</source>
+        <translation>2시간</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="292"/>
+        <source>4 hours</source>
+        <translation>4시간</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="293"/>
+        <source>8 hours</source>
+        <translation>8시간</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="294"/>
+        <source>12 hours</source>
+        <translation>12시간</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="295"/>
+        <source>daily</source>
+        <translation>매일</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="302"/>
+        <source>Update libraries at certain time</source>
+        <translation>특정 시간에 라이브러리 업데이트</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="308"/>
+        <source>Time:</source>
+        <translation>시간:</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="335"/>
+        <source>WARNING! During library updates writes to the database are disabled!
+Don&apos;t schedule updates while you may be using the app actively.
 During automatic updates the app will block some of the actions until the update is finished.
 To stop an automatic update tap on the loading indicator next to the Libraries title.</source>
-            <oldsource>WARNING! During library updates writes to the database are disabled!
-Don't schedule updates while you may be using the app actively.
+        <oldsource>WARNING! During library updates writes to the database are disabled!
+Don&apos;t schedule updates while you may be using the app actively.
 To stop an automatic update tap on the loading indicator next to the Libraries title.</oldsource>
-            <translation>주의! 라이브러리를 업데이트하는 동안에는 데이터베이스에 기록할 수 없습니다.
+        <translation>주의! 라이브러리를 업데이트하는 동안에는 데이터베이스에 기록할 수 없습니다.
 앱을 적극적으로 사용 중일 때는 업데이트를 예약하지 마세요.
 자동 업데이트가 진행되는 동안에는 일부 기능이 잠시 차단될 수 있습니다.
 자동 업데이트를 중단하려면 라이브러리 제목 옆에 표시되는 로딩 아이콘을 눌러주세요.</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="337" />
-            <source>Modifications detection</source>
-            <translation>수정 감지</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="339" />
-            <source>Compare the modified date of files when updating a library (not recommended)</source>
-            <translation>라이브러리 업데이트 시 파일 수정 날짜 비교 (권장하지 않음)</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="378" />
-            <source>Enable background image</source>
-            <translation>배경 이미지 사용</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="380" />
-            <source>Opacity level</source>
-            <translation>불투명도</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="385" />
-            <source>Blur level</source>
-            <translation>흐림 정도</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="390" />
-            <source>Use selected comic cover as background</source>
-            <translation>선택한 만화 표지를 배경으로 사용</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="392" />
-            <source>Restore defautls</source>
-            <translation>기본값으로 복원</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="403" />
-            <source>Background</source>
-            <translation>배경</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="406" />
-            <source>Display continue reading banner</source>
-            <translation>이어 읽기 배너 표시</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="407" />
-            <source>Display current comic banner</source>
-            <translation>현재 만화 배너 표시</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="413" />
-            <source>Continue reading</source>
-            <translation>이어 읽기</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="29" />
-            <source>Comic Flow</source>
-            <translation>코믹 플로우</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="28" />
-            <location filename="options_dialog.cpp" line="334" />
-            <source>Libraries</source>
-            <translation>라이브러리</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="30" />
-            <source>Grid view</source>
-            <translation>격자 보기</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="27" />
-            <location filename="../YACReader/options_dialog.cpp" line="253" />
-            <source>General</source>
-            <translation>일반</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="31" />
-            <location filename="../YACReader/options_dialog.cpp" line="256" />
-            <source>Appearance</source>
-            <translation>외관</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="44" />
-            <location filename="../YACReader/options_dialog.cpp" line="271" />
-            <source>Options</source>
-            <translation>환경설정</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="37" />
-            <source>My comics path</source>
-            <translation>내 만화 경로</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="57" />
-            <source>Display</source>
-            <translation>표시</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="59" />
-            <source>Show time in current page information label</source>
-            <translation>현재 페이지 정보 라벨에 시간 표시</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="65" />
-            <source>"Go to flow" size</source>
-            <translation>페이지 흐름 크기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="83" />
-            <source>Background color</source>
-            <translation>배경색</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="86" />
-            <source>Choose</source>
-            <translation>선택</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="95" />
-            <source>Scroll behaviour</source>
-            <translation>스크롤 동작</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="98" />
-            <source>Disable scroll animations and smooth scrolling</source>
-            <translation>스크롤 애니메이션과 부드러운 스크롤 끄기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="99" />
-            <source>Do not turn page using scroll</source>
-            <translation>스크롤로 페이지 넘기지 않기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="100" />
-            <source>Use single scroll step to turn page</source>
-            <translation>한 단계 스크롤로 페이지 넘기기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="108" />
-            <source>Mouse mode</source>
-            <translation>마우스 모드</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="111" />
-            <source>Only Back/Forward buttons can turn pages</source>
-            <translation>뒤로/앞으로 버튼만 페이지 넘김</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="112" />
-            <source>Use the Left/Right buttons to turn pages.</source>
-            <translation>왼쪽/오른쪽 버튼으로 페이지 넘김.</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="113" />
-            <source>Click left or right half of the screen to turn pages.</source>
-            <translation>화면 왼쪽 또는 오른쪽 절반을 클릭하여 페이지 넘김.</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="139" />
-            <source>Quick Navigation Mode</source>
-            <translation>빠른 탐색 모드</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="140" />
-            <source>Disable mouse over activation</source>
-            <translation>마우스 오버 활성화 끄기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="177" />
-            <source>Brightness</source>
-            <translation>밝기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="178" />
-            <source>Contrast</source>
-            <translation>대비</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="179" />
-            <source>Gamma</source>
-            <translation>감마</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="183" />
-            <source>Reset</source>
-            <translation>초기화</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="188" />
-            <source>Image options</source>
-            <translation>이미지 옵션</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="192" />
-            <source>Fit options</source>
-            <translation>맞춤 옵션</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="194" />
-            <source>Enlarge images to fit width/height</source>
-            <translation>작은 그림도 꽉차게 보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="205" />
-            <source>Double Page options</source>
-            <translation>두 페이지 옵션</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="207" />
-            <source>Show covers as single page</source>
-            <translation>표지를 한 장으로 표시</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="218" />
-            <source>Scaling</source>
-            <translation>스케일링</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="220" />
-            <source>Scaling method</source>
-            <translation>스케일링 방법</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="222" />
-            <source>Nearest (fast, low quality)</source>
-            <translation>빠른 모드 (빠름, 저화질)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="223" />
-            <source>Bilinear</source>
-            <translation>보통 모드 (중간 품질)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="224" />
-            <source>Lanczos (better quality)</source>
-            <translation>고화질 모드 (더 좋은 화질)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="254" />
-            <source>Page Flow</source>
-            <translation>페이지 플로우</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="255" />
-            <source>Image adjustment</source>
-            <translation>이미지 조정</translation>
-        </message>
-        <message>
-            <location filename="options_dialog.cpp" line="35" />
-            <location filename="../YACReader/options_dialog.cpp" line="262" />
-            <source>Restart is needed</source>
-            <translation>재시작이 필요합니다</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/options_dialog.cpp" line="285" />
-            <source>Comics directory</source>
-            <translation>만화 폴더</translation>
-        </message>
-    </context>
-    <context>
-        <name>PropertiesDialog</name>
-        <message>
-            <location filename="properties_dialog.cpp" line="88" />
-            <source>General info</source>
-            <translation>일반 정보</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="90" />
-            <source>Authors</source>
-            <translation>작가진</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="91" />
-            <source>Publishing</source>
-            <translation>출판</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="89" />
-            <source>Plot</source>
-            <translation>줄거리</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="92" />
-            <source>Notes</source>
-            <translation>메모</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="101" />
-            <source>Cover page</source>
-            <translation>표지 페이지</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="110" />
-            <source>Load previous page as cover</source>
-            <translation>이전 페이지를 표지로 불러오기</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="114" />
-            <source>Load next page as cover</source>
-            <translation>다음 페이지를 표지로 불러오기</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="119" />
-            <source>Reset cover to the default image</source>
-            <translation>표지를 기본 이미지로 초기화</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="124" />
-            <source>Load custom cover image</source>
-            <translation>사용자 지정 표지 이미지 불러오기</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="168" />
-            <source>Series:</source>
-            <translation>시리즈:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="169" />
-            <source>Title:</source>
-            <translation>제목:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="173" />
-            <location filename="properties_dialog.cpp" line="187" />
-            <location filename="properties_dialog.cpp" line="198" />
-            <source>of:</source>
-            <translation> / </translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="178" />
-            <source>Issue number:</source>
-            <translation>이슈 번호:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="180" />
-            <source>Volume:</source>
-            <translation>볼륨:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="185" />
-            <source>Arc number:</source>
-            <translation>아크 번호:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="191" />
-            <source>Story arc:</source>
-            <translation>스토리 아크:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="196" />
-            <source>alt. number:</source>
-            <translation>대체 번호:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="202" />
-            <source>Alternate series:</source>
-            <translation>대체 시리즈:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="204" />
-            <source>Series Group:</source>
-            <translation>시리즈 그룹:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="206" />
-            <source>Genre:</source>
-            <translation>장르:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="208" />
-            <source>Size:</source>
-            <translation>크기:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="228" />
-            <source>Writer(s):</source>
-            <translation>글:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="231" />
-            <source>Penciller(s):</source>
-            <translation>밑그림:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="238" />
-            <source>Inker(s):</source>
-            <translation>펜선:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="241" />
-            <source>Colorist(s):</source>
-            <translation>채색:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="248" />
-            <source>Letterer(s):</source>
-            <translation>식자:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="251" />
-            <source>Cover Artist(s):</source>
-            <translation>표지 그림:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="258" />
-            <source>Editor(s):</source>
-            <translation>편집:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="261" />
-            <source>Imprint:</source>
-            <translation>임프린트:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="282" />
-            <source>Day:</source>
-            <translation>일:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="286" />
-            <source>Month:</source>
-            <translation>월:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="290" />
-            <source>Year:</source>
-            <translation>연도:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="298" />
-            <source>Publisher:</source>
-            <translation>출판사:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="299" />
-            <source>Format:</source>
-            <translation>형식:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="300" />
-            <source>Color/BW:</source>
-            <translation>컬러/흑백:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="301" />
-            <source>Age rating:</source>
-            <translation>연령 등급:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="302" />
-            <source>Type:</source>
-            <translation>유형:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="303" />
-            <source>Language (ISO):</source>
-            <translation>언어 (ISO):</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="324" />
-            <source>Synopsis:</source>
-            <translation>줄거리:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="331" />
-            <source>Characters:</source>
-            <translation>등장인물:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="334" />
-            <source>Teams:</source>
-            <translation>팀:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="340" />
-            <source>Locations:</source>
-            <translation>장소:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="346" />
-            <source>Main character or team:</source>
-            <translation>주요 등장인물 또는 팀:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="368" />
-            <source>Review:</source>
-            <translation>리뷰:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="369" />
-            <source>Notes:</source>
-            <translation>메모:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="370" />
-            <source>Tags:</source>
-            <translation>태그:</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="468" />
-            <source>Comic Vine link: &lt;a style='color: #FFCB00; text-decoration:none; font-weight:bold;' href="http://www.comicvine.com/comic/4000-%1/"&gt; view &lt;/a&gt;</source>
-            <translation>Comic Vine 링크: &lt;a style='color: #FFCB00; text-decoration:none; font-weight:bold;' href="http://www.comicvine.com/comic/4000-%1/"&gt; 보기 &lt;/a&gt;</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="488" />
-            <source>Not found</source>
-            <translation>찾을 수 없음</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="488" />
-            <source>Comic not found. You should update your library.</source>
-            <translation>만화를 찾을 수 없습니다. 라이브러리를 업데이트하세요.</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="623" />
-            <source>Edit selected comics information</source>
-            <translation>선택한 만화 정보 편집</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="1241" />
-            <source>Invalid cover</source>
-            <translation>잘못된 표지</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="1241" />
-            <source>The image is invalid.</source>
-            <translation>이미지가 유효하지 않습니다.</translation>
-        </message>
-        <message>
-            <location filename="properties_dialog.cpp" line="585" />
-            <source>Edit comic information</source>
-            <translation>만화 정보 편집</translation>
-        </message>
-    </context>
-    <context>
-        <name>QCoreApplication</name>
-        <message>
-            <location filename="../YACReaderLibraryServer/main.cpp" line="82" />
-            <source>
-YACReaderLibraryServer is the headless (no gui) version of YACReaderLibrary.
-
-This appplication supports persistent settings, to set them up edit this file %1
-To learn about the available settings please check the documentation at https://raw.githubusercontent.com/YACReader/yacreader/develop/YACReaderLibraryServer/SETTINGS_README.md</source>
-            <translation>
-YACReaderLibraryServer는 YACReaderLibrary의 헤드리스(GUI 없는) 버전입니다.
-
-이 응용 프로그램은 영구 설정을 지원합니다. 설정을 변경하려면 다음 파일을 편집하세요: %1
-사용 가능한 설정 문서는 다음에서 확인할 수 있습니다: https://raw.githubusercontent.com/YACReader/yacreader/develop/YACReaderLibraryServer/SETTINGS_README.md</translation>
-        </message>
-    </context>
-    <context>
-        <name>QObject</name>
-        <message>
-            <location filename="../common/exit_check.cpp" line="13" />
-            <source>7z lib not found</source>
-            <translation>7z 라이브러리를 찾을 수 없습니다</translation>
-        </message>
-        <message>
-            <location filename="../common/exit_check.cpp" line="13" />
-            <source>unable to load 7z lib from ./utils</source>
-            <translation>./utils에서 7z 라이브러리를 불러올 수 없습니다</translation>
-        </message>
-        <message>
-            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41" />
-            <source>Trace</source>
-            <translation>추적</translation>
-        </message>
-        <message>
-            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43" />
-            <source>Debug</source>
-            <translation>디버그</translation>
-        </message>
-        <message>
-            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45" />
-            <source>Info</source>
-            <translation>정보</translation>
-        </message>
-        <message>
-            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47" />
-            <source>Warning</source>
-            <translation>경고</translation>
-        </message>
-        <message>
-            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49" />
-            <source>Error</source>
-            <translation>오류</translation>
-        </message>
-        <message>
-            <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51" />
-            <source>Fatal</source>
-            <translation>치명적 오류</translation>
-        </message>
-        <message>
-            <location filename="../common/yacreader_global_gui.cpp" line="94" />
-            <source>Select custom cover</source>
-            <translation>사용자 지정 표지 선택</translation>
-        </message>
-        <message>
-            <location filename="../common/yacreader_global_gui.cpp" line="94" />
-            <source>Images (%1)</source>
-            <translation>이미지 (%1)</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_repository.cpp" line="113" />
-            <source>The file could not be read or is not valid JSON.</source>
-            <translation>파일을 읽을 수 없거나 유효한 JSON이 아닙니다.</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_repository.cpp" line="122" />
-            <source>This theme is for %1, not %2.</source>
-            <translation>이 테마는 %2가 아닌 %1용입니다.</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_sidebar.cpp" line="149" />
-            <source>Libraries</source>
-            <translation>라이브러리</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_sidebar.cpp" line="150" />
-            <source>Folders</source>
-            <translation>폴더</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_sidebar.cpp" line="151" />
-            <source>Reading Lists</source>
-            <translation>읽기 목록</translation>
-        </message>
-    </context>
-    <context>
-        <name>RenameLibraryDialog</name>
-        <message>
-            <location filename="rename_library_dialog.cpp" line="49" />
-            <source>Rename current library</source>
-            <translation>현재 라이브러리 이름 변경</translation>
-        </message>
-        <message>
-            <location filename="rename_library_dialog.cpp" line="24" />
-            <source>Cancel</source>
-            <translation>취소</translation>
-        </message>
-        <message>
-            <location filename="rename_library_dialog.cpp" line="20" />
-            <source>Rename</source>
-            <translation>이름 변경</translation>
-        </message>
-        <message>
-            <location filename="rename_library_dialog.cpp" line="15" />
-            <source>New Library Name : </source>
-            <translation>새 라이브러리 이름: </translation>
-        </message>
-    </context>
-    <context>
-        <name>ScraperResultsPaginator</name>
-        <message>
-            <location filename="comic_vine/scraper_results_paginator.cpp" line="19" />
-            <source>Number of volumes found : %1</source>
-            <translation>검색된 볼륨 수 : %1</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/scraper_results_paginator.cpp" line="20" />
-            <location filename="comic_vine/scraper_results_paginator.cpp" line="44" />
-            <source>page %1 of %2</source>
-            <translation>%1 / %2 페이지</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/scraper_results_paginator.cpp" line="43" />
-            <source>Number of %1 found : %2</source>
-            <translation>검색된 %1 수 : %2</translation>
-        </message>
-    </context>
-    <context>
-        <name>SearchSingleComic</name>
-        <message>
-            <location filename="comic_vine/search_single_comic.cpp" line="14" />
-            <source>Please provide some additional information for this comic.</source>
-            <oldsource>Please provide some additional information.</oldsource>
-            <translation>이 만화에 대한 추가 정보를 입력하세요.</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/search_single_comic.cpp" line="18" />
-            <source>Series:</source>
-            <translation>시리즈:</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/search_single_comic.cpp" line="21" />
-            <source>Use exact match search. Disable if you want to find volumes that match some of the words in the name.</source>
-            <translation>정확히 일치 검색을 사용합니다. 이름의 일부 단어와 일치하는 볼륨을 찾으려면 비활성화하세요.</translation>
-        </message>
-    </context>
-    <context>
-        <name>SearchVolume</name>
-        <message>
-            <location filename="comic_vine/search_volume.cpp" line="12" />
-            <source>Please provide some additional information.</source>
-            <translation>추가 정보를 입력하세요.</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/search_volume.cpp" line="14" />
-            <source>Series:</source>
-            <translation>시리즈:</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/search_volume.cpp" line="17" />
-            <source>Use exact match search. Disable if you want to find volumes that match some of the words in the name.</source>
-            <translation>정확히 일치 검색을 사용합니다. 이름의 일부 단어와 일치하는 볼륨을 찾으려면 비활성화하세요.</translation>
-        </message>
-    </context>
-    <context>
-        <name>SelectComic</name>
-        <message>
-            <location filename="comic_vine/select_comic.cpp" line="16" />
-            <source>Please, select the right comic info.</source>
-            <translation>맞는 만화 정보를 선택하세요.</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/select_comic.cpp" line="37" />
-            <source>comics</source>
-            <translation>만화</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/select_comic.cpp" line="106" />
-            <source>loading cover</source>
-            <translation>표지 불러오는 중</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/select_comic.cpp" line="107" />
-            <source>loading description</source>
-            <translation>설명 불러오는 중</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/select_comic.cpp" line="157" />
-            <source>comic description unavailable</source>
-            <translation>만화 설명을 사용할 수 없음</translation>
-        </message>
-    </context>
-    <context>
-        <name>SelectVolume</name>
-        <message>
-            <location filename="comic_vine/select_volume.cpp" line="35" />
-            <source>Please, select the right series for your comic.</source>
-            <translation>만화에 맞는 시리즈를 선택하세요.</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/select_volume.cpp" line="54" />
-            <source>Filter:</source>
-            <translation>필터:</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/select_volume.cpp" line="65" />
-            <source>volumes</source>
-            <translation>볼륨</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/select_volume.cpp" line="148" />
-            <source>Nothing found, clear the filter if any.</source>
-            <translation>검색 결과 없음. 필터가 있으면 초기화하세요.</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/select_volume.cpp" line="154" />
-            <source>loading cover</source>
-            <translation>표지 불러오는 중</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/select_volume.cpp" line="155" />
-            <source>loading description</source>
-            <translation>설명 불러오는 중</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/select_volume.cpp" line="207" />
-            <source>volume description unavailable</source>
-            <translation>볼륨 설명을 사용할 수 없음</translation>
-        </message>
-    </context>
-    <context>
-        <name>SeriesQuestion</name>
-        <message>
-            <location filename="comic_vine/series_question.cpp" line="12" />
-            <source>You are trying to get information for various comics at once, are they part of the same series?</source>
-            <translation>여러 만화의 정보를 한 번에 가져오려고 합니다. 같은 시리즈에 속하는 만화입니까?</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/series_question.cpp" line="13" />
-            <source>yes</source>
-            <translation>예</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/series_question.cpp" line="14" />
-            <source>no</source>
-            <translation>아니오</translation>
-        </message>
-    </context>
-    <context>
-        <name>ServerConfigDialog</name>
-        <message>
-            <location filename="server_config_dialog.cpp" line="27" />
-            <source>set port</source>
-            <translation>포트 설정</translation>
-        </message>
-        <message>
-            <location filename="server_config_dialog.cpp" line="34" />
-            <source>Server connectivity information</source>
-            <translation>서버 연결 정보</translation>
-        </message>
-        <message>
-            <location filename="server_config_dialog.cpp" line="37" />
-            <source>Scan it!</source>
-            <translation>스캔하세요!</translation>
-        </message>
-        <message>
-            <location filename="server_config_dialog.cpp" line="42" />
-            <source>YACReader is available for iOS and Android devices.&lt;br/&gt;Discover it for &lt;a href='https://ios.yacreader.com' style='color:rgb(193, 148, 65)'&gt;iOS&lt;/a&gt; or &lt;a href='https://android.yacreader.com' style='color:rgb(193, 148, 65)'&gt;Android&lt;/a&gt;.</source>
-            <translation>YACReader는 iOS와 Android 기기에서도 사용할 수 있습니다.&lt;br/&gt;&lt;a href='https://ios.yacreader.com' style='color:rgb(193, 148, 65)'&gt;iOS&lt;/a&gt; 또는 &lt;a href='https://android.yacreader.com' style='color:rgb(193, 148, 65)'&gt;Android&lt;/a&gt;에서 확인하세요.</translation>
-        </message>
-        <message>
-            <location filename="server_config_dialog.cpp" line="48" />
-            <source>Choose an IP address</source>
-            <translation>IP 주소 선택</translation>
-        </message>
-        <message>
-            <location filename="server_config_dialog.cpp" line="51" />
-            <source>Port</source>
-            <translation>포트</translation>
-        </message>
-        <message>
-            <location filename="server_config_dialog.cpp" line="83" />
-            <source>enable the server</source>
-            <translation>서버 사용</translation>
-        </message>
-    </context>
-    <context>
-        <name>SortVolumeComics</name>
-        <message>
-            <location filename="comic_vine/sort_volume_comics.cpp" line="59" />
-            <source>Please, sort the list of comics on the left until it matches the comics' information.</source>
-            <translation>왼쪽의 만화 목록을 만화 정보와 일치할 때까지 정렬하세요.</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/sort_volume_comics.cpp" line="61" />
-            <source>sort comics to match comic information</source>
-            <translation>만화 정보에 맞게 정렬</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/sort_volume_comics.cpp" line="98" />
-            <source>issues</source>
-            <translation>이슈</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/sort_volume_comics.cpp" line="126" />
-            <source>remove selected comics</source>
-            <translation>선택한 만화 제거</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/sort_volume_comics.cpp" line="127" />
-            <source>restore all removed comics</source>
-            <translation>제거한 만화 모두 복원</translation>
-        </message>
-    </context>
-    <context>
-        <name>ThemeEditorDialog</name>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="65" />
-            <source>Theme Editor</source>
-            <translation>테마 편집기</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="69" />
-            <source>+</source>
-            <translation>+</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="70" />
-            <source>-</source>
-            <translation>-</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="71" />
-            <source>i</source>
-            <translation>i</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="75" />
-            <source>Expand all</source>
-            <translation>모두 펼치기</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="76" />
-            <source>Collapse all</source>
-            <translation>모두 접기</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="77" />
-            <source>Hold to flash the selected value in the UI (magenta / toggled / 0↔10). Releases restore the original.</source>
-            <translation>누르고 있으면 UI에서 선택한 값이 깜박입니다 (마젠타 / 토글 / 0↔10). 놓으면 원래대로 돌아갑니다.</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="82" />
-            <source>Search…</source>
-            <translation>검색…</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="100" />
-            <source>Light</source>
-            <translation>밝은</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="101" />
-            <source>Dark</source>
-            <translation>어두운</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="104" />
-            <source>ID:</source>
-            <translation>ID:</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="105" />
-            <source>Display name:</source>
-            <translation>표시 이름:</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="106" />
-            <source>Variant:</source>
-            <translation>변형:</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="108" />
-            <source>Theme info</source>
-            <translation>테마 정보</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="129" />
-            <source>Parameter</source>
-            <translation>매개변수</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="129" />
-            <source>Value</source>
-            <translation>값</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="153" />
-            <source>Save and apply</source>
-            <translation>저장 후 적용</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="154" />
-            <source>Export to file...</source>
-            <translation>파일로 내보내기...</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="155" />
-            <source>Load from file...</source>
-            <translation>파일에서 불러오기...</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="156" />
-            <source>Close</source>
-            <translation>닫기</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="213" />
-            <source>Double-click to edit color</source>
-            <translation>두 번 클릭하여 색 편집</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="215" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="267" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="268" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="462" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="467" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="498" />
-            <source>true</source>
-            <translation>true</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="215" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="268" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="467" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="498" />
-            <source>false</source>
-            <translation>false</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="218" />
-            <source>Double-click to toggle</source>
-            <translation>두 번 클릭하여 전환</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="222" />
-            <source>Double-click to edit value</source>
-            <translation>두 번 클릭하여 값 편집</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="236" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="283" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="288" />
-            <source>Edit: %1</source>
-            <translation>편집: %1</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="402" />
-            <source>Save theme</source>
-            <translation>테마 저장</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="402" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="417" />
-            <source>JSON files (*.json);;All files (*)</source>
-            <translation>JSON 파일 (*.json);;모든 파일 (*)</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="408" />
-            <source>Save failed</source>
-            <translation>저장 실패</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="408" />
-            <source>Could not open file for writing:
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="343"/>
+        <source>Modifications detection</source>
+        <translation>수정 감지</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="345"/>
+        <source>Compare the modified date of files when updating a library (not recommended)</source>
+        <translation>라이브러리 업데이트 시 파일 수정 날짜 비교 (권장하지 않음)</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="384"/>
+        <source>Enable background image</source>
+        <translation>배경 이미지 사용</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="386"/>
+        <source>Opacity level</source>
+        <translation>불투명도</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="391"/>
+        <source>Blur level</source>
+        <translation>흐림 정도</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="396"/>
+        <source>Use selected comic cover as background</source>
+        <translation>선택한 만화 표지를 배경으로 사용</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="398"/>
+        <source>Restore defautls</source>
+        <translation>기본값으로 복원</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="409"/>
+        <source>Background</source>
+        <translation>배경</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="412"/>
+        <source>Display continue reading banner</source>
+        <translation>이어 읽기 배너 표시</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="413"/>
+        <source>Display current comic banner</source>
+        <translation>현재 만화 배너 표시</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="419"/>
+        <source>Continue reading</source>
+        <translation>이어 읽기</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="35"/>
+        <source>Comic Flow</source>
+        <translation>코믹 플로우</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="34"/>
+        <location filename="options_dialog.cpp" line="340"/>
+        <source>Libraries</source>
+        <translation>라이브러리</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="36"/>
+        <source>Grid view</source>
+        <translation>격자 보기</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="33"/>
+        <source>General</source>
+        <translation>일반</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="37"/>
+        <source>Appearance</source>
+        <translation>외관</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="50"/>
+        <source>Options</source>
+        <translation>환경설정</translation>
+    </message>
+    <message>
+        <location filename="options_dialog.cpp" line="41"/>
+        <source>Restart is needed</source>
+        <translation>재시작이 필요합니다</translation>
+    </message>
+</context>
+<context>
+    <name>PropertiesDialog</name>
+    <message>
+        <location filename="properties_dialog.cpp" line="88"/>
+        <source>General info</source>
+        <translation>일반 정보</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="90"/>
+        <source>Authors</source>
+        <translation>작가진</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="91"/>
+        <source>Publishing</source>
+        <translation>출판</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="89"/>
+        <source>Plot</source>
+        <translation>줄거리</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="92"/>
+        <source>Notes</source>
+        <translation>메모</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="101"/>
+        <source>Cover page</source>
+        <translation>표지 페이지</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="110"/>
+        <source>Load previous page as cover</source>
+        <translation>이전 페이지를 표지로 불러오기</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="114"/>
+        <source>Load next page as cover</source>
+        <translation>다음 페이지를 표지로 불러오기</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="119"/>
+        <source>Reset cover to the default image</source>
+        <translation>표지를 기본 이미지로 초기화</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="124"/>
+        <source>Load custom cover image</source>
+        <translation>사용자 지정 표지 이미지 불러오기</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="168"/>
+        <source>Series:</source>
+        <translation>시리즈:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="169"/>
+        <source>Title:</source>
+        <translation>제목:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="173"/>
+        <location filename="properties_dialog.cpp" line="187"/>
+        <location filename="properties_dialog.cpp" line="198"/>
+        <source>of:</source>
+        <translation> / </translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="178"/>
+        <source>Issue number:</source>
+        <translation>이슈 번호:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="180"/>
+        <source>Volume:</source>
+        <translation>볼륨:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="185"/>
+        <source>Arc number:</source>
+        <translation>아크 번호:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="191"/>
+        <source>Story arc:</source>
+        <translation>스토리 아크:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="196"/>
+        <source>alt. number:</source>
+        <translation>대체 번호:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="202"/>
+        <source>Alternate series:</source>
+        <translation>대체 시리즈:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="204"/>
+        <source>Series Group:</source>
+        <translation>시리즈 그룹:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="206"/>
+        <source>Genre:</source>
+        <translation>장르:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="208"/>
+        <source>Size:</source>
+        <translation>크기:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="228"/>
+        <source>Writer(s):</source>
+        <translation>글:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="231"/>
+        <source>Penciller(s):</source>
+        <translation>밑그림:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="238"/>
+        <source>Inker(s):</source>
+        <translation>펜선:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="241"/>
+        <source>Colorist(s):</source>
+        <translation>채색:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="248"/>
+        <source>Letterer(s):</source>
+        <translation>식자:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="251"/>
+        <source>Cover Artist(s):</source>
+        <translation>표지 그림:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="258"/>
+        <source>Editor(s):</source>
+        <translation>편집:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="261"/>
+        <source>Imprint:</source>
+        <translation>임프린트:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="282"/>
+        <source>Day:</source>
+        <translation>일:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="286"/>
+        <source>Month:</source>
+        <translation>월:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="290"/>
+        <source>Year:</source>
+        <translation>연도:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="298"/>
+        <source>Publisher:</source>
+        <translation>출판사:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="299"/>
+        <source>Format:</source>
+        <translation>형식:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="300"/>
+        <source>Color/BW:</source>
+        <translation>컬러/흑백:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="301"/>
+        <source>Age rating:</source>
+        <translation>연령 등급:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="302"/>
+        <source>Type:</source>
+        <translation>유형:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="303"/>
+        <source>Language (ISO):</source>
+        <translation>언어 (ISO):</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="324"/>
+        <source>Synopsis:</source>
+        <translation>줄거리:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="331"/>
+        <source>Characters:</source>
+        <translation>등장인물:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="334"/>
+        <source>Teams:</source>
+        <translation>팀:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="340"/>
+        <source>Locations:</source>
+        <translation>장소:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="346"/>
+        <source>Main character or team:</source>
+        <translation>주요 등장인물 또는 팀:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="368"/>
+        <source>Review:</source>
+        <translation>리뷰:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="369"/>
+        <source>Notes:</source>
+        <translation>메모:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="370"/>
+        <source>Tags:</source>
+        <translation>태그:</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="467"/>
+        <source>Comic Vine link: &lt;a style=&apos;color: #FFCB00; text-decoration:none; font-weight:bold;&apos; href=&quot;http://www.comicvine.com/comic/4000-%1/&quot;&gt; view &lt;/a&gt;</source>
+        <translation>Comic Vine 링크: &lt;a style=&apos;color: #FFCB00; text-decoration:none; font-weight:bold;&apos; href=&quot;http://www.comicvine.com/comic/4000-%1/&quot;&gt; 보기 &lt;/a&gt;</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="487"/>
+        <source>Not found</source>
+        <translation>찾을 수 없음</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="487"/>
+        <source>Comic not found. You should update your library.</source>
+        <translation>만화를 찾을 수 없습니다. 라이브러리를 업데이트하세요.</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="593"/>
+        <source>Edit selected comics information</source>
+        <translation>선택한 만화 정보 편집</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="1211"/>
+        <source>Invalid cover</source>
+        <translation>잘못된 표지</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="1211"/>
+        <source>The image is invalid.</source>
+        <translation>이미지가 유효하지 않습니다.</translation>
+    </message>
+    <message>
+        <location filename="properties_dialog.cpp" line="555"/>
+        <source>Edit comic information</source>
+        <translation>만화 정보 편집</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
+        <source>7z lib not found</source>
+        <translation>7z 라이브러리를 찾을 수 없습니다</translation>
+    </message>
+    <message>
+        <location filename="../common/exit_check.cpp" line="13"/>
+        <source>unable to load 7z lib from ./utils</source>
+        <translation>./utils에서 7z 라이브러리를 불러올 수 없습니다</translation>
+    </message>
+    <message>
+        <location filename="../common/yacreader_global_gui.cpp" line="94"/>
+        <source>Select custom cover</source>
+        <translation>사용자 지정 표지 선택</translation>
+    </message>
+    <message>
+        <location filename="../common/yacreader_global_gui.cpp" line="94"/>
+        <source>Images (%1)</source>
+        <translation>이미지 (%1)</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_repository.cpp" line="151"/>
+        <source>The file could not be read or is not valid JSON.</source>
+        <translation>파일을 읽을 수 없거나 유효한 JSON이 아닙니다.</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_repository.cpp" line="160"/>
+        <source>This theme is for %1, not %2.</source>
+        <translation>이 테마는 %2가 아닌 %1용입니다.</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="147"/>
+        <source>Libraries</source>
+        <translation>라이브러리</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="148"/>
+        <source>Folders</source>
+        <translation>폴더</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_sidebar.cpp" line="149"/>
+        <source>Reading Lists</source>
+        <translation>읽기 목록</translation>
+    </message>
+</context>
+<context>
+    <name>RenameLibraryDialog</name>
+    <message>
+        <location filename="rename_library_dialog.cpp" line="49"/>
+        <source>Rename current library</source>
+        <translation>현재 라이브러리 이름 변경</translation>
+    </message>
+    <message>
+        <location filename="rename_library_dialog.cpp" line="24"/>
+        <source>Cancel</source>
+        <translation>취소</translation>
+    </message>
+    <message>
+        <location filename="rename_library_dialog.cpp" line="20"/>
+        <source>Rename</source>
+        <translation>이름 변경</translation>
+    </message>
+    <message>
+        <location filename="rename_library_dialog.cpp" line="15"/>
+        <source>New Library Name : </source>
+        <translation>새 라이브러리 이름: </translation>
+    </message>
+</context>
+<context>
+    <name>ScraperResultsPaginator</name>
+    <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="20"/>
+        <source>Number of volumes found : %1</source>
+        <translation>검색된 볼륨 수 : %1</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="21"/>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="45"/>
+        <source>page %1 of %2</source>
+        <translation>%1 / %2 페이지</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/scraper_results_paginator.cpp" line="44"/>
+        <source>Number of %1 found : %2</source>
+        <translation>검색된 %1 수 : %2</translation>
+    </message>
+</context>
+<context>
+    <name>SearchSingleComic</name>
+    <message>
+        <location filename="comic_vine/search_single_comic.cpp" line="14"/>
+        <source>Please provide some additional information for this comic.</source>
+        <oldsource>Please provide some additional information.</oldsource>
+        <translation>이 만화에 대한 추가 정보를 입력하세요.</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/search_single_comic.cpp" line="18"/>
+        <source>Series:</source>
+        <translation>시리즈:</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/search_single_comic.cpp" line="21"/>
+        <source>Use exact match search. Disable if you want to find volumes that match some of the words in the name.</source>
+        <translation>정확히 일치 검색을 사용합니다. 이름의 일부 단어와 일치하는 볼륨을 찾으려면 비활성화하세요.</translation>
+    </message>
+</context>
+<context>
+    <name>SearchVolume</name>
+    <message>
+        <location filename="comic_vine/search_volume.cpp" line="12"/>
+        <source>Please provide some additional information.</source>
+        <translation>추가 정보를 입력하세요.</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/search_volume.cpp" line="14"/>
+        <source>Series:</source>
+        <translation>시리즈:</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/search_volume.cpp" line="17"/>
+        <source>Use exact match search. Disable if you want to find volumes that match some of the words in the name.</source>
+        <translation>정확히 일치 검색을 사용합니다. 이름의 일부 단어와 일치하는 볼륨을 찾으려면 비활성화하세요.</translation>
+    </message>
+</context>
+<context>
+    <name>SelectComic</name>
+    <message>
+        <location filename="comic_vine/select_comic.cpp" line="16"/>
+        <source>Please, select the right comic info.</source>
+        <translation>맞는 만화 정보를 선택하세요.</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_comic.cpp" line="37"/>
+        <source>comics</source>
+        <translation>만화</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_comic.cpp" line="106"/>
+        <source>loading cover</source>
+        <translation>표지 불러오는 중</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_comic.cpp" line="107"/>
+        <source>loading description</source>
+        <translation>설명 불러오는 중</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_comic.cpp" line="157"/>
+        <source>comic description unavailable</source>
+        <translation>만화 설명을 사용할 수 없음</translation>
+    </message>
+</context>
+<context>
+    <name>SelectVolume</name>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="31"/>
+        <source>Please, select the right series for your comic.</source>
+        <translation>만화에 맞는 시리즈를 선택하세요.</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="50"/>
+        <source>Filter:</source>
+        <translation>필터:</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="61"/>
+        <source>volumes</source>
+        <translation>볼륨</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="144"/>
+        <source>Nothing found, clear the filter if any.</source>
+        <translation>검색 결과 없음. 필터가 있으면 초기화하세요.</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="150"/>
+        <source>loading cover</source>
+        <translation>표지 불러오는 중</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="151"/>
+        <source>loading description</source>
+        <translation>설명 불러오는 중</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/select_volume.cpp" line="203"/>
+        <source>volume description unavailable</source>
+        <translation>볼륨 설명을 사용할 수 없음</translation>
+    </message>
+</context>
+<context>
+    <name>SeriesQuestion</name>
+    <message>
+        <location filename="comic_vine/series_question.cpp" line="12"/>
+        <source>You are trying to get information for various comics at once, are they part of the same series?</source>
+        <translation>여러 만화의 정보를 한 번에 가져오려고 합니다. 같은 시리즈에 속하는 만화입니까?</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/series_question.cpp" line="13"/>
+        <source>yes</source>
+        <translation>예</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/series_question.cpp" line="14"/>
+        <source>no</source>
+        <translation>아니오</translation>
+    </message>
+</context>
+<context>
+    <name>ServerConfigDialog</name>
+    <message>
+        <location filename="server_config_dialog.cpp" line="26"/>
+        <source>set port</source>
+        <translation>포트 설정</translation>
+    </message>
+    <message>
+        <location filename="server_config_dialog.cpp" line="33"/>
+        <source>Server connectivity information</source>
+        <translation>서버 연결 정보</translation>
+    </message>
+    <message>
+        <location filename="server_config_dialog.cpp" line="36"/>
+        <source>Scan it!</source>
+        <translation>스캔하세요!</translation>
+    </message>
+    <message>
+        <location filename="server_config_dialog.cpp" line="41"/>
+        <source>YACReader is available for iOS and Android devices.&lt;br/&gt;Discover it for &lt;a href=&apos;https://ios.yacreader.com&apos; style=&apos;color:rgb(193, 148, 65)&apos;&gt;iOS&lt;/a&gt; or &lt;a href=&apos;https://android.yacreader.com&apos; style=&apos;color:rgb(193, 148, 65)&apos;&gt;Android&lt;/a&gt;.</source>
+        <translation>YACReader는 iOS와 Android 기기에서도 사용할 수 있습니다.&lt;br/&gt;&lt;a href=&apos;https://ios.yacreader.com&apos; style=&apos;color:rgb(193, 148, 65)&apos;&gt;iOS&lt;/a&gt; 또는 &lt;a href=&apos;https://android.yacreader.com&apos; style=&apos;color:rgb(193, 148, 65)&apos;&gt;Android&lt;/a&gt;에서 확인하세요.</translation>
+    </message>
+    <message>
+        <location filename="server_config_dialog.cpp" line="47"/>
+        <source>Choose an IP address</source>
+        <translation>IP 주소 선택</translation>
+    </message>
+    <message>
+        <location filename="server_config_dialog.cpp" line="50"/>
+        <source>Port</source>
+        <translation>포트</translation>
+    </message>
+    <message>
+        <location filename="server_config_dialog.cpp" line="82"/>
+        <source>enable the server</source>
+        <translation>서버 사용</translation>
+    </message>
+</context>
+<context>
+    <name>SortVolumeComics</name>
+    <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="59"/>
+        <source>Please, sort the list of comics on the left until it matches the comics&apos; information.</source>
+        <translation>왼쪽의 만화 목록을 만화 정보와 일치할 때까지 정렬하세요.</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="61"/>
+        <source>sort comics to match comic information</source>
+        <translation>만화 정보에 맞게 정렬</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="98"/>
+        <source>issues</source>
+        <translation>이슈</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="126"/>
+        <source>remove selected comics</source>
+        <translation>선택한 만화 제거</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/sort_volume_comics.cpp" line="127"/>
+        <source>restore all removed comics</source>
+        <translation>제거한 만화 모두 복원</translation>
+    </message>
+</context>
+<context>
+    <name>ThemeEditorDialog</name>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="59"/>
+        <source>Theme Editor</source>
+        <translation>테마 편집기</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="63"/>
+        <source>+</source>
+        <translation>+</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="64"/>
+        <source>-</source>
+        <translation>-</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="65"/>
+        <source>i</source>
+        <translation>i</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="69"/>
+        <source>Expand all</source>
+        <translation>모두 펼치기</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="70"/>
+        <source>Collapse all</source>
+        <translation>모두 접기</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="71"/>
+        <source>Hold to flash the selected value in the UI (magenta / toggled / 0↔10). Releases restore the original.</source>
+        <translation>누르고 있으면 UI에서 선택한 값이 깜박입니다 (마젠타 / 토글 / 0↔10). 놓으면 원래대로 돌아갑니다.</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="76"/>
+        <source>Search…</source>
+        <translation>검색…</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="94"/>
+        <source>Light</source>
+        <translation>밝은</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="95"/>
+        <source>Dark</source>
+        <translation>어두운</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="98"/>
+        <source>ID:</source>
+        <translation>ID:</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="99"/>
+        <source>Display name:</source>
+        <translation>표시 이름:</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="100"/>
+        <source>Variant:</source>
+        <translation>변형:</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="102"/>
+        <source>Theme info</source>
+        <translation>테마 정보</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="125"/>
+        <source>Parameter</source>
+        <translation>매개변수</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="125"/>
+        <source>Value</source>
+        <translation>값</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="149"/>
+        <source>Save and apply</source>
+        <translation>저장 후 적용</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="150"/>
+        <source>Export to file...</source>
+        <translation>파일로 내보내기...</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="151"/>
+        <source>Load from file...</source>
+        <translation>파일에서 불러오기...</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="152"/>
+        <source>Close</source>
+        <translation>닫기</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="209"/>
+        <source>Double-click to edit color</source>
+        <translation>두 번 클릭하여 색 편집</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="211"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="264"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="265"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="459"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="464"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="495"/>
+        <source>true</source>
+        <translation>true</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="211"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="265"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="464"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="495"/>
+        <source>false</source>
+        <translation>false</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="214"/>
+        <source>Double-click to toggle</source>
+        <translation>두 번 클릭하여 전환</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="218"/>
+        <source>Double-click to edit value</source>
+        <translation>두 번 클릭하여 값 편집</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="232"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="280"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="285"/>
+        <source>Edit: %1</source>
+        <translation>편집: %1</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="399"/>
+        <source>Save theme</source>
+        <translation>테마 저장</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="399"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="414"/>
+        <source>JSON files (*.json);;All files (*)</source>
+        <translation>JSON 파일 (*.json);;모든 파일 (*)</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="405"/>
+        <source>Save failed</source>
+        <translation>저장 실패</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="405"/>
+        <source>Could not open file for writing:
 %1</source>
-            <translation>쓰기 위해 파일을 열 수 없습니다:
+        <translation>쓰기 위해 파일을 열 수 없습니다:
 %1</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="417" />
-            <source>Load theme</source>
-            <translation>테마 불러오기</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="423" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="430" />
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="434" />
-            <source>Load failed</source>
-            <translation>불러오기 실패</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="423" />
-            <source>Could not open file:
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="414"/>
+        <source>Load theme</source>
+        <translation>테마 불러오기</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="420"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="427"/>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="431"/>
+        <source>Load failed</source>
+        <translation>불러오기 실패</translation>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="420"/>
+        <source>Could not open file:
 %1</source>
-            <translation>파일을 열 수 없습니다:
+        <translation>파일을 열 수 없습니다:
 %1</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="430" />
-            <source>Invalid JSON:
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="427"/>
+        <source>Invalid JSON:
 %1</source>
-            <translation>잘못된 JSON:
+        <translation>잘못된 JSON:
 %1</translation>
-        </message>
-        <message>
-            <location filename="../common/themes/theme_editor_dialog.cpp" line="434" />
-            <source>Expected a JSON object.</source>
-            <translation>JSON 객체가 필요합니다.</translation>
-        </message>
-    </context>
-    <context>
-        <name>TitleHeader</name>
-        <message>
-            <location filename="comic_vine/title_header.cpp" line="27" />
-            <source>SEARCH</source>
-            <translation>검색</translation>
-        </message>
-    </context>
-    <context>
-        <name>UpdateLibraryDialog</name>
-        <message>
-            <location filename="create_library_dialog.cpp" line="170" />
-            <source>Cancel</source>
-            <translation>취소</translation>
-        </message>
-        <message>
-            <location filename="create_library_dialog.cpp" line="164" />
-            <source>Updating....</source>
-            <translation>업데이트 중...</translation>
-        </message>
-        <message>
-            <location filename="create_library_dialog.cpp" line="189" />
-            <source>Update library</source>
-            <translation>라이브러리 업데이트</translation>
-        </message>
-    </context>
-    <context>
-        <name>Viewer</name>
-        <message>
-            <location filename="../YACReader/viewer.cpp" line="60" />
-            <location filename="../YACReader/viewer.cpp" line="1367" />
-            <source>Press 'O' to open comic.</source>
-            <translation>'O'를 눌러 만화를 열어보세요.</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/viewer.cpp" line="262" />
-            <source>Not found</source>
-            <translation>찾을 수 없음</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/viewer.cpp" line="262" />
-            <source>Comic not found</source>
-            <translation>만화를 찾을 수 없습니다</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/viewer.cpp" line="268" />
-            <source>Error opening comic</source>
-            <translation>만화를 여는 중 오류가 발생했습니다</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/viewer.cpp" line="274" />
-            <source>CRC Error</source>
-            <translation>CRC 오류</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/viewer.cpp" line="1383" />
-            <source>Loading...please wait!</source>
-            <translation>불러오는 중... 잠시 기다려주세요!</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/viewer.cpp" line="1394" />
-            <source>Page not available!</source>
-            <translation>페이지를 불러올 수 없습니다!</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/viewer.cpp" line="1602" />
-            <source>Cover!</source>
-            <translation>표지!</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/viewer.cpp" line="1616" />
-            <source>Last page!</source>
-            <translation>마지막 페이지!</translation>
-        </message>
-    </context>
-    <context>
-        <name>VolumeComicsModel</name>
-        <message>
-            <location filename="comic_vine/model/volume_comics_model.cpp" line="120" />
-            <source>title</source>
-            <translation>제목</translation>
-        </message>
-    </context>
-    <context>
-        <name>VolumesModel</name>
-        <message>
-            <location filename="comic_vine/model/volumes_model.cpp" line="118" />
-            <source>year</source>
-            <translation>연도</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/model/volumes_model.cpp" line="120" />
-            <source>issues</source>
-            <translation>이슈</translation>
-        </message>
-        <message>
-            <location filename="comic_vine/model/volumes_model.cpp" line="122" />
-            <source>publisher</source>
-            <translation>출판사</translation>
-        </message>
-    </context>
-    <context>
-        <name>YACReader3DFlowConfigWidget</name>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="19" />
-            <source>Presets:</source>
-            <translation>프리셋:</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="21" />
-            <source>Classic look</source>
-            <translation>클래식 스타일</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="24" />
-            <source>Stripe look</source>
-            <translation>줄무늬 스타일</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="27" />
-            <source>Overlapped Stripe look</source>
-            <translation>겹친 줄무늬 스타일</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="30" />
-            <source>Modern look</source>
-            <translation>모던 스타일</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="33" />
-            <source>Roulette look</source>
-            <translation>룰렛 스타일</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="77" />
-            <source>Show advanced settings</source>
-            <translation>고급 설정 보기</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="86" />
-            <source>Custom:</source>
-            <translation>사용자 지정:</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="89" />
-            <source>View angle</source>
-            <translation>시야각</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="95" />
-            <source>Position</source>
-            <translation>위치</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="101" />
-            <source>Cover gap</source>
-            <translation>표지 간격</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="107" />
-            <source>Central gap</source>
-            <translation>중앙 간격</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="113" />
-            <source>Zoom</source>
-            <translation>확대/축소</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="119" />
-            <source>Y offset</source>
-            <translation>Y축 오프셋</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="125" />
-            <source>Z offset</source>
-            <translation>Z축 오프셋</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="131" />
-            <source>Cover Angle</source>
-            <translation>표지 각도</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="137" />
-            <source>Visibility</source>
-            <translation>가시성</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="143" />
-            <source>Light</source>
-            <translation>조명</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="149" />
-            <source>Max angle</source>
-            <translation>최대 각도</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="181" />
-            <source>Low Performance</source>
-            <translation>저성능</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="183" />
-            <source>High Performance</source>
-            <translation>고성능</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="194" />
-            <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
-            <translation>수직 동기화 사용 (전체화면 결의 이미지 품질 향상, 성능 저하)</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="202" />
-            <source>Performance:</source>
-            <translation>성능:</translation>
-        </message>
-    </context>
-    <context>
-        <name>YACReader::MainWindowViewer</name>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="190" />
-            <source>&amp;Open</source>
-            <translation>열기(&amp;O)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="191" />
-            <source>Open a comic</source>
-            <translation>만화 열기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="197" />
-            <source>New instance</source>
-            <translation>새 창</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="216" />
-            <source>Open Folder</source>
-            <translation>폴더 열기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="217" />
-            <source>Open image folder</source>
-            <translation>이미지 폴더 열기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="222" />
-            <source>Open latest comic</source>
-            <translation>마지막 만화 열기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="223" />
-            <source>Open the latest comic opened in the previous reading session</source>
-            <translation>이전 작업에서 마지막으로 열었던 만화 열기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="235" />
-            <source>Clear</source>
-            <translation>지우기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="236" />
-            <source>Clear open recent list</source>
-            <translation>최근 목록 지우기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="239" />
-            <source>Save</source>
-            <translation>저장</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="240" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="945" />
-            <source>Save current page</source>
-            <translation>현재 페이지 저장</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="245" />
-            <source>Previous Comic</source>
-            <translation>이전 만화</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="246" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1733" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1737" />
-            <source>Open previous comic</source>
-            <translation>이전 만화 열기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="251" />
-            <source>Next Comic</source>
-            <translation>다음 만화</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="252" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1732" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1738" />
-            <source>Open next comic</source>
-            <translation>다음 만화 열기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="257" />
-            <source>&amp;Previous</source>
-            <translation>이전(&amp;P)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="259" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1735" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1739" />
-            <source>Go to previous page</source>
-            <translation>이전 페이지로 이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="264" />
-            <source>&amp;Next</source>
-            <translation>다음(&amp;N)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="266" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1734" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1740" />
-            <source>Go to next page</source>
-            <translation>다음 페이지로 이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="271" />
-            <source>Fit Height</source>
-            <translation>꽉차게 보기 (높이 맞춤)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="272" />
-            <source>Fit image to height</source>
-            <translation>이미지를 높이에 맞춤</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="278" />
-            <source>Fit Width</source>
-            <translation>꽉차게 보기 (폭 맞춤)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="279" />
-            <source>Fit image to width</source>
-            <translation>이미지를 폭에 맞춤</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="285" />
-            <source>Show full size</source>
-            <translation>원본 크기 (100%)로 보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="292" />
-            <source>Fit to page</source>
-            <translation>꽉차게 보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="298" />
-            <source>Continuous scroll</source>
-            <translation>연속 스크롤</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="299" />
-            <source>Switch to continuous scroll mode</source>
-            <translation>연속 스크롤 모드로 전환</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="331" />
-            <source>Reset zoom</source>
-            <translation>확대/축소 초기화</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="336" />
-            <source>Show zoom slider</source>
-            <translation>확대/축소 슬라이더 보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="338" />
-            <source>Zoom+</source>
-            <translation>확대+</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="343" />
-            <source>Zoom-</source>
-            <translation>축소-</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="348" />
-            <source>Rotate image to the left</source>
-            <translation>이미지 왼쪽으로 회전</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="353" />
-            <source>Rotate image to the right</source>
-            <translation>이미지 오른쪽으로 회전</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="358" />
-            <source>Double page mode</source>
-            <translation>두 페이지씩 보기 (왼쪽 → 오른쪽)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="359" />
-            <source>Switch to double page mode</source>
-            <translation>두 페이지씩 보기로 전환</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="367" />
-            <source>Double page manga mode</source>
-            <translation>두 페이지씩 보기 (왼쪽 ← 오른쪽)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="368" />
-            <source>Reverse reading order in double page mode</source>
-            <translation>두 페이지씩 보기에서 읽기 순서 뒤집기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="376" />
-            <source>Go To</source>
-            <translation>이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="377" />
-            <source>Go to page ...</source>
-            <translation>페이지로 이동...</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="382" />
-            <source>Options</source>
-            <translation>환경설정</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="383" />
-            <source>YACReader options</source>
-            <translation>YACReader 환경설정</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="389" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="684" />
-            <source>Help</source>
-            <translation>도움말</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="390" />
-            <source>Help, About YACReader</source>
-            <translation>도움말, YACReader 정보</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="395" />
-            <source>Magnifying glass</source>
-            <translation>돋보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="396" />
-            <source>Switch Magnifying glass</source>
-            <translation>돋보기 전환</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="402" />
-            <source>Set bookmark</source>
-            <translation>책갈피 설정</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="403" />
-            <source>Set a bookmark on the current page</source>
-            <translation>현재 페이지에 책갈피 설정</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="411" />
-            <source>Show bookmarks</source>
-            <translation>책갈피 보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="412" />
-            <source>Show the bookmarks of the current comic</source>
-            <translation>현재 만화의 책갈피 보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="417" />
-            <source>Show keyboard shortcuts</source>
-            <translation>키보드 단축키 보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="422" />
-            <source>Show Info</source>
-            <translation>정보 보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="427" />
-            <source>Close</source>
-            <translation>닫기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="432" />
-            <source>Show Dictionary</source>
-            <translation>사전 보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="438" />
-            <source>Show go to flow</source>
-            <translation>페이지 흐름 보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="443" />
-            <source>Edit shortcuts</source>
-            <translation>단축키 편집</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="464" />
-            <source>&amp;File</source>
-            <translation>파일(&amp;F)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="479" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="638" />
-            <source>Open recent</source>
-            <translation>최근 항목 열기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="627" />
-            <source>File</source>
-            <translation>파일</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="648" />
-            <source>Edit</source>
-            <translation>편집</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="652" />
-            <source>View</source>
-            <translation>보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="669" />
-            <source>Go</source>
-            <translation>이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="677" />
-            <source>Window</source>
-            <translation>창</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="794" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="796" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="798" />
-            <source>Open Comic</source>
-            <translation>만화 열기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="794" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="796" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="798" />
-            <source>Comic files</source>
-            <translation>만화 파일</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="889" />
-            <source>Open folder</source>
-            <translation>폴더 열기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="945" />
-            <source>page_%1.jpg</source>
-            <translation>page_%1.jpg</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="945" />
-            <source>Image files (*.jpg)</source>
-            <translation>이미지 파일 (*.jpg)</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1151" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1164" />
-            <source>Comics</source>
-            <translation>만화</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1152" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1180" />
-            <source>General</source>
-            <translation>일반</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1153" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1218" />
-            <source>Magnifiying glass</source>
-            <translation>돋보기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1154" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1229" />
-            <source>Page adjustement</source>
-            <translation>페이지 조정</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1155" />
-            <location filename="../YACReader/main_window_viewer.cpp" line="1307" />
-            <source>Reading</source>
-            <translation>읽기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1174" />
-            <source>Toggle fullscreen mode</source>
-            <translation>전체화면 전환</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1177" />
-            <source>Hide/show toolbar</source>
-            <translation>도구 모음 표시/숨김</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1199" />
-            <source>Size up magnifying glass</source>
-            <translation>돋보기 크게</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1202" />
-            <source>Size down magnifying glass</source>
-            <translation>돋보기 작게</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1205" />
-            <source>Zoom in magnifying glass</source>
-            <translation>돋보기 확대</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1208" />
-            <source>Zoom out magnifying glass</source>
-            <translation>돋보기 축소</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1211" />
-            <source>Reset magnifying glass</source>
-            <translation>돋보기 초기화</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1225" />
-            <source>Toggle between fit to width and fit to height</source>
-            <translation>폭 맞춤 / 높이 맞춤 전환</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1247" />
-            <source>Autoscroll down</source>
-            <translation>아래로 자동 스크롤</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1250" />
-            <source>Autoscroll up</source>
-            <translation>위로 자동 스크롤</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1253" />
-            <source>Autoscroll forward, horizontal first</source>
-            <translation>세로 우선으로 정방향 자동 스크롤</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1257" />
-            <source>Autoscroll backward, horizontal first</source>
-            <translation>가로 우선으로 정방향 자동 스크롤</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1261" />
-            <source>Autoscroll forward, vertical first</source>
-            <translation>세로 우선으로 역방향 자동 스크롤</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1265" />
-            <source>Autoscroll backward, vertical first</source>
-            <translation>가로 우선으로 역방향 자동 스크롤</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1269" />
-            <source>Move down</source>
-            <translation>아래로 이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1272" />
-            <source>Move up</source>
-            <translation>위로 이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1275" />
-            <source>Move left</source>
-            <translation>왼쪽으로 이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1278" />
-            <source>Move right</source>
-            <translation>오른쪽으로 이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1281" />
-            <source>Go to the first page</source>
-            <translation>첫 페이지로 이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1284" />
-            <source>Go to the last page</source>
-            <translation>마지막 페이지로 이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1287" />
-            <source>Offset double page to the left</source>
-            <translation>두 페이지 왼쪽으로 이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1289" />
-            <source>Offset double page to the right</source>
-            <translation>두 페이지 오른쪽으로 이동</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1356" />
-            <source>There is a new version available</source>
-            <translation>새 버전을 내려받으시겠습니까?</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1357" />
-            <source>Do you want to download the new version?</source>
-            <translation>새 버전을 내려받으시겠습니까?</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1360" />
-            <source>Remind me in 14 days</source>
-            <translation>14일 후에 다시 알림</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/main_window_viewer.cpp" line="1361" />
-            <source>Not now</source>
-            <translation>나중에</translation>
-        </message>
-    </context>
-    <context>
-        <name>YACReader::TrayIconController</name>
-        <message>
-            <location filename="trayicon_controller.cpp" line="52" />
-            <source>&amp;Restore</source>
-            <translation>복원(&amp;R)</translation>
-        </message>
-        <message>
-            <location filename="trayicon_controller.cpp" line="79" />
-            <source>Systray</source>
-            <translation>시스템 트레이</translation>
-        </message>
-        <message>
-            <location filename="trayicon_controller.cpp" line="80" />
-            <source>YACReaderLibrary will keep running in the system tray. To terminate the program, choose &lt;b&gt;Quit&lt;/b&gt; in the context menu of the system tray icon.</source>
-            <translation>YACReaderLibrary는 시스템 트레이에서 계속 실행됩니다. 프로그램을 종료하려면 시스템 트레이 아이콘의 컨텍스트 메뉴에서 &lt;b&gt;끝내기&lt;/b&gt;를 선택하세요.</translation>
-        </message>
-    </context>
-    <context>
-        <name>YACReaderFieldEdit</name>
-        <message>
-            <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9" />
-            <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28" />
-            <source>Click to overwrite</source>
-            <translation>클릭해서 덮어쓰기</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11" />
-            <source>Restore to default</source>
-            <translation>기본값으로 복원</translation>
-        </message>
-    </context>
-    <context>
-        <name>YACReaderFieldPlainTextEdit</name>
-        <message>
-            <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9" />
-            <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19" />
-            <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44" />
-            <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50" />
-            <source>Click to overwrite</source>
-            <translation>클릭해서 덮어쓰기</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10" />
-            <source>Restore to default</source>
-            <translation>기본값으로 복원</translation>
-        </message>
-    </context>
-    <context>
-        <name>YACReaderFlowConfigWidget</name>
-        <message>
-            <source>CoverFlow look</source>
-            <translation type="vanished">코버플로 스타일</translation>
-        </message>
-        <message>
-            <source>How to show covers:</source>
-            <translation type="vanished">표지 표시 방식:</translation>
-        </message>
-        <message>
-            <source>Stripe look</source>
-            <translation type="vanished">줄무늬 스타일</translation>
-        </message>
-        <message>
-            <source>Overlapped Stripe look</source>
-            <translation type="vanished">겹친 줄무늬 스타일</translation>
-        </message>
-    </context>
-    <context>
-        <name>YACReaderGLFlowConfigWidget</name>
-        <message>
-            <source>Stripe look</source>
-            <translation type="vanished">줄무늬 스타일</translation>
-        </message>
-        <message>
-            <source>Overlapped Stripe look</source>
-            <translation type="vanished">겹친 줄무늬 스타일</translation>
-        </message>
-    </context>
-    <context>
-        <name>YACReaderOptionsDialog</name>
-        <message>
-            <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="19" />
-            <source>Save</source>
-            <translation>저장</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="20" />
-            <source>Cancel</source>
-            <translation>취소</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="25" />
-            <source>Edit shortcuts</source>
-            <translation>단축키 편집</translation>
-        </message>
-        <message>
-            <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28" />
-            <source>Shortcuts</source>
-            <translation>단축키</translation>
-        </message>
-    </context>
-    <context>
-        <name>YACReaderSearchLineEdit</name>
-        <message>
-            <location filename="../custom_widgets/yacreader_search_line_edit.cpp" line="31" />
-            <source>type to search</source>
-            <translation>검색어 입력</translation>
-        </message>
-    </context>
-    <context>
-        <name>YACReaderSlider</name>
-        <message>
-            <location filename="../YACReader/width_slider.cpp" line="49" />
-            <source>Reset</source>
-            <translation>초기화</translation>
-        </message>
-    </context>
-    <context>
-        <name>YACReaderTranslator</name>
-        <message>
-            <location filename="../YACReader/translator.cpp" line="42" />
-            <source>YACReader translator</source>
-            <translation>YACReader 번역기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/translator.cpp" line="82" />
-            <location filename="../YACReader/translator.cpp" line="188" />
-            <source>Translation</source>
-            <translation>번역</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/translator.cpp" line="102" />
-            <source>clear</source>
-            <translation>지우기</translation>
-        </message>
-        <message>
-            <location filename="../YACReader/translator.cpp" line="197" />
-            <source>Service not available</source>
-            <translation>서비스를 사용할 수 없습니다</translation>
-        </message>
-    </context>
+    </message>
+    <message>
+        <location filename="../common/themes/theme_editor_dialog.cpp" line="431"/>
+        <source>Expected a JSON object.</source>
+        <translation>JSON 객체가 필요합니다.</translation>
+    </message>
+</context>
+<context>
+    <name>TitleHeader</name>
+    <message>
+        <location filename="comic_vine/title_header.cpp" line="27"/>
+        <source>SEARCH</source>
+        <translation>검색</translation>
+    </message>
+</context>
+<context>
+    <name>UpdateLibraryDialog</name>
+    <message>
+        <location filename="create_library_dialog.cpp" line="171"/>
+        <source>Cancel</source>
+        <translation>취소</translation>
+    </message>
+    <message>
+        <location filename="create_library_dialog.cpp" line="165"/>
+        <source>Updating....</source>
+        <translation>업데이트 중...</translation>
+    </message>
+    <message>
+        <location filename="create_library_dialog.cpp" line="190"/>
+        <source>Update library</source>
+        <translation>라이브러리 업데이트</translation>
+    </message>
+</context>
+<context>
+    <name>VolumeComicsModel</name>
+    <message>
+        <location filename="comic_vine/model/volume_comics_model.cpp" line="121"/>
+        <source>title</source>
+        <translation>제목</translation>
+    </message>
+</context>
+<context>
+    <name>VolumesModel</name>
+    <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="118"/>
+        <source>year</source>
+        <translation>연도</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="120"/>
+        <source>issues</source>
+        <translation>이슈</translation>
+    </message>
+    <message>
+        <location filename="comic_vine/model/volumes_model.cpp" line="122"/>
+        <source>publisher</source>
+        <translation>출판사</translation>
+    </message>
+</context>
+<context>
+    <name>YACReader3DFlowConfigWidget</name>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="19"/>
+        <source>Presets:</source>
+        <translation>프리셋:</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="21"/>
+        <source>Classic look</source>
+        <translation>클래식 스타일</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="24"/>
+        <source>Stripe look</source>
+        <translation>줄무늬 스타일</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="27"/>
+        <source>Overlapped Stripe look</source>
+        <translation>겹친 줄무늬 스타일</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="30"/>
+        <source>Modern look</source>
+        <translation>모던 스타일</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="33"/>
+        <source>Roulette look</source>
+        <translation>룰렛 스타일</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="77"/>
+        <source>Show advanced settings</source>
+        <translation>고급 설정 보기</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="86"/>
+        <source>Custom:</source>
+        <translation>사용자 지정:</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="89"/>
+        <source>View angle</source>
+        <translation>시야각</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="95"/>
+        <source>Position</source>
+        <translation>위치</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="101"/>
+        <source>Cover gap</source>
+        <translation>표지 간격</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="107"/>
+        <source>Central gap</source>
+        <translation>중앙 간격</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="113"/>
+        <source>Zoom</source>
+        <translation>확대/축소</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="119"/>
+        <source>Y offset</source>
+        <translation>Y축 오프셋</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="125"/>
+        <source>Z offset</source>
+        <translation>Z축 오프셋</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="131"/>
+        <source>Cover Angle</source>
+        <translation>표지 각도</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="137"/>
+        <source>Visibility</source>
+        <translation>가시성</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="143"/>
+        <source>Light</source>
+        <translation>조명</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="149"/>
+        <source>Max angle</source>
+        <translation>최대 각도</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="181"/>
+        <source>Low Performance</source>
+        <translation>저성능</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="183"/>
+        <source>High Performance</source>
+        <translation>고성능</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="194"/>
+        <source>Use VSync (improve the image quality in fullscreen mode, worse performance)</source>
+        <translation>수직 동기화 사용 (전체화면 결의 이미지 품질 향상, 성능 저하)</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_3d_flow_config_widget.cpp" line="202"/>
+        <source>Performance:</source>
+        <translation>성능:</translation>
+    </message>
+</context>
+<context>
+    <name>YACReader::TrayIconController</name>
+    <message>
+        <location filename="trayicon_controller.cpp" line="51"/>
+        <source>&amp;Restore</source>
+        <translation>복원(&amp;R)</translation>
+    </message>
+    <message>
+        <location filename="trayicon_controller.cpp" line="78"/>
+        <source>Systray</source>
+        <translation>시스템 트레이</translation>
+    </message>
+    <message>
+        <location filename="trayicon_controller.cpp" line="79"/>
+        <source>YACReaderLibrary will keep running in the system tray. To terminate the program, choose &lt;b&gt;Quit&lt;/b&gt; in the context menu of the system tray icon.</source>
+        <translation>YACReaderLibrary는 시스템 트레이에서 계속 실행됩니다. 프로그램을 종료하려면 시스템 트레이 아이콘의 컨텍스트 메뉴에서 &lt;b&gt;끝내기&lt;/b&gt;를 선택하세요.</translation>
+    </message>
+</context>
+<context>
+    <name>YACReader::WhatsNewDialog</name>
+    <message>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="183"/>
+        <source>Release notes are not available.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/whats_new_dialog.cpp" line="239"/>
+        <source>Previous versions</source>
+        <translation type="unfinished"></translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderFieldEdit</name>
+    <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="28"/>
+        <source>Click to overwrite</source>
+        <translation>클릭해서 덮어쓰기</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_field_edit.cpp" line="11"/>
+        <source>Restore to default</source>
+        <translation>기본값으로 복원</translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderFieldPlainTextEdit</name>
+    <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="9"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="19"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="44"/>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="50"/>
+        <source>Click to overwrite</source>
+        <translation>클릭해서 덮어쓰기</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_field_plain_text_edit.cpp" line="10"/>
+        <source>Restore to default</source>
+        <translation>기본값으로 복원</translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderOptionsDialog</name>
+    <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="19"/>
+        <source>Save</source>
+        <translation>저장</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="20"/>
+        <source>Cancel</source>
+        <translation>취소</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="25"/>
+        <source>Edit shortcuts</source>
+        <translation>단축키 편집</translation>
+    </message>
+    <message>
+        <location filename="../custom_widgets/yacreader_options_dialog.cpp" line="28"/>
+        <source>Shortcuts</source>
+        <translation>단축키</translation>
+    </message>
+</context>
+<context>
+    <name>YACReaderSearchLineEdit</name>
+    <message>
+        <location filename="../custom_widgets/yacreader_search_line_edit.cpp" line="31"/>
+        <source>type to search</source>
+        <translation>검색어 입력</translation>
+    </message>
+</context>
 </TS>

--- a/YACReaderLibrary/yacreaderlibrary_ko.ts
+++ b/YACReaderLibrary/yacreaderlibrary_ko.ts
@@ -2869,12 +2869,12 @@ To stop an automatic update tap on the loading indicator next to the Libraries t
     <message>
         <location filename="../custom_widgets/whats_new_dialog.cpp" line="183"/>
         <source>Release notes are not available.</source>
-        <translation type="unfinished"></translation>
+        <translation type="릴리스 노트를 사용할 수 없습니다."></translation>
     </message>
     <message>
         <location filename="../custom_widgets/whats_new_dialog.cpp" line="239"/>
         <source>Previous versions</source>
-        <translation type="unfinished"></translation>
+        <translation type="이전 버전"></translation>
     </message>
 </context>
 <context>

--- a/YACReaderLibraryServer/CMakeLists.txt
+++ b/YACReaderLibraryServer/CMakeLists.txt
@@ -39,6 +39,7 @@ qt_add_translations(YACReaderLibraryServer
         yacreaderlibraryserver_zh_CN.ts
         yacreaderlibraryserver_zh_TW.ts
         yacreaderlibraryserver_zh_HK.ts
+        yacreaderlibraryserver_ko.ts
         yacreaderlibraryserver_source.ts
 )
 

--- a/YACReaderLibraryServer/yacreaderlibraryserver_ko.ts
+++ b/YACReaderLibraryServer/yacreaderlibraryserver_ko.ts
@@ -1,71 +1,33 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1">
+<TS version="2.1" language="ko">
 <context>
     <name>FileComic</name>
     <message>
-        <location filename="../common/comic.cpp" line="454"/>
+        <location filename="../common/comic.cpp" line="456"/>
         <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
         <translation>%1번 페이지에서 CRC 오류 발생: 일부 페이지가 올바르게 표시되지 않을 수 있습니다</translation>
     </message>
     <message>
-        <location filename="../common/comic.cpp" line="461"/>
+        <location filename="../common/comic.cpp" line="463"/>
         <source>Unknown error opening the file</source>
         <translation>파일을 여는 중 알 수 없는 오류가 발생했습니다</translation>
     </message>
     <message>
-        <location filename="../common/comic.cpp" line="562"/>
+        <location filename="../common/comic.cpp" line="564"/>
         <source>7z not found</source>
         <translation>7z를 찾을 수 없습니다</translation>
     </message>
     <message>
-        <location filename="../common/comic.cpp" line="568"/>
+        <location filename="../common/comic.cpp" line="570"/>
         <source>Format not supported</source>
         <translation>지원하지 않는 형식입니다</translation>
     </message>
 </context>
 <context>
-    <name>LogWindow</name>
-    <message>
-        <location filename="../third_party/QsLog/QsLogWindow.ui" line="14"/>
-        <source>Log window</source>
-        <translation>로그 창</translation>
-    </message>
-    <message>
-        <location filename="../third_party/QsLog/QsLogWindow.ui" line="22"/>
-        <source>&amp;Pause</source>
-        <translation>일시 정지(&amp;P)</translation>
-    </message>
-    <message>
-        <location filename="../third_party/QsLog/QsLogWindow.ui" line="39"/>
-        <source>&amp;Save</source>
-        <translation>저장(&amp;S)</translation>
-    </message>
-    <message>
-        <location filename="../third_party/QsLog/QsLogWindow.ui" line="56"/>
-        <source>C&amp;lear</source>
-        <translation>지우기(&amp;L)</translation>
-    </message>
-    <message>
-        <location filename="../third_party/QsLog/QsLogWindow.ui" line="73"/>
-        <source>&amp;Copy</source>
-        <translation>복사(&amp;C)</translation>
-    </message>
-    <message>
-        <location filename="../third_party/QsLog/QsLogWindow.ui" line="90"/>
-        <source>Level:</source>
-        <translation>레벨:</translation>
-    </message>
-    <message>
-        <location filename="../third_party/QsLog/QsLogWindow.ui" line="136"/>
-        <source>&amp;Auto scroll</source>
-        <translation>자동 스크롤(&amp;A)</translation>
-    </message>
-</context>
-<context>
     <name>QCoreApplication</name>
     <message>
-        <location filename="main.cpp" line="84"/>
+        <location filename="main.cpp" line="77"/>
         <source>
 YACReaderLibraryServer is the headless (no gui) version of YACReaderLibrary.
 
@@ -76,80 +38,6 @@ YACReaderLibraryServer는 YACReaderLibrary의 헤드리스(GUI 없는) 버전입
 
 이 응용 프로그램은 영구 설정을 지원합니다. 설정을 변경하려면 다음 파일을 편집하세요: %1
 사용 가능한 설정 문서는 다음에서 확인할 수 있습니다: https://raw.githubusercontent.com/YACReader/yacreader/develop/YACReaderLibraryServer/SETTINGS_README.md</translation>
-    </message>
-</context>
-<context>
-    <name>QObject</name>
-    <message>
-        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41"/>
-        <source>Trace</source>
-        <translation>추적</translation>
-    </message>
-    <message>
-        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43"/>
-        <source>Debug</source>
-        <translation>디버그</translation>
-    </message>
-    <message>
-        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45"/>
-        <source>Info</source>
-        <translation>정보</translation>
-    </message>
-    <message>
-        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47"/>
-        <source>Warning</source>
-        <translation>경고</translation>
-    </message>
-    <message>
-        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49"/>
-        <source>Error</source>
-        <translation>오류</translation>
-    </message>
-    <message>
-        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51"/>
-        <source>Fatal</source>
-        <translation>치명적 오류</translation>
-    </message>
-</context>
-<context>
-    <name>QsLogging::LogWindowModel</name>
-    <message>
-        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="141"/>
-        <source>Time</source>
-        <translation>시간</translation>
-    </message>
-    <message>
-        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="143"/>
-        <source>Level</source>
-        <translation>레벨</translation>
-    </message>
-    <message>
-        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="145"/>
-        <source>Message</source>
-        <translation>메시지</translation>
-    </message>
-</context>
-<context>
-    <name>QsLogging::Window</name>
-    <message>
-        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
-        <source>&amp;Pause</source>
-        <translation>일시 정지(&amp;P)</translation>
-    </message>
-    <message>
-        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
-        <source>&amp;Resume</source>
-        <translation>재개(&amp;R)</translation>
-    </message>
-    <message>
-        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="236"/>
-        <source>Save log</source>
-        <translation>로그 저장</translation>
-    </message>
-    <message>
-        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="237"/>
-        <source>Log file (*.log)</source>
-        <translation>로그 파일 (*.log)</translation>
     </message>
 </context>
 </TS>

--- a/YACReaderLibraryServer/yacreaderlibraryserver_ko.ts
+++ b/YACReaderLibraryServer/yacreaderlibraryserver_ko.ts
@@ -1,0 +1,155 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!DOCTYPE TS>
+<TS version="2.1">
+<context>
+    <name>FileComic</name>
+    <message>
+        <location filename="../common/comic.cpp" line="454"/>
+        <source>CRC error on page (%1): some of the pages will not be displayed correctly</source>
+        <translation>%1번 페이지에서 CRC 오류 발생: 일부 페이지가 올바르게 표시되지 않을 수 있습니다</translation>
+    </message>
+    <message>
+        <location filename="../common/comic.cpp" line="461"/>
+        <source>Unknown error opening the file</source>
+        <translation>파일을 여는 중 알 수 없는 오류가 발생했습니다</translation>
+    </message>
+    <message>
+        <location filename="../common/comic.cpp" line="562"/>
+        <source>7z not found</source>
+        <translation>7z를 찾을 수 없습니다</translation>
+    </message>
+    <message>
+        <location filename="../common/comic.cpp" line="568"/>
+        <source>Format not supported</source>
+        <translation>지원하지 않는 형식입니다</translation>
+    </message>
+</context>
+<context>
+    <name>LogWindow</name>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="14"/>
+        <source>Log window</source>
+        <translation>로그 창</translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="22"/>
+        <source>&amp;Pause</source>
+        <translation>일시 정지(&amp;P)</translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="39"/>
+        <source>&amp;Save</source>
+        <translation>저장(&amp;S)</translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="56"/>
+        <source>C&amp;lear</source>
+        <translation>지우기(&amp;L)</translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="73"/>
+        <source>&amp;Copy</source>
+        <translation>복사(&amp;C)</translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="90"/>
+        <source>Level:</source>
+        <translation>레벨:</translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.ui" line="136"/>
+        <source>&amp;Auto scroll</source>
+        <translation>자동 스크롤(&amp;A)</translation>
+    </message>
+</context>
+<context>
+    <name>QCoreApplication</name>
+    <message>
+        <location filename="main.cpp" line="84"/>
+        <source>
+YACReaderLibraryServer is the headless (no gui) version of YACReaderLibrary.
+
+This appplication supports persistent settings, to set them up edit this file %1
+To learn about the available settings please check the documentation at https://raw.githubusercontent.com/YACReader/yacreader/develop/YACReaderLibraryServer/SETTINGS_README.md</source>
+        <translation>
+YACReaderLibraryServer는 YACReaderLibrary의 헤드리스(GUI 없는) 버전입니다.
+
+이 응용 프로그램은 영구 설정을 지원합니다. 설정을 변경하려면 다음 파일을 편집하세요: %1
+사용 가능한 설정 문서는 다음에서 확인할 수 있습니다: https://raw.githubusercontent.com/YACReader/yacreader/develop/YACReaderLibraryServer/SETTINGS_README.md</translation>
+    </message>
+</context>
+<context>
+    <name>QObject</name>
+    <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="41"/>
+        <source>Trace</source>
+        <translation>추적</translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="43"/>
+        <source>Debug</source>
+        <translation>디버그</translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="45"/>
+        <source>Info</source>
+        <translation>정보</translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="47"/>
+        <source>Warning</source>
+        <translation>경고</translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="49"/>
+        <source>Error</source>
+        <translation>오류</translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogLevel.cpp" line="51"/>
+        <source>Fatal</source>
+        <translation>치명적 오류</translation>
+    </message>
+</context>
+<context>
+    <name>QsLogging::LogWindowModel</name>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="141"/>
+        <source>Time</source>
+        <translation>시간</translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="143"/>
+        <source>Level</source>
+        <translation>레벨</translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindowModel.cpp" line="145"/>
+        <source>Message</source>
+        <translation>메시지</translation>
+    </message>
+</context>
+<context>
+    <name>QsLogging::Window</name>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
+        <source>&amp;Pause</source>
+        <translation>일시 정지(&amp;P)</translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="176"/>
+        <source>&amp;Resume</source>
+        <translation>재개(&amp;R)</translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="236"/>
+        <source>Save log</source>
+        <translation>로그 저장</translation>
+    </message>
+    <message>
+        <location filename="../third_party/QsLog/QsLogWindow.cpp" line="237"/>
+        <source>Log file (*.log)</source>
+        <translation>로그 파일 (*.log)</translation>
+    </message>
+</context>
+</TS>


### PR DESCRIPTION
Adds Korean (ko) localization for all three YACReader components, 
based on the develop branch source files (YACReader 10.0.0).

## Files added

- `YACReader/yacreader_ko.ts`
- `YACReaderLibrary/yacreaderlibrary_ko.ts`
- `YACReaderLibraryServer/yacreaderlibraryserver_ko.ts` 
  (newly added — no Korean translation existed previously)

## Status

- yacreaderlibrary_ko.ts: 699 strings, 100% finished
- yacreaderlibraryserver_ko.ts: 25 strings, 100% finished
- yacreader_ko.ts mirrors yacreaderlibrary source content (679 
  strings, identical in develop)

All `.qm` files have been compiled locally and verified to apply 
correctly throughout YACReader, YACReaderLibrary, and 
YACReaderLibraryServer on Windows.

This follows up on the email correspondence regarding the Korean 
localization completion.