### PR TITLE
fix: remove world writable permissions from install folder and binary

### DIFF
--- a/ci/win/build_installer_qt6.iss
+++ b/ci/win/build_installer_qt6.iss
@@ -92,9 +92,9 @@ Source: "vc_redist.{#PLATFORM}.exe"; DestDir: {tmp}; Flags: deleteafterinstall
 Source: utils\7z.dll; DestDir: {app}\utils\
 
 ;Bin
-Source: YACReader.exe; DestDir: {app}; Permissions: everyone-full;
-Source: YACReaderLibrary.exe; DestDir: {app}; Permissions: everyone-full; Tasks:
-Source: YACReaderLibraryServer.exe; DestDir: {app}; Permissions: everyone-full; Tasks:
+Source: YACReader.exe; DestDir: {app};
+Source: YACReaderLibrary.exe; DestDir: {app}; Tasks:
+Source: YACReaderLibraryServer.exe; DestDir: {app}; Tasks:
 
 ;License
 Source: README.md; DestDir: {app}; Flags: isreadme
@@ -106,7 +106,7 @@ Source: languages\*; DestDir: {app}\languages\; Flags: recursesubdirs; Excludes:
 Source: server\*; DestDir: {app}\server\; Flags: recursesubdirs
 
 [Dirs]
-Name: {app}; Permissions: everyone-full
+Name: {app};
 
 [CustomMessages]
 App=YACReader


### PR DESCRIPTION
Currently the installer creates the app directory and binaries with world-writable permissions. This allows any unprivileged user to delete or otherwise modify the files. The default install location is  under `%ProgramFiles%` which is generally considered privileged and should only be written to by Administrators. Even if installing to another directory, using inherited permissions should cover any reasonable use case.

Removing these additional permissions lets the directory and binaries inherit the the permissions set on `%ProgramFiles%`.