### PR TITLE
Change default backend on linux to libarchive

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -75,7 +75,7 @@ jobs:
 
   # Linux Qt6 build
   linux-qt6:
-    name: Linux (Qt6)
+    name: Linux (Qt6 + libarchive)
     runs-on: ubuntu-24.04
     needs: [initialization, code-format-validation]
     steps:
@@ -84,7 +84,7 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update
-          sudo apt-get install -y libunarr-dev libgl-dev libgles2-mesa-dev \
+          sudo apt-get install -y libarchive-dev libgl-dev libgles2-mesa-dev \
             libfontconfig1-dev libfreetype-dev libxkbcommon-dev libpoppler-qt6-dev \
             libspeechd-dev
 
@@ -98,7 +98,6 @@ jobs:
       - name: Build
         run: |
           cmake -B build \
-            -DDECOMPRESSION_BACKEND=unarr \
             -DPDF_BACKEND=poppler \
             -DBUILD_NUMBER="${{ needs.initialization.outputs.build_number }}" \
             -DCMAKE_BUILD_TYPE=Release

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ cmake --build build --parallel
 ```
 
 Build options:
-- `DECOMPRESSION_BACKEND`: `unarr` | `7zip` | `libarchive` (default: 7zip on Windows/macOS/Linux)
+- `DECOMPRESSION_BACKEND`: `unarr` | `7zip` | `libarchive` (default: 7zip on Windows/macOS, libarchive on Linux)
 - `PDF_BACKEND`: `pdfium` | `poppler` | `pdfkit` | `no_pdf` (default: pdfium on Windows, pdfkit on macOS, poppler on Linux)
 - `BUILD_SERVER_STANDALONE=ON`: builds only `YACReaderLibraryServer` (headless), requires only Qt 6.4+
 - `BUILD_TESTS=ON` (default): enables the test suite

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ set(YACREADER_PDF_BACKENDS pdfium poppler pdfkit no_pdf)
 
 # --- Platform defaults ---
 if(UNIX AND NOT APPLE)
-    set(_default_decompression_backend "7zip")
+    set(_default_decompression_backend "libarchive")
     set(_default_pdf_backend "poppler")
 elseif(APPLE)
     set(_default_decompression_backend "7zip")

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -67,9 +67,9 @@ recommended for installations where the license is an issue.
 
 [libarchive](https://github.com/libarchive/libarchive) is a portable, efficient decompression backend, and the default decompression backend for Linux.
 
-libarchive supports a wide variaty of archive formats, and supports the RAR5 format (with some limitations) without using non-free software. 
+libarchive supports a wide variety of archive formats, and supports the RAR5 format (with some limitations) without using non-free software.
 
-The libarchive backend is recommended for packaging, and installations where GPL compatability is required.
+The libarchive backend is recommended for packaging, and installations where GPL compatibility is required.
 
 #### unarr
 

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -41,7 +41,7 @@ required qml modules (Quick, QuickControls2) are missing.
 ### Decompression
 
 YACReader currently supports three decompression backends: 7zip, (lib)unarr, and libarchive. YACReader
-defaults to 7zip for Windows, macOS, Linux, and other OSes, but you can
+defaults to 7zip for Windows and macOS, and libarchive for Linux and other OSes, but you can
 override this using the `DECOMPRESSION_BACKEND` option:
 
 ```
@@ -52,7 +52,7 @@ cmake -B build -DDECOMPRESSION_BACKEND=libarchive
 
 #### 7zip
 
-[7zip](https://www.7-zip.org/) is the default decompression backend.
+[7zip](https://www.7-zip.org/) is the default decompression backend for Windows and macOS.
 
 It is recommended for most builds, as it currently has better support for 7z
 files and supports the RAR5 format.
@@ -63,16 +63,20 @@ FetchContent. No manual setup is needed.
 As this backend is not 100% GPL compatible (unrar license restriction), it is not
 recommended for installations where the license is an issue.
 
+#### libarchive
+
+[libarchive](https://github.com/libarchive/libarchive) is a portable, efficient decompression backend, and the default decompression backend for Linux.
+
+libarchive supports a wide variaty of archive formats, and supports the RAR5 format (with some limitations) without using non-free software. 
+
+The libarchive backend is recommended for packaging, and installations where GPL compatability is required.
+
 #### unarr
 
 [(lib)unarr](https://github.com/selmf/unarr) is a lightweight decompression backend.
 
 As of version 1.0.1, it supports less formats than 7zip, notably missing RAR5 support and only having
-limited support for 7z on git versions. However, this is rarely an issue in practice as the vast majority
-of comic books use either zip or RAR4 compression, which is handled nicely by this backend.
-
-The unarr backend is recommended for packaging, lightweight installations and generally for all users requiring
-more stability than the 7zip backend can offer.
+limited support for 7z on git versions. It is recommended that packagers switch to the libarchive backend.
 
 The recommended way to use this on Linux or other *NIX is to install it as a package, but you can also do an embedded build.
 For more information, please consult the [README](compressed_archive/unarr/README.txt)


### PR DESCRIPTION
Fixes issue #570 

I also updated the documentation to reflect the new defaults.