### PR TITLE
Magnifying glass improvements (macOS)

### DIFF
--- a/YACReader/mouse_handler.cpp
+++ b/YACReader/mouse_handler.cpp
@@ -109,7 +109,9 @@ void YACReader::MouseHandler::mouseMoveEvent(QMouseEvent *event)
                     if (gtfPos.y() < 0 || gtfPos.x() < 0 || gtfPos.x() > viewer->goToFlow->width()) // TODO this extra check is for Mavericks (mouseMove over goToFlowGL seems to be broken)
                         viewer->animateHideGoToFlow();
                     // goToFlow->hide();
-                } else {
+                } else if (!viewer->magnifyingGlassShown) {
+                    // Don't pop up the bottom page-selection bar while the
+                    // magnifying glass is active: it prevents magnifying that area.
                     int umbral = (viewer->width() - viewer->goToFlow->width()) / 2;
                     if ((position.y() > viewer->height() - 15) && (position.x() > umbral) && (position.x() < viewer->width() - umbral)) {
 

--- a/YACReader/viewer.cpp
+++ b/YACReader/viewer.cpp
@@ -1070,8 +1070,12 @@ QImage Viewer::grabMagnifiedRegion(const QPoint &viewerPos, const QSize &glassSi
     }
 
     if (outImage) {
+        // The magnified image is kept at source resolution (device pixel ratio 1),
+        // matching the in-bounds path below. Do NOT set a >1 device pixel ratio here:
+        // a QPainter draws in logical coordinates, so painting the DPR-1 source crop
+        // onto a DPR>1 image would scale the content up by the ratio (and clip it),
+        // producing a sudden magnification jump at the image edges on HiDPI displays.
         QImage img(zoomWScaled, zoomHScaled, QImage::Format_RGB32);
-        img.setDevicePixelRatio(devicePixelRatioF());
         img.fill(bgColor);
         if (zw > 0 && zh > 0) {
             QPainter painter(&img);


### PR DESCRIPTION
Two tiny bugfixes in one PR:

1. Magnifying glass zoom level appears to jump as the glass approaches the edge of the page. This is because of how the glass contents were painted, on hi resolution screens. Needs regression testing on non-macOS systems.
1. ~~Default +/- key events were stepping on the main window's +/- events when the magnifier was open. This prevented any of these key events from being consumed. Fixed by toggling off the +/- page events when magnifier is active. Note: if you set your page zoom to some other key combo, it may have worked while magnifier is open, but not after this fix. Not sure if this is an issue or not.~~
1. Ignore the page-selection bar at the bottom of the screen when the magnifying glass is active. This didn't show the page selection but it kept the magnifier from reaching the bottom of the page.

Passed clang-format, tested on macOS. I'm happy to make any changes if needed.
AI was used but I Know What I'm Doing™️.

Thank you!

EDIT 2026-07-25: Rewrote the branch to remove the shortcut toggles now that @luisangelsm fixed the issue upstream by changing the default keys. No need to disable the actions any more. I left the other two fixes as they were before.