### PR TITLE
CI: fail fast when the Qt install fails on Windows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -212,7 +212,7 @@ jobs:
           pip install -U pip
           pip install aqtinstall
           mkdir C:\Qt
-          python -m aqt install-qt windows desktop 6.9.3 win64_msvc2022_64 -O c:\Qt -m qt5compat qtmultimedia qtimageformats qtshadertools qtspeech
+          python -m aqt install-qt windows desktop 6.9.3 win64_msvc2022_64 -O c:\Qt -m qt5compat qtmultimedia qtimageformats qtshadertools qtspeech || exit /b 1
           dir C:\Qt\6.9.3\msvc2022_64\bin
           curl.exe -L --retry 5 --retry-delay 5 --retry-all-errors "https://aka.ms/vs/17/release/vc_redist.x64.exe" -o "%GITHUB_WORKSPACE%\vc_redist.x64.exe"
           where iscc
@@ -356,8 +356,8 @@ jobs:
         run: |
           pip install aqtinstall
           mkdir C:\Qt
-          python -m aqt install-qt windows desktop 6.9.3 win64_msvc2022_64 -O c:\Qt -m qt5compat qtmultimedia qtimageformats qtshadertools qtspeech
-          python -m aqt install-qt windows desktop 6.9.3 win64_msvc2022_arm64_cross_compiled -O c:\Qt -m qt5compat qtmultimedia qtimageformats qtshadertools qtspeech
+          python -m aqt install-qt windows desktop 6.9.3 win64_msvc2022_64 -O c:\Qt -m qt5compat qtmultimedia qtimageformats qtshadertools qtspeech || exit /b 1
+          python -m aqt install-qt windows desktop 6.9.3 win64_msvc2022_arm64_cross_compiled -O c:\Qt -m qt5compat qtmultimedia qtimageformats qtshadertools qtspeech || exit /b 1
           dir C:\Qt\6.9.3\msvc2022_arm64\bin
           curl.exe -L --retry 5 --retry-delay 5 --retry-all-errors "https://aka.ms/vs/17/release/vc_redist.arm64.exe" -o "%GITHUB_WORKSPACE%\vc_redist.arm64.exe"
           where iscc


### PR DESCRIPTION
The Windows install steps run under `shell: cmd`, which has no equivalent of `set -e`: every line runs regardless of what came before, and the step takes its exit code from the last command. When `aqt install-qt` fails, the trailing `where iscc` still succeeds, so the step is reported green with an incomplete Qt installation.

The failure then surfaces about a minute later in the Build step as `Failed to find required Qt component "ShaderTools"` followed by `ninja: error: loading 'build.ninja'`, which gives no hint that Qt was never installed in the first place.

Seen on a recent run, where aqt aborted with
`py7zr.exceptions.Bad7zFile: Specified path is bad: metatypes/qt6shadertools_metatypes.json` while unpacking qtshadertools downloaded from a mirror, and the job was left looking like a build error.

Guard the three `install-qt` calls with `|| exit /b 1` so the step fails where the problem actually is, with aqt's own error on screen. The macOS job needs no change: it uses the default shell, which already exits on error.