### PR TITLE
macOS: reveal comics in Finder without AppleScript

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ Version counting is based on semantic versioning (Major.Feature.Patch)
 * Add funtion to open the library root location.
 * Add a help dialog for the search engine. Use the drop down menu in the search field.
 * Add quick search presets. Use the drop down menu in the search field.
+* Fix `open containing folder` asking for permission to control Finder on macOS.
 
 ### YACReaderLibraryServer
 * Add the `repair-library` command to restore missing covers and rescan files that previously failed to be added.

--- a/YACReaderLibrary/library_window.cpp
+++ b/YACReaderLibrary/library_window.cpp
@@ -2694,17 +2694,12 @@ void LibraryWindow::openContainingFolderComic()
 #endif
 
 #ifdef Q_OS_MACOS
-    QString filePath = file.absoluteFilePath();
+    // `open -R` reveals and selects the file in Finder without sending an Apple
+    // Event, so it doesn't trigger the macOS automation permission prompt.
     QStringList args;
-    args << "-e";
-    args << "tell application \"Finder\"";
-    args << "-e";
-    args << "activate";
-    args << "-e";
-    args << "select POSIX file \"" + filePath + "\"";
-    args << "-e";
-    args << "end tell";
-    QProcess::startDetached("osascript", args);
+    args << "-R";
+    args << file.absoluteFilePath();
+    QProcess::startDetached("open", args);
 #endif
 
 #ifdef Q_OS_WIN


### PR DESCRIPTION
"Open containing folder" on a comic drove Finder through osascript, which sends an Apple Event and therefore trips the macOS automation consent dialog ("YACReaderLibrary wants access to control Finder"). The prompt is opaque to users, since neither Info.plist declares an NSAppleEventsUsageDescription to explain the request, and denying it leaves the menu action silently doing nothing.

Use `open -R <path>` instead. It reveals and selects the file in Finder with the same result, but goes through Launch Services rather than Apple Events, so no permission is required. This also matches how the rest of the codebase shells out to `open`.