### PR TITLE
Fixed slow linux wayland mouse wheel scrolling in grid view

### DIFF
--- a/YACReaderLibrary/qml/GridComicsView.qml
+++ b/YACReaderLibrary/qml/GridComicsView.qml
@@ -533,14 +533,19 @@ SplitView {
                     currentIndexHelper.setGridColumnCount(wholeCells)
                 }
 
-                WheelHandler {
-                    onWheel: {
-                        if (grid.contentHeight <= grid.height) {
-                            return;
-                        }
+                MouseArea {
+                    anchors.fill: parent
+                    acceptedButtons: Qt.NoButton
 
-                        var newValue =  Math.min((grid.contentHeight - grid.height + grid.originY), (Math.max(grid.originY , grid.contentY - event.angleDelta.y)));
-                        grid.contentY = newValue;
+                    onWheel: (wheel) => {
+                        if (grid.contentHeight <= grid.height)
+                            return
+
+                            var newValue = Math.min(
+                                (grid.contentHeight - grid.height + grid.originY),
+                                                    Math.max(grid.originY, grid.contentY - wheel.angleDelta.y)
+                            )
+                            grid.contentY = newValue
                     }
                 }
 
@@ -732,14 +737,19 @@ SplitView {
                 EmptyInfoView { width: infoView.width }
             }
 
-            WheelHandler {
-                onWheel: {
-                    if (infoFlickable.contentHeight <= infoFlickable.height) {
-                        return;
-                    }
+            MouseArea {
+                anchors.fill: parent
+                acceptedButtons: Qt.NoButton
 
-                    var newValue =  Math.min((infoFlickable.contentHeight - infoFlickable.height), (Math.max(infoFlickable.originY , infoFlickable.contentY - event.angleDelta.y)));
-                    infoFlickable.contentY = newValue;
+                onWheel: (wheel) => {
+                    if (infoFlickable.contentHeight <= infoFlickable.height)
+                        return
+
+                        var newValue = Math.min(
+                            (infoFlickable.contentHeight - infoFlickable.height),
+                                                Math.max(infoFlickable.originY, infoFlickable.contentY - wheel.angleDelta.y)
+                        )
+                        infoFlickable.contentY = newValue
                 }
             }
 


### PR DESCRIPTION
Fixed extremely slow mouse wheel scrolling in grid view on Linux Wayland. Click and drag and scrollbar were unaffected. 

Confirmed the WheelHandler attached to GridView never received wheel events. It was still possible to scroll but whatever it fell back on did not work well, it required scrolling many more times (>10x) to move the same distance compared to the windows version.

Flow View already used MouseArea with an onWheel handler instead of WheelHandler and that worked so I changed grid view to use the same qml element for the main grid scroll and the info panel scroll. I was able to keep the actual scroll calculation exactly the same. I used the parent object size and filtered the other mouse buttons. 